### PR TITLE
Disable proof checking for all blocks on load

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -225,9 +225,6 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
                 pindexNew->nStatus        = diskindex.nStatus;
                 pindexNew->nTx            = diskindex.nTx;
 
-                if (!CheckProof(pindexNew->GetBlockHeader()))
-                    return error("LoadBlockIndex() : CheckProof failed: %s", pindexNew->ToString());
-
                 pcursor->Next();
             } else {
                 break; // if shutdown requested or finished loading block index


### PR DESCRIPTION
We still verify the headers of the last -checkblocks blocks.