### PR TITLE
Give a nice error for "make bitcoind", instead of a misleading one.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -396,6 +396,9 @@ clean-local:
 	rm -f leveldb/*/*.gcno leveldb/helpers/memenv/*.gcno
 	-rm -f config.h
 
+bitcoind bitcoin-cli bitcoin-tx:
+	@echo "Remember to 'make alpha*' rather than 'make bitcoin*' in this repository."
+
 .rc.o:
 	@test -f $(WINDRES)
 	$(AM_V_GEN) $(WINDRES) -DWINDRES_PREPROC -i $< -o $@


### PR DESCRIPTION
Right now, running 'make src/bitcoind' in alpha gives a very misleading error message about include files. What's actually happening is, there's no rule for 'bitcoind' in the Makefile, but because there's a source file named bitcoind.cpp, make is inventing a default rule, which doesn't work.

So let's make an overriding rule that displays a helpful error. (I did this for the three binaries I have run into this building; we can add more if there are more I forgot about.)