### PR TITLE
[Trivial] Change 'bitcoin-cli' to 'elements-cli' in error message

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -126,7 +126,7 @@ bool AppInit(int argc, char* argv[])
 
         if (fCommandLine)
         {
-            fprintf(stderr, "Error: There is no RPC client functionality in elementsd anymore. Use the bitcoin-cli utility instead.\n");
+            fprintf(stderr, "Error: There is no RPC client functionality in elementsd anymore. Use the elements-cli utility instead.\n");
             exit(1);
         }
 #ifndef WIN32


### PR DESCRIPTION
Fixed the error message when trying to use RPC commands with elementsd.