### PR TITLE
have createblindedaddress use blinding pubkey instead

### DIFF
--- a/qa/rpc-tests/confidential_transactions.py
+++ b/qa/rpc-tests/confidential_transactions.py
@@ -189,15 +189,16 @@ class CTTest (BitcoinTestFramework):
         # Check createblindedaddress functionality
         blinded_addr = self.nodes[0].getnewaddress()
         validated_addr = self.nodes[0].validateaddress(blinded_addr)
+        blinding_pubkey = self.nodes[0].validateaddress(blinded_addr)["confidential_key"]
         blinding_key = self.nodes[0].dumpblindingkey(blinded_addr)
-        assert_equal(blinded_addr, self.nodes[1].createblindedaddress(validated_addr["unconfidential"], blinding_key))
+        assert_equal(blinded_addr, self.nodes[1].createblindedaddress(validated_addr["unconfidential"], blinding_pubkey))
 
         # If a blinding key is over-ridden by a newly imported one, funds may be unaccounted for
         new_addr = self.nodes[0].getnewaddress()
         new_validated = self.nodes[0].validateaddress(new_addr)
         self.nodes[2].sendtoaddress(new_addr, 1)
-        diff_blind = self.nodes[1].createblindedaddress(new_validated["unconfidential"], blinding_key)
         self.sync_all()
+        diff_blind = self.nodes[1].createblindedaddress(new_validated["unconfidential"], blinding_pubkey)
         assert_equal(len(self.nodes[0].listunspent(0, 0, [new_validated["unconfidential"]])), 1)
         self.nodes[0].importblindingkey(diff_blind, blinding_key)
         # CT values for this wallet transaction  have been cached via importblindingkey

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -362,7 +362,7 @@ UniValue createblindedaddress(const UniValue& params, bool fHelp)
             "\nCreates a blinded address using the provided blinding key.\n"
             "\nArguments:\n"
             "1. \"address\"        (string, required) The unblinded address to be blinded.\n"
-            "2. \"key\"            (string, required) The blinding private key.\n"
+            "2. \"key\"            (string, required) The blinding public key. This can be obtained for a given address using `validateaddress`.\n"
             "\nResult:\n"
             "\"blinded_address\"   (string) The blinded address.\n"
             "\nExamples:\n"
@@ -386,14 +386,14 @@ UniValue createblindedaddress(const UniValue& params, bool fHelp)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid hexadecimal for key");
     }
     std::vector<unsigned char> keydata = ParseHex(params[1].get_str());
-    if (keydata.size() != 32) {
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid hexadecimal key length, must be 32 bytes long.");
+    if (keydata.size() != 33) {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid hexadecimal key length, must be length 66.");
     }
 
-    CKey key;
-    key.Set(keydata.begin(), keydata.end(), true);
+    CPubKey key;
+    key.Set(keydata.begin(), keydata.end());
 
-    return address.AddBlindingKey(key.GetPubKey()).ToString();
+    return address.AddBlindingKey(key).ToString();
 }
 
 UniValue verifymessage(const UniValue& params, bool fHelp)


### PR DESCRIPTION
@Christewart we found this to be more useful downstream, so we switched.