### PR TITLE
Add `report_error` function for peer errors which can be overridden

### DIFF
--- a/contrib/fedpeg/blocksign.py
+++ b/contrib/fedpeg/blocksign.py
@@ -52,6 +52,9 @@ class WatchPeerController(RotatingConsensus):
 		self.round_local_block_hex = ""
 		return
 
+	def report_error(self, msg):
+		settings.report_error(msg)
+
 sidechain.importprivkey(settings.blocksigning_private_key)
 
 settings.nodes.remove(settings.my_node)

--- a/contrib/fedpeg/constants.py
+++ b/contrib/fedpeg/constants.py
@@ -44,3 +44,7 @@ class FedpegConstants:
 		self.sigs_required = int(self.redeem_script[:2], 16) - 0x50
 
 		self.inverse_bitcoin_genesis_hash = "".join(reversed([self.bitcoin_genesis_hash[i:i+2] for i in range(0, len(self.bitcoin_genesis_hash), 2)]))
+
+	def report_error(self, msg):
+		print("Error: %s" % msg)
+


### PR DESCRIPTION
I'm not sure exactly which errors should go through this function rather than being `print`ed directly; the idea is that these messages are ones that indicate network/peer problems that should be addressed immediately.
