### PR TITLE
fundrawtransaction needs to push back all outputs

### DIFF
--- a/qa/rpc-tests/confidential_transactions.py
+++ b/qa/rpc-tests/confidential_transactions.py
@@ -185,6 +185,9 @@ class CTTest (BitcoinTestFramework):
         blinded = self.nodes[0].blindrawtransaction(funded["hex"])
         # blind again to make sure we know output blinders
         blinded2 = self.nodes[0].blindrawtransaction(blinded)
+        # then sign and send
+        signed = self.nodes[0].signrawtransaction(blinded2)
+        self.nodes[0].sendrawtransaction(signed["hex"])
 
         # Check createblindedaddress functionality
         blinded_addr = self.nodes[0].getnewaddress()
@@ -399,7 +402,7 @@ class CTTest (BitcoinTestFramework):
         txid1 = self.nodes[0].sendtoaddress(blinded_addr, 1)
         txid2 = self.nodes[0].sendtoaddress(blinded_addr, 3)
         unspent = self.nodes[0].listunspent(0, 0)
-        assert_equal(len(unspent), 3)
+        assert_equal(len(unspent), 4)
         rawtx = self.nodes[0].createrawtransaction([{"txid":unspent[0]["txid"], "vout":unspent[0]["vout"]}, {"txid":unspent[1]["txid"], "vout":unspent[1]["vout"]}], {addr:unspent[0]["amount"]+unspent[1]["amount"]-Decimal("0.2"), "fee":Decimal("0.2")})
         # Blinding will fail with 2 blinded inputs and 0 blinded outputs
         # since it has no notion of a wallet to fill in a 0-value OP_RETURN output

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2657,7 +2657,7 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, bool ov
         const CTxOut& out = wtx.tx->vout[i];
         tx.vout.push_back(out);
         if (wtx.tx->wit.vtxoutwit.size() <= i) {
-            break;
+            continue;
         }
         // We want to re-add previously existing outwitnesses
         // even though we don't create any new ones


### PR DESCRIPTION
Another dumb fundraw bug due to no test.

Transaction ended up missing things outside of the witness vector, like explicit fees.