### PR TITLE
Miner selects any feerate no matter how small

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -169,7 +169,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     // transaction (which in most cases can be a no-op).
     fIncludeWitness = IsWitnessEnabled(pindexPrev, chainparams.GetConsensus()) && fMineWitnessTx;
 
-    addPriorityTxs();
+    //addPriorityTxs(); addPackageTxs will take anything at any rate
     int nPackagesSelected = 0;
     int nDescendantsUpdated = 0;
     addPackageTxs(nPackagesSelected, nDescendantsUpdated);
@@ -483,11 +483,6 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
             packageSize = modit->nSizeWithAncestors;
             packageFees = modit->nModFeesWithAncestors;
             packageSigOpsCost = modit->nSigOpCostWithAncestors;
-        }
-
-        if (packageFees < blockMinFeeRate.GetFee(packageSize)) {
-            // Everything else we might consider has a lower fee rate
-            return;
         }
 
         if (!TestPackage(packageSize, packageSigOpsCost)) {


### PR DESCRIPTION
We have no centralization concerns, and mempool will still enforce minimums. This simply allows the miner to clear out the mempool as fast as possible based on feerate rather than wait for transactions to hit a minimum priority amount. 

