### PR TITLE
[rpc] Add getblindedaddress RPC command

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3658,6 +3658,7 @@ extern UniValue dumpblindingkey(const UniValue& params, bool fHelp);
 extern UniValue dumpissuanceblindingkey(const UniValue& params, bool fHelp);
 extern UniValue importblindingkey(const UniValue& params, bool fHelp);
 extern UniValue importissuanceblindingkey(const UniValue& params, bool fHelp);
+UniValue getblindedaddress(const UniValue& params, bool fHelp);
 
 static const CRPCCommand commands[] =
 { //  category              name                        actor (function)           okSafeMode
@@ -3679,6 +3680,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "getaccount",               &getaccount,               true  },
     { "wallet",             "getaddressesbyaccount",    &getaddressesbyaccount,    true  },
     { "wallet",             "getbalance",               &getbalance,               false },
+    { "wallet",             "getblindedaddress",        &getblindedaddress,        false },
     { "wallet",             "getnewaddress",            &getnewaddress,            true  },
     { "wallet",             "getpeginaddress",          &getpeginaddress,          false },
     { "wallet",             "getrawchangeaddress",      &getrawchangeaddress,      true  },


### PR DESCRIPTION
This turns an unblinded address into its blinded equivalent, if known.

This command is useful when examining (raw) transactions which have outpoints to your wallet. It is possible to get the blinded version of the address by passing the address argument in getrawtransaction to getblindedaddress.

(Note that elements-0.14 is broken on macOS atm, which is why I am PR'ing the 0.13 branch.)