### PR TITLE
Properly builds on Mac OS X

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1020,10 +1020,14 @@ void ThreadMapPort()
 #ifndef UPNPDISCOVER_SUCCESS
     /* miniupnpc 1.5 */
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0);
-#else
+#elif MINIUPNPC_API_VERSION < 14
     /* miniupnpc 1.6 */
     int error = 0;
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);
+#else
+    /* miniupnpc 1.9.20150730 */
+    int error = 0;
+    devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, 2, &error);
 #endif
 
     struct UPNPUrls urls;


### PR DESCRIPTION
In order to properly build Elements Alpha on Mac OS X, it seems the miniupnpc fix commit @ https://github.com/bitcoin/bitcoin/commit/9f3e48e is required.

It may also be necessary for OS X users to diverge from the normal OS X build instructions by running `brew link openssl --force` (untested though, so not opening PR for this yet)
