### PR TITLE
Chainparams: Don't check the genesis block, but store its transaction…

### DIFF
--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -210,11 +210,11 @@ static void MutateTxAddInput(CMutableTransaction& tx, const string& strInput)
         throw runtime_error("invalid TX input vout");
 
     // Remove vout
-    pos = strVout.find(':');
+    pos = strVout.find(':', pos + 1);
     strVout = strVout.substr(pos + 1, string::npos);
 
     // extract and validate VALUE
-    pos = strVout.find(':');
+    pos = strVout.find(':', pos + 1);
     if (pos == string::npos)
         throw runtime_error("TX input missing separator");
     string strValue = strVout.substr(0, pos);
@@ -225,16 +225,16 @@ static void MutateTxAddInput(CMutableTransaction& tx, const string& strInput)
     CAssetID assetID = CAssetID(Params().HashGenesisBlock());
     // extract and validate sequence number
     uint32_t nSequence = ~(uint32_t)0;
-    pos = strVout.find(':');
+    pos = strVout.find(':', pos + 1);
     if (pos != string::npos) {
         if ((pos == 0) || (pos == (strVout.size() - 1)))
             throw runtime_error("empty TX input field");
 
         string strSeq = strVout.substr(pos + 1, string::npos);
-        size_t posAsset = strInput.find(':');
-        if (posAsset != string::npos && posAsset != 0 && posAsset != (strInput.size() - 1)) {
-            strSeq = strInput.substr(pos + 1, posAsset);
-            string strAsset = strInput.substr(posAsset + 1, string::npos);
+        size_t posAsset = strVout.find(':');
+        if (posAsset != string::npos && posAsset != 0 && posAsset != (strVout.size() - 1)) {
+            strSeq = strVout.substr(pos + 1, posAsset);
+            string strAsset = strVout.substr(posAsset + 1, string::npos);
             assetID = CAssetID(uint256(strAsset));
         }
 
@@ -283,9 +283,9 @@ static void MutateTxAddOutAddr(CMutableTransaction& tx, const string& strInput)
     // extract and validate ADDRESS
     string strAddr = strInput.substr(pos + 1, string::npos);
     CAssetID assetID = CAssetID(Params().HashGenesisBlock());
-    size_t posAsset = strInput.find(':');
+    size_t posAsset = strInput.find(':', pos + 1);
     if (posAsset != string::npos && posAsset != 0 && posAsset != (strInput.size() - 1)) {
-        strAddr = strInput.substr(pos, posAsset);
+        strAddr = strInput.substr(pos + 1, posAsset - pos - 1);
         string strAsset = strInput.substr(posAsset + 1, string::npos);
         assetID = CAssetID(uint256(strAsset));
     }
@@ -371,7 +371,7 @@ static void MutateTxAddOutScript(CMutableTransaction& tx, const string& strInput
     // extract and validate script
     string strScript = strInput.substr(pos + 1, string::npos);
     CAssetID assetID = CAssetID(Params().HashGenesisBlock());
-    size_t posAsset = strInput.find(':');
+    size_t posAsset = strInput.find(':', pos + 1);
     if (posAsset != string::npos && posAsset != 0 && posAsset != (strInput.size() - 1)) {
         strScript = strInput.substr(pos, posAsset);
         string strAsset = strInput.substr(posAsset + 1, string::npos);

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -231,7 +231,7 @@ static void MutateTxAddInput(CMutableTransaction& tx, const string& strInput)
             throw runtime_error("empty TX input field");
 
         string strSeq = strVout.substr(pos + 1, string::npos);
-        size_t posAsset = strVout.find(':');
+        size_t posAsset = strVout.find(':', pos + 1);
         if (posAsset != string::npos && posAsset != 0 && posAsset != (strVout.size() - 1)) {
             strSeq = strVout.substr(pos + 1, posAsset);
             string strAsset = strVout.substr(posAsset + 1, string::npos);
@@ -257,12 +257,12 @@ static void MutateTxAddInput(CMutableTransaction& tx, const string& strInput)
         throw runtime_error("invalid TX input: sequence missing");
     }
 
-    CAmountMap mTxReward = CTransaction(tx).GetTxRewardMap();
-    mTxReward[assetID] += value;
-    tx.SetFeesFromTxRewardMap(mTxReward);
     // append to transaction input list
     CTxIn txin(txid, vout, CScript(), nSequence);
     tx.vin.push_back(txin);
+    CAmountMap mTxReward = CTransaction(tx).GetTxRewardMap();
+    mTxReward[assetID] += value;
+    tx.SetFeesFromTxRewardMap(mTxReward);
 }
 
 static void MutateTxAddOutAddr(CMutableTransaction& tx, const string& strInput)
@@ -303,10 +303,10 @@ static void MutateTxAddOutAddr(CMutableTransaction& tx, const string& strInput)
         CPubKey pubkey = addr.GetBlindingKey();
         txout.nValue.vchNonceCommitment = std::vector<unsigned char>(pubkey.begin(), pubkey.end());
     }
+    tx.vout.push_back(txout);
     CAmountMap mTxReward = CTransaction(tx).GetTxRewardMap();
     mTxReward[assetID] -= value;
     tx.SetFeesFromTxRewardMap(mTxReward);
-    tx.vout.push_back(txout);
 }
 
 static void MutateTxBlind(CMutableTransaction& tx, const string& strInput)

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -358,7 +358,8 @@ bool CCoinsViewCache::VerifyAmounts(const CTransaction& tx) const
 bool CCoinsViewCache::HaveInputs(const CTransaction& tx) const
 {
     if (!tx.IsCoinBase()) {
-        for (unsigned int i = 0; i < tx.vin.size(); i++) {
+        // Don't check the null input in asset defintion transactions
+        for (unsigned int i = tx.IsAssetDefinition() ? 1 : 0; i < tx.vin.size(); i++) {
             const COutPoint &prevout = tx.vin[i].prevout;
             const CCoins* coins = AccessCoins(prevout.hash);
             if (!coins || !coins->IsAvailable(prevout.n)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1081,8 +1081,9 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         // do all inputs exist?
         // Note that this does not check for the presence of actual outputs (see the next check for that),
         // only helps filling in pfMissingInputs (to determine missing vs spent).
-        BOOST_FOREACH(const CTxIn txin, tx.vin) {
-            if (!view.HaveCoins(txin.prevout.hash)) {
+        // Don't check the null input in asset defintion transactions
+        for (unsigned int i = tx.IsAssetDefinition() ? 1 : 0; i < tx.vin.size(); i++) {
+            if (!view.HaveCoins(tx.vin[i].prevout.hash)) {
                 if (pfMissingInputs)
                     *pfMissingInputs = true;
                 return false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1068,7 +1068,6 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         CCoinsView dummy;
         CCoinsViewCache view(&dummy);
 
-        CAmountMap mTxReward;
         {
         LOCK(pool.cs);
         CCoinsViewMemPool viewMemPool(pcoinsTip, pool);
@@ -1097,13 +1096,6 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
 
         // Bring the best block into scope
         view.GetBestBlock();
-
-            mTxReward = tx.GetTxRewardMap();
-            if (!view.VerifyAmounts(tx, mTxReward))
-                return state.DoS(0,
-                                 error("AcceptToMemoryPool : input amounts do not match output amounts %s",
-                                       hash.ToString()),
-                                 REJECT_NONSTANDARD, "bad-txns-amount-mismatch");
 
         // we have all inputs cached now, so switch back to dummy, so we don't need to keep lock on mempool
         view.SetBackend(dummy);
@@ -1143,6 +1135,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
 
         double dPriority = view.GetPriority(tx, chainActive.Height());
 
+        CAmountMap mTxReward = tx.GetTxRewardMap();
         const CAmount nFees = mTxReward.find(feeAssetID)->second;
         CTxMemPoolEntry entry(tx, nFees, GetTime(), dPriority, chainActive.Height());
         unsigned int nSize = entry.GetTxSize();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1787,6 +1787,24 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 {
     const CChainParams& chainparams = Params();
     AssertLockHeld(cs_main);
+
+    CTxUndo undoDummy;
+    CBlockUndo blockundo;
+    blockundo.vtxundo.reserve(block.vtx.size() - 1);
+
+    // Special case for the genesis block: it is valid by definition
+    // but we must connect its transactions (for 2wp and genesis asset)
+    if (block.GetHash() == Params().HashGenesisBlock()) {
+        view.SetBestBlock(pindex->GetBlockHash());
+        for (unsigned int i = 0; i < block.vtx.size(); i++) {
+            const CTransaction &tx = block.vtx[i];
+            // TODO Refactor: decouple UpdateCoins() from undo stuff:
+            // genesis transactions will never be rolled back by defintion
+            UpdateCoins(tx, state, view, i == 0 ? undoDummy : blockundo.vtxundo.back(), pindex->nHeight);
+        }
+        return true;
+    }
+
     // Check it again in case a previous version let a bad block in
     if (!CheckBlock(block, state, !fJustCheck, !fJustCheck))
         return false;
@@ -1794,13 +1812,6 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     // verify that the view's current state corresponds to the previous block
     uint256 hashPrevBlock = pindex->pprev == NULL ? uint256(0) : pindex->pprev->GetBlockHash();
     assert(hashPrevBlock == view.GetBestBlock());
-
-    // Special case for the genesis block, skipping connection of its transactions
-    // (its coinbase is unspendable)
-    /*if (block.GetHash() == Params().HashGenesisBlock()) {
-        view.SetBestBlock(pindex->GetBlockHash());
-        return true;
-    }*/
 
     bool fScriptChecks = pindex->nHeight >= Checkpoints::GetTotalBlocksEstimate();
 
@@ -1844,8 +1855,6 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     flags |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
     flags |= SCRIPT_VERIFY_CHECKSEQUENCEVERIFY;
 
-    CBlockUndo blockundo;
-
     CCheckQueueControl<CScriptCheck> control(fScriptChecks && nScriptCheckThreads ? &scriptcheckqueue : NULL);
 
     int64_t nTimeStart = GetTimeMicros();
@@ -1855,7 +1864,6 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     CDiskTxPos pos(pindex->GetBlockPos(), GetSizeOfCompactSize(block.vtx.size()));
     std::vector<std::pair<uint256, CDiskTxPos> > vPos;
     vPos.reserve(block.vtx.size());
-    blockundo.vtxundo.reserve(block.vtx.size() - 1);
     for (unsigned int i = 0; i < block.vtx.size(); i++)
     {
         const CTransaction &tx = block.vtx[i];
@@ -1996,7 +2004,6 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             }
         }
 
-        CTxUndo undoDummy;
         if (i > 0) {
             blockundo.vtxundo.push_back(CTxUndo());
         }

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -244,9 +244,11 @@ void CMutableTransaction::SetFeesFromTxRewardMap(const CAmountMap& mTxReward)
     }
 }
 
-bool CTransaction::GetFee(const CAssetID& assetID) const
+CAmount CTransaction::GetFee(const CAssetID& assetID) const
 {
     const CAmountMap mTxReward = GetTxRewardMap();
+    if (!mTxReward.count(assetID))
+        return 0;
     return mTxReward.find(assetID)->second;
 }
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -328,7 +328,7 @@ public:
      * @return a CAmountMap with total fees per asset.
      */
     CAmountMap GetTxRewardMap() const;
-    bool GetFee(const CAssetID& assetID) const;
+    CAmount GetFee(const CAssetID& assetID) const;
 
     // Compute modified tx size for priority calculation (optionally given tx size)
     unsigned int CalculateModifiedSize(unsigned int nTxSize=0) const;


### PR DESCRIPTION
…s asvalid (HF for bitcoin)

- Like in #6597 (bitcoin), the genesis block shouldn't be checked
because it is a consensus rule in itself

- On the other hand, some elements like deterministic peg (because the
  21M reserve of pegged-coins needs to be created at some point) and
  multi-assets (because one cannot define new assets without existing
  utxos to be used as input for the asset definition transactions)