### PR TITLE
Fixed errors after receiving a tx with wrong scanning key

### DIFF
--- a/src/wallet.h
+++ b/src/wallet.h
@@ -737,6 +737,10 @@ public:
         CAmount amount = 0;
         if (pwallet->IsMine(vout[nTxOut]) & filter)
             amount = GetValueOut(nTxOut);
+        // Can be -1 if someone sent us a transaction using a wrong scanning key:
+        if (amount == -1) {
+            return 0;
+        }
         if (!MoneyRange(amount))
             throw std::runtime_error("CWallet::GetCredit() : value out of range");
         return amount;


### PR DESCRIPTION
After someone sent a transaction using a wrong scanning key to an alphad wallet, "CWallet::GetCredit() : value out of range" errors were returned on attempts to get balance or create new outgoing transactions. (because at https://github.com/ElementsProject/elements/blob/292f923d0341a7f33a85e8e73cc955697c7aa070/src/wallet.h#L938 the amount returned is -1 if unblinding fails)

This change causes such outputs to be ignored, thus preventing wallet from being locked down this way.