### PR TITLE
Refactor: Easier support for chains with multiple genesis assets

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -19,6 +19,8 @@
 
 #include "chainparamsseeds.h"
 
+static const uint32_t MAX_GENESIS_OUTPUTS = 500;
+
 // Safer for users if they load incorrect parameters via arguments.
 static std::vector<unsigned char> CommitToArguments(const Consensus::Params& params, const std::string& networkID)
 {
@@ -43,20 +45,38 @@ static CScript StrHexToScriptWithDefault(std::string strScript, const CScript de
     return returnScript;
 }
 
-static CBlock CreateGenesisBlock(const Consensus::Params& params, const std::string& networkID, const CScript& genesisOutputScript, uint32_t nTime, int32_t nVersion, const CAmount& genesisReward, const uint32_t rewardShards, const CAsset& genesisAsset)
+struct GenesisReward
 {
-    // Shards must be evenly divisible
-    assert(MAX_MONEY % rewardShards == 0);
+    const CAmount nTotalAmount;
+    const CScript outputScript;
+    const CAsset asset;
+    const uint32_t nShards;
+  
+    GenesisReward(const CAmount& nTotalAmountIn, const CScript& outputScriptIn, const CAsset& assetIn, const uint32_t nShardsIn=1) :
+        nTotalAmount(nTotalAmountIn), outputScript(outputScriptIn), asset(assetIn), nShards(nShardsIn) {};
+};
+
+static CBlock CreateGenesisBlock(const Consensus::Params& params, const std::string& networkID, uint32_t nTime, int32_t nVersion, const std::vector<GenesisReward>& genesisRewards)
+{
     CMutableTransaction txNew;
     txNew.nVersion = 1;
     txNew.vin.resize(1);
-    txNew.vout.resize(rewardShards);
     // Any consensus-related values that are command-line set can be added here for anti-footgun
     txNew.vin[0].scriptSig = CScript(CommitToArguments(params, networkID));
-    for (unsigned int i = 0; i < rewardShards; i++) {
-        txNew.vout[i].nValue = genesisReward/rewardShards;
-        txNew.vout[i].nAsset = genesisAsset;
-        txNew.vout[i].scriptPubKey = genesisOutputScript;
+
+    unsigned int totalOutputs = 0;
+    for (GenesisReward gReward : genesisRewards) totalOutputs += gReward.nShards;
+    assert(totalOutputs <= MAX_GENESIS_OUTPUTS);
+    txNew.vout.resize(totalOutputs);
+
+    for (GenesisReward gReward : genesisRewards) {
+        for (unsigned int i = 0; i < gReward.nShards; i++) {
+            // Shards must be evenly divisible
+            assert(gReward.nTotalAmount % gReward.nShards == 0);
+            txNew.vout[i].nValue = gReward.nTotalAmount / gReward.nShards;
+            txNew.vout[i].nAsset = gReward.asset;
+            txNew.vout[i].scriptPubKey = gReward.outputScript;
+        }
     }
 
     CBlock genesis;
@@ -151,7 +171,10 @@ public:
         CalculateAsset(consensus.pegged_asset, entropy);
 
         CScript scriptDestination(CScript() << std::vector<unsigned char>(parentGenesisBlockHash.begin(), parentGenesisBlockHash.end()) << OP_WITHDRAWPROOFVERIFY);
-        genesis = CreateGenesisBlock(consensus, strNetworkID, scriptDestination, 1231006505, 1, MAX_MONEY, 100, consensus.pegged_asset);
+        const std::vector<GenesisReward> genesisRewards = {
+            GenesisReward(MAX_MONEY, scriptDestination, consensus.pegged_asset, 100),
+        };
+        genesis = CreateGenesisBlock(consensus, strNetworkID, 1231006505, 1, genesisRewards);
         consensus.hashGenesisBlock = genesis.GetHash();
 
         scriptCoinbaseDestination = CScript() << ParseHex("0229536c4c83789f59c30b93eb40d4abbd99b8dcc99ba8bd748f29e33c1d279e3c") << OP_CHECKSIG;
@@ -260,7 +283,10 @@ public:
         GenerateAssetEntropy(entropy,  COutPoint(uint256(commit), 0), parentGenesisBlockHash);
         CalculateAsset(consensus.pegged_asset, entropy);
 
-        genesis = CreateGenesisBlock(consensus, strNetworkID, defaultRegtestScript, 1296688602, 1, MAX_MONEY, 100, consensus.pegged_asset);
+        const std::vector<GenesisReward> genesisRewards = {
+            GenesisReward(MAX_MONEY, defaultRegtestScript, consensus.pegged_asset, 100),
+        };
+        genesis = CreateGenesisBlock(consensus, strNetworkID, 1296688602, 1, genesisRewards);
         consensus.hashGenesisBlock = genesis.GetHash();
 
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -68,6 +68,7 @@ struct Params {
     CScript fedpegScript;
     CAsset pegged_asset;
     uint256 defaultAssumeValid;
+    CScript signblockScript;
 };
 } // namespace Consensus
 

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -21,21 +21,20 @@
 #include "wallet/wallet.h"
 #endif
 
-CScript CombineBlockSignatures(const CBlockHeader& header, const CScript& scriptSig1, const CScript& scriptSig2)
+CScript CombineBlockSignatures(const Consensus::Params& params, const CBlockHeader& header, const CScript& scriptSig1, const CScript& scriptSig2)
 {
     SignatureData sig1(scriptSig1);
     SignatureData sig2(scriptSig2);
-    return GenericCombineSignatures(header.proof.challenge, header, sig1, sig2).scriptSig;
+    return GenericCombineSignatures(params.signblockScript, header, sig1, sig2).scriptSig;
 }
 
 bool CheckChallenge(const CBlockHeader& block, const CBlockIndex& indexLast, const Consensus::Params& params)
 {
-    return block.proof.challenge == indexLast.proof.challenge;
+    return true;
 }
 
 void ResetChallenge(CBlockHeader& block, const CBlockIndex& indexLast, const Consensus::Params& params)
 {
-    block.proof.challenge = indexLast.proof.challenge;
 }
 
 bool CheckBitcoinProof(uint256 hash, unsigned int nBits)
@@ -61,14 +60,14 @@ bool CheckProof(const CBlockHeader& block, const Consensus::Params& params)
 {
     if (block.GetHash() == params.hashGenesisBlock)
        return true;
-    return GenericVerifyScript(block.proof.solution, block.proof.challenge, SCRIPT_VERIFY_P2SH, block);
+    return GenericVerifyScript(block.proof.solution, params.signblockScript, SCRIPT_VERIFY_P2SH, block);
 }
 
-bool MaybeGenerateProof(CBlockHeader *pblock, CWallet *pwallet)
+bool MaybeGenerateProof(const Consensus::Params& params, CBlockHeader *pblock, CWallet *pwallet)
 {
 #ifdef ENABLE_WALLET
     SignatureData solution(pblock->proof.solution);
-    bool res = GenericSignScript(*pwallet, *pblock, pblock->proof.challenge, solution);
+    bool res = GenericSignScript(*pwallet, *pblock, params.signblockScript, solution);
     pblock->proof.solution = solution.scriptSig;
     return res;
 #endif
@@ -83,16 +82,6 @@ void ResetProof(CBlockHeader& block)
 double GetChallengeDifficulty(const CBlockIndex* blockindex)
 {
     return 1;
-}
-
-std::string GetChallengeStr(const CBlockIndex& block)
-{
-    return ScriptToAsmStr(block.proof.challenge);
-}
-
-std::string GetChallengeStrHex(const CBlockIndex& block)
-{
-    return ScriptToAsmStr(block.proof.challenge);
 }
 
 uint32_t GetNonce(const CBlockHeader& block)

--- a/src/pow.h
+++ b/src/pow.h
@@ -24,17 +24,15 @@ class uint256;
 bool CheckBitcoinProof(uint256 hash, unsigned int nBits);
 bool CheckProof(const CBlockHeader& block, const Consensus::Params&);
 /** Scans nonces looking for a hash with at least some zero bits */
-bool MaybeGenerateProof(CBlockHeader* pblock, CWallet* pwallet);
+bool MaybeGenerateProof(const Consensus::Params& params, CBlockHeader* pblock, CWallet* pwallet);
 void ResetProof(CBlockHeader& block);
 bool CheckChallenge(const CBlockHeader& block, const CBlockIndex& indexLast, const Consensus::Params&);
 void ResetChallenge(CBlockHeader& block, const CBlockIndex& indexLast, const Consensus::Params&);
 
-CScript CombineBlockSignatures(const CBlockHeader& header, const CScript& scriptSig1, const CScript& scriptSig2);
+CScript CombineBlockSignatures(const Consensus::Params& params, const CBlockHeader& header, const CScript& scriptSig1, const CScript& scriptSig2);
 
 /** Avoid using these functions when possible */
 double GetChallengeDifficulty(const CBlockIndex* blockindex);
-std::string GetChallengeStr(const CBlockIndex& block);
-std::string GetChallengeStrHex(const CBlockIndex& block);
 uint32_t GetNonce(const CBlockHeader& block);
 void SetNonce(CBlockHeader& block, uint32_t nNonce);
 

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -13,8 +13,8 @@
 
 std::string CProof::ToString() const
 {
-    return strprintf("CProof(challenge=%s, solution=%s)",
-                     ScriptToAsmStr(challenge), ScriptToAsmStr(solution));
+    return strprintf("CProof(solution=%s)",
+                     ScriptToAsmStr(solution));
 }
 
 uint256 CBlockHeader::GetHash() const

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -14,34 +14,31 @@
 class CProof
 {
 public:
-    CScript challenge;
     CScript solution;
 
     CProof()
     {
         SetNull();
     }
-    CProof(CScript challengeIn, CScript solutionIn) : challenge(challengeIn), solution(solutionIn) {}
+    CProof(CScript solutionIn) : solution(solutionIn) {}
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action)
     {
-        READWRITE(*(CScriptBase*)(&challenge));
         if (!(s.GetType() & SER_GETHASH))
             READWRITE(*(CScriptBase*)(&solution));
     }
 
     void SetNull()
     {
-        challenge.clear();
         solution.clear();
     }
 
     bool IsNull() const
     {
-        return challenge.empty();
+        return solution.empty();
     }
 
     std::string ToString() const;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -215,14 +215,15 @@ UniValue combineblocksigs(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Block decode failed");
 
     UniValue result(UniValue::VOBJ);
+    const Consensus::Params& consensusParams = Params().GetConsensus();
     const UniValue& sigs = request.params[1].get_array();
     for (unsigned int i = 0; i < sigs.size(); i++) {
         const std::string& sig = sigs[i].get_str();
         if (!IsHex(sig))
             continue;
         std::vector<unsigned char> vchScript = ParseHex(sig);
-        block.proof.solution = CombineBlockSignatures(block, block.proof.solution, CScript(vchScript.begin(), vchScript.end()));
-        if (CheckProof(block, Params().GetConsensus())) {
+        block.proof.solution = CombineBlockSignatures(consensusParams, block, block.proof.solution, CScript(vchScript.begin(), vchScript.end()));
+        if (CheckProof(block, consensusParams)) {
             result.push_back(Pair("hex", EncodeHexBlock(block)));
             result.push_back(Pair("complete", true));
             return result;
@@ -738,7 +739,6 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     result.push_back(Pair("coinbaseaux", aux));
     result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0]->vout[0].nValue.GetAmount()));
     result.push_back(Pair("longpollid", chainActive.Tip()->GetBlockHash().GetHex() + i64tostr(nTransactionsUpdatedLast)));
-    result.push_back(Pair("target", GetChallengeStrHex(*pblock)));
     result.push_back(Pair("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1));
     result.push_back(Pair("mutable", aMutable));
     result.push_back(Pair("noncerange", "00000000ffffffff"));
@@ -755,7 +755,6 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
         result.push_back(Pair("weightlimit", (int64_t)MAX_BLOCK_WEIGHT));
     }
     result.push_back(Pair("curtime", pblock->GetBlockTime()));
-    result.push_back(Pair("bits", GetChallengeStr(*pblock)));
     result.push_back(Pair("height", (int64_t)(pindexPrev->nHeight+1)));
 
     if (!pblocktemplate->vchCoinbaseCommitment.empty() && fSupportsSegwit) {

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -73,7 +73,7 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
         newCoinbase.vout[i].scriptPubKey = scriptPubKey;
     const_cast<CBlock&>(Params().GenesisBlock()).vtx[0] = MakeTransactionRef(newCoinbase);
     const_cast<CBlock&>(Params().GenesisBlock()).hashMerkleRoot = BlockMerkleRoot(Params().GenesisBlock());
-    const_cast<CBlock&>(Params().GenesisBlock()).proof = CProof(CScript()<<OP_TRUE, CScript());
+    const_cast<CBlock&>(Params().GenesisBlock()).proof = CProof(CScript());
     const_cast<Consensus::Params&>(Params().GetConsensus()).hashGenesisBlock = Params().GenesisBlock().GetHash();
 
         ClearDatadirCache();

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3369,7 +3369,7 @@ UniValue signblock(const JSONRPCRequest& request)
     }
 
     block.proof.solution = CScript();
-    MaybeGenerateProof(&block, pwalletMain);
+    MaybeGenerateProof(Params().GetConsensus(), &block, pwalletMain);
     return HexStr(block.proof.solution.begin(), block.proof.solution.end());
 }
 


### PR DESCRIPTION
Replaces #164 .
See documentation there.

Dependencies:

- [x] HF: Genesis block includes fedpegscript #187
- [x] Remove CChainParams::bitcoinID #188
- [ ] HF: Move block.proof.challenge to Consensus::Params::signblockScript #189
