### PR TITLE
change base58 prefix for script addresses

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -151,7 +151,7 @@ public:
             0
         };
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,235);
-        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,40);
+        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,75);
         base58Prefixes[BLINDED_ADDRESS]= std::vector<unsigned char>(1,4);
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,239);
         base58Prefixes[EXT_PUBLIC_KEY] = boost::assign::list_of(0x04)(0x35)(0x87)(0xCF).convert_to_container<std::vector<unsigned char> >();
@@ -255,7 +255,7 @@ public:
             0
         };
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,235);
-        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,40);
+        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,75);
         base58Prefixes[BLINDED_ADDRESS]= std::vector<unsigned char>(1,4);
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,239);
         base58Prefixes[EXT_PUBLIC_KEY] = boost::assign::list_of(0x04)(0x35)(0x87)(0xCF).convert_to_container<std::vector<unsigned char> >();


### PR DESCRIPTION
Eliminates collision with Liquid address type.

Resulting prefix makes addresses start with "X".