### PR TITLE
elementsd does not start on MacOS

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -340,10 +340,10 @@ public:
 };
 
 
-const std::map<std::string, uint256> CChainParams::supportedChains =
-    boost::assign::map_list_of
-    ( CHAINPARAMS_ELEMENTS, CElementsParams().GenesisBlock().GetHash())
-    ( CHAINPARAMS_REGTEST, CRegTestParams().GenesisBlock().GetHash())
+const std::vector<std::string> CChainParams::supportedChains =
+    boost::assign::list_of
+    ( CHAINPARAMS_ELEMENTS )
+    ( CHAINPARAMS_REGTEST )
     ;
 
 static std::unique_ptr<CChainParams> globalChainParams;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -63,7 +63,7 @@ public:
     /**
      * Maps strNetworkID [see BIP70] to chainID (hashGenesisBlock and genesis checkpoint)
      */
-    static const std::map<std::string, uint256> supportedChains;
+    static const std::vector<std::string> supportedChains;
 
     const Consensus::Params& GetConsensus() const { return consensus; }
     const CMessageHeader::MessageStartChars& MessageStart() const { return pchMessageStart; }

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -219,11 +219,11 @@ void PaymentServer::ipcParseCommandLine(int argc, char* argv[])
             if (GUIUtil::parseBitcoinURI(arg, &r) && !r.address.isEmpty())
             {
                 CBitcoinAddress address(r.address.toStdString());
-                std::map<std::string, uint256>::const_iterator iter;
+                std::vector<std::string>::const_iterator iter;
                 for (iter = CChainParams::supportedChains.begin(); iter != CChainParams::supportedChains.end(); ++iter) {
-                    auto tempChainParams = CreateChainParams(iter->first);
+                    auto tempChainParams = CreateChainParams(*iter);
                     if (address.IsValid(*tempChainParams)) {
-                        SelectParams(iter->first);
+                        SelectParams(*iter);
                         break;
                     }
                 }


### PR DESCRIPTION
elementsd does not start on MacOS because of LOCK(cs_args) failuer when setting CChainParams::supportedChains.
the type of supportedChains is simple map (key/string, value/uint256), but its value were never used.
so change its type to 'vectorstd::string' instead of.