### PR TITLE
fixed gettxout rpc bug + invalidateblock.py syntax

### DIFF
--- a/qa/rpc-tests/invalidateblock.py
+++ b/qa/rpc-tests/invalidateblock.py
@@ -27,13 +27,13 @@ class InvalidateTest(BitcoinTestFramework):
         
     def run_test(self):
         print("Make sure we repopulate setBlockIndexCandidates after InvalidateBlock:")
-        print "Mine 104 blocks on Node 0"
+        print("Mine 104 blocks on Node 0")
         self.nodes[0].generate(104)
         assert(self.nodes[0].getblockcount() == 104)
         besthash = self.nodes[0].getbestblockhash()
 
         #Mining extra blocks to properly fork elements chain
-        print "Mine competing 106 blocks on Node 1"
+        print("Mine competing 106 blocks on Node 1")
         self.nodes[1].generate(100)
         self.nodes[1].sendtoaddress(self.nodes[1].getnewaddress(), 1)
         self.nodes[1].generate(6)
@@ -54,13 +54,13 @@ class InvalidateTest(BitcoinTestFramework):
 
         print("\nMake sure we won't reorg to a lower work chain:")
         connect_nodes_bi(self.nodes,1,2)
-        print "Sync node 2 to node 1 so both have 106 blocks"
+        print("Sync node 2 to node 1 so both have 106 blocks")
         sync_blocks(self.nodes[1:3])
         assert(self.nodes[2].getblockcount() == 106)
-        print "Invalidate block 105 on node 1 so its tip is now at 104"
+        print("Invalidate block 105 on node 1 so its tip is now at 104")
         self.nodes[1].invalidateblock(self.nodes[1].getblockhash(105))
         assert(self.nodes[1].getblockcount() == 104)
-        print "Invalidate block 103 on node 102, so its tip is now 102"
+        print("Invalidate block 103 on node 102, so its tip is now 102")
         self.nodes[2].invalidateblock(self.nodes[2].getblockhash(103))
         assert(self.nodes[2].getblockcount() == 102)
         #print "..and then mine a block" #This will create identical invalid block

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -74,13 +74,20 @@ class WalletTest (BitcoinTestFramework):
         # Send 21 BTC from 0 to 2 using sendtoaddress call.
         txid1 = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 11)
         txout1v0 = self.nodes[0].gettxout(txid1, 0)
+        rawtx1 = self.nodes[0].getrawtransaction(txid1, 1)
+        valuecommit1 = rawtx1["vout"][0]["serValue"]
         assert_equal(txout1v0['confirmations'], 0)
         assert(not txout1v0['coinbase'])
+        assert_equal(valuecommit1, txout1v0['valuecommitment'])
+
 
         txid2 = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 10)
         txout2v0 = self.nodes[0].gettxout(txid2, 0)
+        rawtx2 = self.nodes[0].getrawtransaction(txid2, 1)
+        valuecommit2 = rawtx2["vout"][0]["serValue"]
         assert_equal(txout2v0['confirmations'], 0)
         assert(not txout2v0['coinbase'])
+        assert_equal(valuecommit2, txout2v0['valuecommitment'])
 
         walletinfo = self.nodes[0].getwalletinfo("bitcoin")
         assert_equal(walletinfo['immature_balance'], 0)

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -70,16 +70,22 @@ class WalletTest (BitcoinTestFramework):
         #assert_equal(self.nodes[0].getbalance(), 21000000-1100000)
         #assert_equal(self.nodes[1].getbalance(), 1000000)
         #assert_equal(self.nodes[2].getbalance(), 100000)
-        
 
         # Send 21 BTC from 0 to 2 using sendtoaddress call.
-        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 11)
-        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 10)
+        txid1 = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 11)
+        txout1v0 = self.nodes[0].gettxout(txid1, 0)
+        assert_equal(txout1v0['confirmations'], 0)
+        assert(not txout1v0['coinbase'])
+
+        txid2 = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 10)
+        txout2v0 = self.nodes[0].gettxout(txid2, 0)
+        assert_equal(txout2v0['confirmations'], 0)
+        assert(not txout2v0['coinbase'])
 
         walletinfo = self.nodes[0].getwalletinfo("bitcoin")
         assert_equal(walletinfo['immature_balance'], 0)
 
-        # Have node0 mine a block, thus it will collect its own fee.
+        # Have node0 mine a block, thus it will collect its own fee. Confirm previous transactions.
         self.nodes[0].generate(1)
         self.sync_all()
 
@@ -110,24 +116,27 @@ class WalletTest (BitcoinTestFramework):
         # create both transactions
         txns_to_send = []
         for utxo in node0utxos:
-            if utxo["amount"] <= 3:
+            if utxo["amount"] <= 3: # arbitrary value of 3?
                 continue
             inputs = []
             outputs = {}
             inputs.append({ "txid" : utxo["txid"], "vout" : utxo["vout"], "nValue":utxo["amount"]})
-            outputs[self.nodes[2].getnewaddress("from1")] = utxo["amount"] - Decimal(3)
+            outputs[self.nodes[2].getnewaddress("from1")] = utxo["amount"]
             raw_tx = self.nodes[0].createrawtransaction(inputs, outputs)
             raw_tx = self.nodes[0].blindrawtransaction(raw_tx)
             txns_to_send.append(self.nodes[0].signrawtransaction(raw_tx))
 
-        return #TODO Fix the rest
-        # Have node 1 (miner) send the transactions
-        self.nodes[1].sendrawtransaction(txns_to_send[0]["hex"], True)
-        self.nodes[1].sendrawtransaction(txns_to_send[1]["hex"], True)
+        # Have node 1 (miner) send the transaction
+        txid = self.nodes[1].sendrawtransaction(txns_to_send[0]["hex"], True)
 
-        # Have node1 mine a block to confirm transactions:
+        # Have node1 mine a block to confirm transaction:
         self.nodes[1].generate(1)
         self.sync_all()
+
+        txoutv0 = self.nodes[0].gettxout(txid, 0)
+        assert_equal(txoutv0['confirmations'], 1)
+        assert(not txoutv0['coinbase'])
+        return #TODO fix the rest
 
         assert_equal(self.nodes[0].getbalance(), 0)
         assert_equal(self.nodes[2].getbalance(), 94)

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -766,7 +766,7 @@ UniValue gettxout(const UniValue& params, bool fHelp)
     if (coins.vout[n].nValue.IsExplicit()) {
         ret.push_back(Pair("value", ValueFromAmount(coins.vout[n].nValue.GetAmount())));
     } else {
-        ret.push_back(Pair("valuecommitment", uint256(coins.vout[n].nValue.vchCommitment).GetHex()));
+        ret.push_back(Pair("valuecommitment", HexStr(coins.vout[n].nValue.vchCommitment)));
     }
     UniValue o(UniValue::VOBJ);
     ScriptPubKeyToJSON(coins.vout[n].scriptPubKey, o, true);


### PR DESCRIPTION
instead of cast to uint256, just convert commitment to hex string using HexStr()

invalidateblock.py had incorrect python syntax, it now passes