### PR TITLE
build: fix qt5.7 build under macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,6 @@ else
   CXXFLAGS_overridden=no
 fi
 AC_PROG_CXX
-m4_ifdef([AC_PROG_OBJCXX],[AC_PROG_OBJCXX])
 
 dnl By default, libtool for mingw refuses to link static libs into a dll for
 dnl fear of mixing pic/non-pic objects, and import/export complications. Since
@@ -57,6 +56,15 @@ dnl Require C++11 compiler (no GNU extensions)
 AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
 dnl Check if -latomic is required for <std::atomic>
 CHECK_ATOMIC
+
+dnl Unless the user specified OBJCXX, force it to be the same as CXX. This ensures
+dnl that we get the same -std flags for both.
+m4_ifdef([AC_PROG_OBJCXX],[
+if test "x${OBJCXX+set}" = "x"; then
+  OBJCXX="${CXX}"
+fi
+AC_PROG_OBJCXX
+])
 
 dnl Libtool init checks.
 LT_INIT([pic-only])


### PR DESCRIPTION
QT does not get the C++11 std flag properly with the 0.13.1 version. This commit by @theuni fixes.

[from https://github.com/bitcoin/bitcoin/pull/9169]

OBJCXX's std flags don't get defined by our cxx macro. Rather than hard-coding
to c++11, just force OBJCXX to be the same as CXX unless the user specified
otherwise.

Github-Pull: #9169
Rebased-From: 70266e98292bf9c8f019ca4b11d681b575f71448