### PR TITLE
Fix transaction re-blinding, remove legacy static key

### DIFF
--- a/qa/rpc-tests/confidential_transactions.py
+++ b/qa/rpc-tests/confidential_transactions.py
@@ -174,6 +174,17 @@ class CTTest (BitcoinTestFramework):
         assert_equal(self.nodes[1].getbalance(), node1)
         assert_equal(self.nodes[2].getbalance(), node2)
 
+        # Testing wallet's ability to deblind its own outputs
+        addr = self.nodes[0].getnewaddress()
+        addr2 = self.nodes[0].getnewaddress()
+        # We add two to-blind outputs, fundraw adds an already-blinded change output
+        # If we only add one, the newly blinded will be 0-blinded because input = -output
+        raw = self.nodes[0].createrawtransaction([], {addr:Decimal('1.1'), addr2:1})
+        funded = self.nodes[0].fundrawtransaction(raw)
+        blinded = self.nodes[0].blindrawtransaction(funded["hex"])
+        # blind again to make sure we know output blinders
+        blinded2 = self.nodes[0].blindrawtransaction(blinded)
+
         # Check createblindedaddress functionality
         blinded_addr = self.nodes[0].getnewaddress()
         validated_addr = self.nodes[0].validateaddress(blinded_addr)

--- a/qa/rpc-tests/confidential_transactions.py
+++ b/qa/rpc-tests/confidential_transactions.py
@@ -196,6 +196,7 @@ class CTTest (BitcoinTestFramework):
         new_validated = self.nodes[0].validateaddress(new_addr)
         self.nodes[2].sendtoaddress(new_addr, 1)
         diff_blind = self.nodes[1].createblindedaddress(new_validated["unconfidential"], blinding_key)
+        self.sync_all()
         assert_equal(len(self.nodes[0].listunspent(0, 0, [new_validated["unconfidential"]])), 1)
         self.nodes[0].importblindingkey(diff_blind, blinding_key)
         # CT values for this wallet transaction  have been cached via importblindingkey

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -524,7 +524,7 @@ void FillOutputBlinds(const CMutableTransaction& tx, bool fUseWallet, std::vecto
             uint256 blinding_factor;
             CAmount amount;
 #ifdef ENABLE_WALLET
-            if (fUseWallet && UnblindOutput(pwalletMain->blinding_key, tx.vout[nOut], amount, blinding_factor) != 0) {
+            if (fUseWallet && UnblindOutput(pwalletMain->GetBlindingKey(&tx.vout[nOut].scriptPubKey), tx.vout[nOut], amount, blinding_factor) != 0) {
                 output_blinds.push_back(blinding_factor);
                 output_pubkeys.push_back(CPubKey());
             } else if (fUseWallet)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3794,10 +3794,6 @@ CKey CWallet::GetBlindingKey(const CScript* script) const
         }
     }
 
-    if (script == NULL && blinding_key.IsValid()) {
-        return blinding_key;
-    }
-
     return CKey();
 }
 
@@ -3841,13 +3837,6 @@ void CWallet::ComputeBlindingData(const CTxOut& output, CAmount& amount, CPubKey
     CKey blinding_key;
     if ((blinding_key = GetBlindingKey(&output.scriptPubKey)).IsValid()) {
         // For outputs using derived blinding.
-        if (UnblindOutput(blinding_key, output, amount, blindingfactor)) {
-            pubkey = blinding_key.GetPubKey();
-            return;
-        }
-    }
-    if ((blinding_key = GetBlindingKey(NULL)).IsValid()) {
-        // For outputs using deprecated static blinding.
         if (UnblindOutput(blinding_key, output, amount, blindingfactor)) {
             pubkey = blinding_key.GetPubKey();
             return;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -659,7 +659,6 @@ public:
         nLastResend = 0;
         nTimeFirstKey = 0;
         fBroadcastTransactions = false;
-        blinding_key = CKey();
         blinding_derivation_key = uint256();
     }
 
@@ -684,9 +683,6 @@ public:
     //! The actual blinding key is computed as HMAC-SHA256(key=blinding_derivation_key, msg=scriptPubKey).
     //! There can be exceptions in mapSpecificBlindingKeys.
     uint256 blinding_derivation_key;
-
-    //! Only for backward compatibility with older wallets (superseded by blinding_derivation_key).
-    CKey blinding_key;
 
     const CWalletTx* GetWalletTx(const uint256& hash) const;
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -619,18 +619,6 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
                 return false;
             }
         }
-        /* Only for backward compatibility with older wallets. */
-        else if (strType == "blindingkey")
-        {
-            assert(!pwallet->blinding_key.IsValid());
-            std::vector<unsigned char> vchBlindingKey;
-            ssValue >> vchBlindingKey;
-            pwallet->blinding_key.Set(vchBlindingKey.begin(), vchBlindingKey.end(), true);
-            if (!pwallet->blinding_key.IsValid()) {
-                strErr = "Error reading wallet blinding key";
-                return false;
-            }
-        }
         else if (strType == "blindingderivationkey")
         {
             assert(pwallet->blinding_derivation_key.IsNull());


### PR DESCRIPTION
There was some leftover static blinding key code that meant blinding a partially-blinded transaction would fail because it would attempt to deblind an output using the deprecated static blinding key.

I fixed this, added a test, and removed the last of the static blinding key code.