### PR TITLE
Fixed sidechain-manipulation print bug when there are 0 confirmations

### DIFF
--- a/contrib/sidechain-manipulation.py
+++ b/contrib/sidechain-manipulation.py
@@ -246,7 +246,7 @@ try:
 		prev_script = prev_out["scriptPubKey"]["asm"].split(" ")
 		assert(prev_script[10] == "OP_NOP3")
 		if "confirmations" not in prev_tx or prev_tx["confirmations"] < int(prev_script[9]):
-			print("You must wait for at least %s confirmations to claim this output (have %d)" % (prev_script[9], prev_tx["confirmations"]))
+			print("You must wait for at least %s confirmations to claim this output (have %d)" % (prev_script[9], prev_tx.get("confirmations", 0)))
 			exit(1)
 
 		p2sh_res = sidechain.createmultisig(1, [args.sidechainAddress])


### PR DESCRIPTION
This logic is invalid: If the "confirmations" key does not exists you cannot get the value from this key from the dict, it needs to do a "get-or-default-to-0-if-null". Traceback:

Traceback (most recent call last):
  File "./contrib/sidechain-manipulation.py", line 249, in <module>
    print("You must wait for at least %s confirmations to claim this output (have %d)" % (prev_script[9], prev_tx.get("confirmations")))
KeyError: 'confirmations'
