### PR TITLE
Support locked Bitcoin wallets in sidechain manipulation script

### DIFF
--- a/contrib/sidechain-manipulation.py
+++ b/contrib/sidechain-manipulation.py
@@ -138,7 +138,7 @@ try:
 		except:
 			# Compensate for <0.9 BC Core by gracefully handling the "already unlocked" wallet case.
 			try:
-				txid = bitcoin.walletpassphrase('walletPassword', 1000)
+				bitcoin.walletpassphrase('walletPassword', 1000)
 			except JSONRPCException as e:
 				if e.error['code'] != '-17':
 					print("Got the following error from an RPC Call:")

--- a/contrib/sidechain-manipulation.py
+++ b/contrib/sidechain-manipulation.py
@@ -136,6 +136,14 @@ try:
 
 			txid = bitcoin.sendrawtransaction(tx_hex)
 		except:
+			# Compensate for <0.9 BC Core by gracefully handling the "already unlocked" wallet case.
+			try:
+				txid = bitcoin.walletpassphrase('walletPassword', 1000)
+			except JSONRPCException as e:
+				if e.error['code'] != '-17':
+					print("Got the following error from an RPC Call:")
+					print(e.error)
+					sys.exit()
 			txid = bitcoin.sendtoaddress(send_address, Decimal(sys.argv[3]))
 
 		print("Sent tx with id %s" % txid)


### PR DESCRIPTION
As is, the sidechain manipulation script chokes during the "send-to-sidechain" step if the wallet is locked. I've added rudimentary support for unlocking wallets. There are a couple of notes.

- As written, the user must manually edit the password. I'd prefer to make the password an optional CL parameter. If this is preferential, let me know and I'll go back and edit all files as necessary.
- While it's doubtful that the script will encounter a pre-0.9 BC Core, the code compensates for the pre-0.9 "wallet already unlocked" error (RPC_WALLET_ALREADY_UNLOCKED) if it's encountered. Any other error kills the script. It's a bit crude but it should work.
- Is 1000 the default unlock time? I'm happy to change it as necessary. (Perhaps it would be best to use 10 instead?)

Thanks.