### PR TITLE
Allow sidechain-manipulation to use RPC_USER and RPC_PASS from environment

### DIFF
--- a/contrib/fedpeg/constants.py
+++ b/contrib/fedpeg/constants.py
@@ -4,8 +4,14 @@ import os
 
 class FedpegConstants:
 	# VARIOUS SETTINGS...
-	sidechain_url = "http://user:pass@127.0.0.1:4241"
-	bitcoin_url = "http://user:pass@127.0.0.1:18332"
+
+	# user from environment
+	user = os.getenv('RPC_USER', 'user')
+	password = os.getenv('RPC_PASS', 'pass')
+
+	# Use user/pass in URLs (used by sidechain manipulation)
+	sidechain_url = "http://" + user + ":" + password + "@127.0.0.1:4241"
+	bitcoin_url = "http://" + user + ":" + password + "@127.0.0.1:18332"
 
 	redeem_script = "55210269992fb441ae56968e5b77d46a3e53b69f136444ae65a94041fc937bdb28d93321021df31471281d4478df85bfce08a10aab82601dca949a79950f8ddf7002bd915a2102174c82021492c2c6dfcbfa4187d10d38bed06afb7fdcd72c880179fddd641ea121033f96e43d72c33327b6a4631ccaa6ea07f0b106c88b9dc71c9000bb6044d5e88a210313d8748790f2a86fb524579b46ce3c68fedd58d2a738716249a9f7d5458a15c221030b632eeb079eb83648886122a04c7bf6d98ab5dfb94cf353ee3e9382a4c2fab02102fb54a7fcaa73c307cfd70f3fa66a2e4247a71858ca731396343ad30c7c4009ce57ae"
 	redeem_script_address = "2N353JioQVxQPpCmeidjsb8kRX28TYXtBtc"


### PR DESCRIPTION
The instructions for sidechain manipulation from elementsproject.org says

"
**Note:** *If you set a custom RPCUSER and RPCPASS in the earlier step, you’ll need to edit ./contrib/sidechain-manipulation.py now to reflect those values somewhere around lines 9 and 10.*
"

This is both no longer true and rather annoying. This patch changes just the `FedpegConstants`, `sidechain_url` and `bitcoin_url`, to contain optional user and password from the environment. Names were selected based on elementsproject.org documentation wording.

`RPC_USER`
`RPC_PASS`
