### PR TITLE
Default --with-libs to "no"

### DIFF
--- a/alpha-README.md
+++ b/alpha-README.md
@@ -46,7 +46,9 @@ for notes on dependencies that must be installed before beginning.
 ```bash
   git clone https://github.com/jgarzik/python-bitcoinrpc
 ```
-5\. Use sidechain-manipulation.py:
+5\. Edit sidechain-manipulation.py, setting the `sidechain_url` and `bitcoin_url` values appropriately.
+
+6\. Use sidechain-manipulation.py:
 ```bash
   [matt@2ca87f82dd9a bitcoin]$ cd elements
   [matt@2ca87f82dd9a bitcoin]$ ./contrib/sidechain-manipulation.py generate-one-of-one-multisig sidechain-wallet
@@ -72,8 +74,8 @@ for notes on dependencies that must be installed before beginning.
 
 ### To move money back out of Elements Alpha:
 
-  1. See 1-4 of above.
-4\. Use sidechain-manipulation.py:
+  1. See 1-5 above.
+  2. Use sidechain-manipulation.py:
 ```bash
   [matt@2ca87f82dd9a bitcoin]$ cd elements
   [matt@2ca87f82dd9a bitcoin]$ ./contrib/sidechain-manipulation.py generate-one-of-one-multisig mainchain-wallet

--- a/configure.ac
+++ b/configure.ac
@@ -179,9 +179,9 @@ AC_ARG_WITH([utils],
 
 AC_ARG_WITH([libs],
   [AS_HELP_STRING([--with-libs],
-  [build libraries (default=yes)])],
+  [build libraries (default=no)])],
   [build_bitcoin_libs=$withval],
-  [build_bitcoin_libs=yes])
+  [build_bitcoin_libs=no])
 
 AC_ARG_WITH([daemon],
   [AS_HELP_STRING([--with-daemon],


### PR DESCRIPTION
We're not using the consensus library for anything in particular for alpha, and it seems to cause build problems on OS X for reasons unclear to me ( #11 ). So let's default it to not build.