### PR TITLE
updated alpha-README instructions to include adding RPC username/pass…

### DIFF
--- a/alpha-README.md
+++ b/alpha-README.md
@@ -78,8 +78,8 @@ for notes on dependencies that must be installed before beginning.
 
 ### To move money back out of Elements Alpha:
 
-  1. See 1-4 of above.
-4\. Use sidechain-manipulation.py:
+1\. See 1-5 of above.  
+2\. Use sidechain-manipulation.py:
 ```bash
   [matt@2ca87f82dd9a bitcoin]$ cd elements
   [matt@2ca87f82dd9a bitcoin]$ ./contrib/sidechain-manipulation.py generate-one-of-one-multisig mainchain-wallet
@@ -90,7 +90,7 @@ for notes on dependencies that must be installed before beginning.
 
 ### To run a fedpeg operator (for your own sidechain):
   1. See 1 and 2 in "To run alphad" (Do not forget to append -blindtrust=false to the alphad command args once bitcoin syncs!)
-  2. See 2-4 of "To move money into Elements Alpha"
+  2. See 2-5 of "To move money into Elements Alpha"
  Note that the bitcoind/sidechaind wallets must be EMPTY of keys/transactions except for those created automatically by fedpeg scripts
   3. Install python ZeroMQ.
   4. Ensure your clock is reasonably accurate (within a second should suffice)

--- a/alpha-README.md
+++ b/alpha-README.md
@@ -46,7 +46,13 @@ for notes on dependencies that must be installed before beginning.
 ```bash
   git clone https://github.com/jgarzik/python-bitcoinrpc
 ```
-5\. Use sidechain-manipulation.py:
+5\. Edit sidechain-manipulation.py (replace `user:pass` with your RPC username and password):
+```python
+  # VARIOUS SETTINGS...
+  sidechain_url = "http://user:pass@127.0.0.1:4241"
+  bitcoin_url = "http://user:pass@127.0.0.1:18332"
+```
+6\. Use sidechain-manipulation.py:
 ```bash
   [matt@2ca87f82dd9a bitcoin]$ cd elements
   [matt@2ca87f82dd9a bitcoin]$ ./contrib/sidechain-manipulation.py generate-one-of-one-multisig sidechain-wallet


### PR DESCRIPTION
I was getting the following python error when running `$ ./contrib/sidechain-manipulation.py`:

```bash
$ ./contrib/sidechain-manipulation.py generate-one-of-one-multisig sidechain-wallet
Traceback (most recent call last):
  File "./contrib/sidechain-manipulation.py", line 95, in <module>
    address = sidechain.getnewaddress()
  File "/home/ubuntu/elements/elements/contrib/../../python-bitcoinrpc/bitcoinrpc/authproxy.py", line 136, in __call__
    response = self._get_response()
  File "/home/ubuntu/elements/elements/contrib/../../python-bitcoinrpc/bitcoinrpc/authproxy.py", line 182, in _get_response
    response = json.loads(responsedata, parse_float=decimal.Decimal)
  File "/usr/lib/python2.7/json/__init__.py", line 351, in loads
    return cls(encoding=encoding, **kw).decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 366, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 384, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
```

To fix this error I had to edit `sidechain-manipulation.py` to include my rpc username and password. It wasn't clear from the README this was a necessary step.