### PR TITLE
[trivial] remove unused variable "amount" in rawtransaction.cpp

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -190,7 +190,6 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
             out.push_back(Pair("assetcommitment", HexStr(asset.vchCommitment)));
         }
 
-        const CConfidentialValue& amount = txout.nValue;
         out.push_back(Pair("n", (int64_t)i));
         UniValue o(UniValue::VOBJ);
         ScriptPubKeyToJSON(txout.scriptPubKey, o, true);


### PR DESCRIPTION
[trivial] remove unused variable "amount" in rawtransaction.cppthe keyword "amount" was changed to "value" and is handled earlier if the output value is explicit. the "amount" variable was unused and currently is not necessary. 