### PR TITLE
Only track locks with explicit asset types that are bitcoin

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3106,7 +3106,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             vPos.push_back(std::make_pair(tx.GetHash(), pos));
             for (unsigned int i = 0; i < tx.vout.size(); i++) {
                 CTxOut txout= tx.vout[i];
-                if (txout.scriptPubKey.IsWithdrawLock() && txout.nValue.IsExplicit())
+                if (txout.scriptPubKey.IsWithdrawLock() && txout.nValue.IsExplicit() && txout.nAsset.IsExplicit() && txout.nAsset.GetAsset() == BITCOINID)
                     mLocksCreated.insert(std::make_pair(txout.scriptPubKey.GetWithdrawLockGenesisHash(), std::make_pair(COutPoint(tx.GetHash(), i), txout.nValue.GetAmount())));
             }
 
@@ -3289,8 +3289,9 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
         for (unsigned int j = 0; j < tx.vout.size(); j++) {
             CTxOut txout = tx.vout[j];
-            if (txout.scriptPubKey.IsWithdrawLock() && txout.nValue.IsExplicit())
+            if (txout.scriptPubKey.IsWithdrawLock() && txout.nValue.IsExplicit() && txout.nAsset.IsExplicit() && txout.nAsset.GetAsset() == BITCOINID) {
                 mLocksCreated.insert(std::make_pair(txout.scriptPubKey.GetWithdrawLockGenesisHash(), std::make_pair(COutPoint(tx.GetHash(), j), txout.nValue.GetAmount())));
+            }
         }
         if (!tx.HasValidFee())
             return state.DoS(100, error("ConnectBlock(): transaction fee overflowed"), REJECT_INVALID, "bad-fee-outofrange");


### PR DESCRIPTION
Currently a node may try to peg-in bitcoin funds using a lock that is not explicit bitcoin. Simply don't track these.

For a multi-peg/asset pegging scenario we can generalize this via pegging cleanup.