### PR TITLE
RPC: Introduce -rpcamountdecimals for the RPC to use other units than BTC

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -474,6 +474,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-rpcport=<port>", strprintf(_("Listen for JSON-RPC connections on <port> (default: %u)"), defaultBaseParams->RPCPort()));
     strUsage += HelpMessageOpt("-rpcallowip=<ip>", _("Allow JSON-RPC connections from specified source. Valid for <ip> are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times"));
     strUsage += HelpMessageOpt("-rpcthreads=<n>", strprintf(_("Set the number of threads to service RPC calls (default: %d)"), DEFAULT_HTTP_THREADS));
+    strUsage += HelpMessageOpt("-rpcamountdecimals=<n>", strprintf(_("Number of decimals for amount values in RPC (default: %d [ie unit BTC], allowed: from 0 to 8)"), DEFAULT_RPC_AMOUNT_DECIMALS));
     if (showDebug) {
         strUsage += HelpMessageOpt("-rpcworkqueue=<n>", strprintf("Set the depth of the work queue to service RPC calls (default: %d)", DEFAULT_HTTP_WORKQUEUE));
         strUsage += HelpMessageOpt("-rpcservertimeout=<n>", strprintf("Timeout during HTTP requests (default: %d)", DEFAULT_HTTP_SERVER_TIMEOUT));
@@ -983,6 +984,9 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     if (GetBoolArg("-peerbloomfilters", false))
         nLocalServices = ServiceFlags(nLocalServices | NODE_BLOOM);
+
+    if (!SetRpcAmountDecimals(GetArg("-rpcamountdecimals", DEFAULT_RPC_AMOUNT_DECIMALS)))
+        return InitError("-rpcamountdecimals must be between 0 and 8.");
 
     nMaxTipAge = GetArg("-maxtipage", DEFAULT_MAX_TIP_AGE);
 

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -39,6 +39,7 @@ using namespace std;
 
 static bool fRPCRunning = false;
 static bool fRPCInWarmup = true;
+static unsigned int nRPCAmountDecimals = DEFAULT_RPC_AMOUNT_DECIMALS;
 static std::string rpcWarmupStatus("RPC server started");
 static CCriticalSection cs_rpcWarmup;
 /* Timer-creating functions */
@@ -126,12 +127,21 @@ void RPCTypeCheckObj(const UniValue& o,
     }
 }
 
+bool SetRpcAmountDecimals(unsigned int decimals)
+{
+    if (decimals <= 8) {
+        nRPCAmountDecimals = decimals;
+        return true;
+    }
+    return false;
+}
+
 CAmount AmountFromValue(const UniValue& value)
 {
     if (!value.isNum() && !value.isStr())
         throw JSONRPCError(RPC_TYPE_ERROR, "Amount is not a number or string");
     CAmount amount;
-    if (!ParseFixedPoint(value.getValStr(), 8, &amount))
+    if (!ParseFixedPoint(value.getValStr(), nRPCAmountDecimals, &amount))
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
     if (!MoneyRange(amount))
         throw JSONRPCError(RPC_TYPE_ERROR, "Amount out of range");
@@ -142,8 +152,9 @@ UniValue ValueFromAmount(const CAmount& amount)
 {
     bool sign = amount < 0;
     int64_t n_abs = (sign ? -amount : amount);
-    int64_t quotient = n_abs / COIN;
-    int64_t remainder = n_abs % COIN;
+    unsigned int nRpcUnit = pow(10, nRPCAmountDecimals);
+    int64_t quotient = n_abs / nRpcUnit;
+    int64_t remainder = n_abs % nRpcUnit;
     return UniValue(UniValue::VNUM,
             strprintf("%s%d.%08d", sign ? "-" : "", quotient, remainder));
 }

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -23,6 +23,7 @@
 
 //Thread-local rpc user name for logging purposes
 extern boost::thread_specific_ptr<std::string> userInstance;
+static const unsigned int DEFAULT_RPC_AMOUNT_DECIMALS = 8;
 
 class CRPCCommand;
 
@@ -186,6 +187,7 @@ extern std::vector<unsigned char> ParseHexV(const UniValue& v, std::string strNa
 extern std::vector<unsigned char> ParseHexO(const UniValue& o, std::string strKey);
 
 extern int64_t nWalletUnlockTime;
+bool SetRpcAmountDecimals(unsigned int decimals);
 extern CAmount AmountFromValue(const UniValue& value);
 extern UniValue ValueFromAmount(const CAmount& amount);
 extern double GetDifficulty(const CBlockIndex* blockindex = NULL);


### PR DESCRIPTION
Backport of https://github.com/bitcoin/bitcoin/pull/9882
Even if that doesn't get merged upstream, we need something like this before the assets PR. It would be nicer to use satoshis/minimum_unit for every asset instead of using 8 decimals for every asset.
