### PR TITLE
Add Documentation for Testing and QA

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,32 @@ License
 Elements Alpha is released under the terms of the MIT license. See [COPYING](COPYING) for more
 information or see http://opensource.org/licenses/MIT.
 
+## Testing
+Testing and code review is the bottleneck for development; we get more pull
+requests than we can review and test on short notice. Please be patient and help out by testing
+other people's pull requests, and remember this is a security-critical project where any mistake might cost people
+lots of money.
+
+### Automated Testing
+
+Developers are strongly encouraged to write unit tests for new code, and to
+submit new unit tests for old code. Unit tests can be compiled and run
+(assuming they weren't disabled in configure) with: `make check`
+
+There are also [regression and integration tests](/qa) of the RPC interface, written
+in Python, that are run automatically on the build server.
+These tests can be run with: `qa/pull-tester/rpc-tests.py`
+
+The Travis CI system makes sure that every pull request is built for Windows
+and Linux, OSX, and that unit and sanity tests are automatically run.
+
+### Manual Quality Assurance (QA) Testing
+
+Changes should be tested by somebody other than the developer who wrote the
+code. This is especially important for large or high-risk changes. It is useful
+to add a test plan to the pull request description if testing the changes is
+not straightforward.
+
 [confidential-transactions]: https://www.elementsproject.org/elements/confidential-transactions
 [segregated-witness]: https://www.elementsproject.org/elements/segregated-witness
 [relative-lock-time]: https://www.elementsproject.org/elements/relative-lock-time

--- a/qa/README.md
+++ b/qa/README.md
@@ -1,0 +1,57 @@
+The [pull-tester](/qa/pull-tester/) folder contains a script to call
+multiple tests from the [rpc-tests](/qa/rpc-tests/) folder.
+
+Every pull request to the bitcoin repository is built and run through
+the regression test suite. You can also run all or only individual
+tests locally.
+
+Running tests
+=============
+
+You can run any single test by calling `qa/pull-tester/rpc-tests.py <testname>`.
+
+Or you can run any combination of tests by calling `qa/pull-tester/rpc-tests.py <testname1> <testname2> <testname3> ...`
+
+Run the regression test suite with `qa/pull-tester/rpc-tests.py`
+
+Run all possible tests with `qa/pull-tester/rpc-tests.py -extended`
+
+Possible options:
+
+```
+  -h, --help            show this help message and exit
+  --nocleanup           Leave bitcoinds and test.* datadir on exit or error
+  --noshutdown          Don't stop bitcoinds after the test execution
+  --srcdir=SRCDIR       Source directory containing bitcoind/bitcoin-cli
+                        (default: ../../src)
+  --tmpdir=TMPDIR       Root directory for datadirs
+  --tracerpc            Print out all RPC calls as they are made
+  --coveragedir=COVERAGEDIR
+                        Write tested RPC commands into this directory
+```
+
+If you set the environment variable `PYTHON_DEBUG=1` you will get some debug
+output (example: `PYTHON_DEBUG=1 qa/pull-tester/rpc-tests.py wallet`).
+
+A 200-block -regtest blockchain and wallets for four nodes
+is created the first time a regression test is run and
+is stored in the cache/ directory. Each node has 25 mature
+blocks (25*50=1250 BTC) in its wallet.
+
+After the first run, the cache/ blockchain and wallets are
+copied into a temporary directory and used as the initial
+test state.
+
+If you get into a bad state, you should be able
+to recover with:
+
+```bash
+rm -rf cache
+killall bitcoind
+```
+
+Writing tests
+=============
+You are encouraged to write tests for new or existing features.
+Further information about the test framework and individual rpc
+tests is found in [qa/rpc-tests](/qa/rpc-tests).


### PR DESCRIPTION
This adds documentation to the `qa/` directory, giving information about how to configure and run tests. 
