### PR TITLE
Assets: Attempts to fix regtest

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -316,13 +316,13 @@ bool CCoinsViewCache::VerifyAmounts(const CTransaction& tx, const CAmountMap& mT
         if (vpchCommitsIn.size() + vpchCommitsOut.size() == 0) {
             // Within an asset definition transaction, the asset being defined is identified with a 0
             if (assetID.IsNull()) {
-                // Only asset definitions and coinbase can have null asset IDs in outputs
-                if (!tx.IsAssetDefinition() && !tx.IsCoinBase())
+                // Only asset definitions can have null asset IDs in outputs
+                if (!tx.IsAssetDefinition())
                     return false;
                 // Cannot issue negative amounts
                 if (nPlainAmount < 0)
                     return false;
-            } else if (nPlainAmount != 0 && !tx.IsCoinBase())
+            } else if (nPlainAmount != 0)
                 return false;
         } else {
             // Newly issued assets cannot be confidential

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -316,13 +316,13 @@ bool CCoinsViewCache::VerifyAmounts(const CTransaction& tx, const CAmountMap& mT
         if (vpchCommitsIn.size() + vpchCommitsOut.size() == 0) {
             // Within an asset definition transaction, the asset being defined is identified with a 0
             if (assetID.IsNull()) {
-                // Only asset definitions can have null asset IDs in outputs
-                if (!tx.IsAssetDefinition())
+                // Only asset definitions and coinbase can have null asset IDs in outputs
+                if (!tx.IsAssetDefinition() && !tx.IsCoinBase())
                     return false;
                 // Cannot issue negative amounts
                 if (nPlainAmount < 0)
                     return false;
-            } else if (nPlainAmount != 0)
+            } else if (nPlainAmount != 0 && !tx.IsCoinBase())
                 return false;
         } else {
             // Newly issued assets cannot be confidential

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -939,7 +939,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state)
         return state.DoS(10, error("CheckTransaction() : vout empty"),
                          REJECT_INVALID, "bad-txns-vout-empty");
     // TODO add check to enforce cannonical representation of vTxFees
-    if (tx.vTxFees.size() <= tx.vout.size())
+    if (tx.vTxFees.size() > tx.vout.size())
         return state.DoS(10, error("%s: vTxFees bigger than vout", __func__),
                          REJECT_INVALID, "bad-txns-vtxfees-toolarge");
     // Size limits

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -335,8 +335,8 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
         txNew.vin[0].prevout.SetNull();
         txNew.vin[0].scriptSig = CScript() << nHeight << OP_0;
 
-        txNew.vout.resize(mBlockReward.size());
         mBlockReward[chainparams.HashGenesisBlock()] += GetBlockValue(nHeight, 0);
+        txNew.vout.resize(mBlockReward.size());
         unsigned int i = 0;
         for(CAmountMap::const_iterator it = mBlockReward.begin(); it != mBlockReward.end(); ++it) {
             txNew.vout[i].scriptPubKey = scriptPubKeyIn;

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -72,6 +72,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getrawtransaction", 1 },
     { "createrawtransaction", 0 },
     { "createrawtransaction", 1 },
+    { "createrawtransaction", 2 },
+    { "createrawtransaction", 3 },
     { "signrawtransaction", 1 },
     { "signrawtransaction", 2 },
     { "sendrawtransaction", 1 },

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -454,7 +454,7 @@ Value listunspent(const Array& params, bool fHelp)
 
 Value createrawtransaction(const Array& params, bool fHelp)
 {
-    if (fHelp || params.size() != 2)
+    if (fHelp || params.size() < 2)
         throw runtime_error(
             "createrawtransaction [{\"txid\":\"id\",\"vout\":n},...] {\"address\":amount,...}\n"
             "\nCreate a transaction spending the given inputs and sending to the given addresses.\n"
@@ -484,12 +484,6 @@ Value createrawtransaction(const Array& params, bool fHelp)
             "      \"address\": \"id\"  (string, optional) The key is the bitcoin address, the value is the asset id\n"
             "      ,...\n"
             "    }\n"
-            "3. \"output asset ids\"    (object, optional) a json object with addresses as keys and asset ids as values\n"
-            "                                              All addresses not contained here default to -feeasset\n"
-            "    {\n"
-            "      \"address\": \"id\"  (string, optional) The key is the bitcoin address, the value is the asset id\n"
-            "      ,...\n"
-            "    }\n"
             "4. Asset definition        (boolean, optional, default=false) Make it an asset definition transaction. Outputs with assetID = 0 will represent the newly issued assets.\n"
 
             "\nResult:\n"
@@ -500,7 +494,13 @@ Value createrawtransaction(const Array& params, bool fHelp)
             + HelpExampleRpc("createrawtransaction", "\"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\", \"{\\\"address\\\":0.01}\"")
         );
 
-    RPCTypeCheck(params, list_of(array_type)(obj_type));
+    if (params.size() == 2) {
+        RPCTypeCheck(params, list_of(array_type)(obj_type));
+    } else if (params.size() == 3) {
+        RPCTypeCheck(params, list_of(array_type)(obj_type)(obj_type));
+    } else if (params.size() == 4) {
+        RPCTypeCheck(params, list_of(array_type)(obj_type)(obj_type)(bool_type));
+    }
 
     Array inputs = params[0].get_array();
     Object sendTo = params[1].get_obj();


### PR DESCRIPTION
This PR includes my attempts to get alphad to work in regtest mode. What I'm trying to do is generate 100 blocks and then `createrawtransaction` to issue a new asset.

 1. I got `CheckTransaction: vTxFees bigger than vout` by just running it without any modifications. This seems due to `>` check being reversed in `CheckTransaction` in `main.cpp`.
 2. After the change above alphad still fails with `ConnectBlock: coinbase pays too much` on startup. I relaxed the checks in `CCoinsViewCache::VerifyAmounts` in `coins.cpp` so they now allow coinbase with null asset id. Not sure if it's correct, but at least it makes the server start.
 3. However it now SIGSEGVs on `setgenerate true` due to `vout` being too small in `miner.cpp`. Moving the `resize` after the change to `mBlockReward` makes `setgenerate` at least succeed
 4. Now I have two more issues - first one is `createrawtransaction` failing with more than two arguments, which I attempted to fix by changing the checks in `rpcrawtransaction.cpp`. However it still fails with `{"code":-3,"message":"Expected type obj, got str"}`, not sure why.
 5. The last issue I'm having seems more serious. While the `setgenerate` calls seem to succeed, restarting the server now fails with `Corrupted block database detected.`. More logs after restart below.

```
2016-03-11 16:01:06 Verifying last 101 blocks at level 3
2016-03-11 16:01:06 ERROR: DisconnectBlock() : added transaction mismatch? database corrupted
2016-03-11 16:01:06 ERROR: DisconnectBlock() : added transaction mismatch? database corrupted
(...)
2016-03-11 16:01:06 ERROR: DisconnectBlock() : added transaction mismatch? database corrupted
2016-03-11 16:01:06 ERROR: DisconnectBlock() : added transaction mismatch? database corrupted
2016-03-11 16:01:06 ERROR: VerifyDB() : *** coin database inconsistencies found (last 101 blocks, 0 good transactions before that)
```

Now I'm not sure if this is due to the other changes I made above, but it seems like too much to debug for me now.