### PR TITLE
bad-txns-in-belowout -> bad-txns-in-ne-out

### DIFF
--- a/qa/rpc-tests/p2p-fullblocktest.py
+++ b/qa/rpc-tests/p2p-fullblocktest.py
@@ -819,7 +819,7 @@ class FullBlockTest(ComparisonTestFramework):
         b59 = block(59)
         tx = create_and_sign_tx(out[17].tx, out[17].n, 51*COIN)
         b59 = update_block(59, [tx])
-        yield rejected(RejectResult(16, b'bad-txns-in-belowout'))
+        yield rejected(RejectResult(16, b'bad-txns-in-ne-out'))
 
         # reset to good chain
         tip(57)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2045,8 +2045,8 @@ bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoins
         if (!tx.HasValidFee())
             return state.DoS(100, false, REJECT_INVALID, "bad-txns-fee-outofrange");
         if (!VerifyAmounts(inputs, tx, pvChecks, cacheStore))
-            return state.DoS(100, false, REJECT_INVALID, "bad-txns-in-belowout", false,
-                strprintf("value in (%s) < value out", FormatMoney(nValueIn)));
+            return state.DoS(100, false, REJECT_INVALID, "bad-txns-in-ne-out", false,
+                strprintf("value in (%s) != value out", FormatMoney(nValueIn)));
 
     return true;
 }


### PR DESCRIPTION
The error message indicates that the outputs exceed the inputs. In reality, at least for blinded transactions, the error will also appear if the in exceeds the out, i.e. this error appears for all transactions where inputs do not sum up to outputs.