### PR TITLE
[WIP] sendtoaddress named arguments work with asset args

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -546,7 +546,7 @@ UniValue sendtoaddress(const JSONRPCRequest& request)
         wtx.mapValue["to"]      = request.params[3].get_str();
 
     bool fSubtractFeeFromAmount = false;
-    if (request.params.size() > 4)
+    if (request.params.size() > 4 && request.params[4].isBool())
         fSubtractFeeFromAmount = request.params[4].get_bool();
 
     std::string strasset = "bitcoin";
@@ -555,8 +555,9 @@ UniValue sendtoaddress(const JSONRPCRequest& request)
     }
 
     bool fIgnoreBlindFail = true;
-    if (request.params.size() > 6)
+    if (request.params.size() > 6 && request.params[6].isBool()) {
         fIgnoreBlindFail = request.params[6].get_bool();
+    }
 
     CAsset asset = GetAssetFromString(strasset);
 
@@ -4142,7 +4143,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "listunspent",              &listunspent,              false,  {"minconf","maxconf","addresses","include_unsafe"} },
     { "wallet",             "lockunspent",              &lockunspent,              true,   {"unlock","transactions"} },
     { "wallet",             "sendmany",                 &sendmany,                 false,  {"fromaccount","amounts","minconf","comment","subtractfeefrom"} },
-    { "wallet",             "sendtoaddress",            &sendtoaddress,            false,  {"address","amount","comment","comment_to","subtractfeefromamount"} },
+    { "wallet",             "sendtoaddress",            &sendtoaddress,            false,  {"address","amount","comment","comment_to","subtractfeefromamount", "assetlabel", "ignoreblindfail"} },
     { "wallet",             "setaccount",               &setaccount,               true,   {"address","account"} },
     { "wallet",             "reissueasset",             &reissueasset,             true,   {"asset", "assetamount"} },
     { "wallet",             "signblock",                &signblock,                true,   {} },


### PR DESCRIPTION
Upstream there are a number of calls that don't correctly check for null arguments, which means named args doesn't work for some calls quite yet. Leaving this as WIP to fix more of them such as `sendmany`, and upstream those fixes.