### PR TITLE
FundTransaction should avoid copying CReserveKeys

### DIFF
--- a/qa/rpc-tests/confidential_transactions.py
+++ b/qa/rpc-tests/confidential_transactions.py
@@ -450,5 +450,21 @@ class CTTest (BitcoinTestFramework):
             if "asset" in output and output["scriptPubKey"]["type"] != "fee":
                 raise AssertionError("An unblinded output exists")
 
+        # Test fundrawtransaction with multiple assets
+        issue = self.nodes[0].issueasset(1, 0)
+        assetaddr = self.nodes[0].getnewaddress()
+        rawtx = self.nodes[0].createrawtransaction([], {assetaddr:1, self.nodes[0].getnewaddress():2}, 0, {assetaddr:issue["asset"]})
+        funded = self.nodes[0].fundrawtransaction(rawtx)
+        blinded = self.nodes[0].blindrawtransaction(funded["hex"])
+        signed = self.nodes[0].signrawtransaction(blinded)
+        txid = self.nodes[0].sendrawtransaction(signed["hex"])
+
+        # Test fundrawtransaction with multiple inputs, creating > vout.size change
+        rawtx = self.nodes[0].createrawtransaction([{"txid":txid, "vout":0}, {"txid":txid, "vout":1}], {self.nodes[0].getnewaddress():5})
+        funded = self.nodes[0].fundrawtransaction(rawtx)
+        blinded = self.nodes[0].blindrawtransaction(funded["hex"])
+        signed = self.nodes[0].signrawtransaction(blinded)
+        txid = self.nodes[0].sendrawtransaction(signed["hex"])
+
 if __name__ == '__main__':
     CTTest ().main ()

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -555,11 +555,10 @@ UniValue createrawtransaction(const JSONRPCRequest& request)
         // Defaults to policyAsset
         CAsset asset(policyAsset);
         if (!assets.isNull()) {
-            if (find_value(assets, name_).isNull())
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, string("Given output_asset address is not a valid given output address: ")+name_);
-            asset = CAsset(ParseHashO(assets, name_));
+            if (!find_value(assets, name_).isNull()) {
+                asset = CAsset(ParseHashO(assets, name_));
+            }
         }
-
         if (name_ == "data") {
             std::vector<unsigned char> data = ParseHexV(sendTo[name_].getValStr(),"Data");
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2605,6 +2605,8 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, bool ov
 {
     vector<CRecipient> vecSend;
     std::vector<CReserveKey> vChangeKey;
+    // Avoid copying CReserveKeys which causes badness
+    vChangeKey.reserve((tx.vin.size()+tx.vout.size())*2);
     std::vector<CReserveKey*> vpChangeKey;
     std::set<CAsset> setAssets;
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2631,6 +2631,14 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, bool ov
             setAssets.insert(txOut.nAsset.GetAsset());
         }
     }
+
+    // Also add reserve keys for inputs, since those could create more change
+    // Any excess will never be reserved, so this should be safe.
+    for (unsigned int i = 0; i < tx.vin.size(); i++) {
+        vChangeKey.push_back(CReserveKey(this));
+        vpChangeKey.push_back(&vChangeKey[vChangeKey.size()-1]);
+    }
+
     // Always add policyAsset, as fees via policyAsset may create change
     if (setAssets.count(policyAsset) == 0) {
         vChangeKey.push_back(CReserveKey(this));

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2607,7 +2607,6 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, bool ov
     std::vector<CReserveKey> vChangeKey;
     // Avoid copying CReserveKeys which causes badness
     vChangeKey.reserve((tx.vin.size()+tx.vout.size())*2);
-    std::vector<CReserveKey*> vpChangeKey;
     std::set<CAsset> setAssets;
 
     // Turn the txout set into a CRecipient vector
@@ -2627,7 +2626,6 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, bool ov
 
         if (setAssets.count(txOut.nAsset.GetAsset()) == 0) {
             vChangeKey.push_back(CReserveKey(this));
-            vpChangeKey.push_back(&vChangeKey[vChangeKey.size()-1]);
             setAssets.insert(txOut.nAsset.GetAsset());
         }
     }
@@ -2636,13 +2634,11 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, bool ov
     // Any excess will never be reserved, so this should be safe.
     for (unsigned int i = 0; i < tx.vin.size(); i++) {
         vChangeKey.push_back(CReserveKey(this));
-        vpChangeKey.push_back(&vChangeKey[vChangeKey.size()-1]);
     }
 
     // Always add policyAsset, as fees via policyAsset may create change
     if (setAssets.count(policyAsset) == 0) {
         vChangeKey.push_back(CReserveKey(this));
-        vpChangeKey.push_back(&vChangeKey[vChangeKey.size()-1]);
     }
 
     CCoinControl coinControl;
@@ -2656,7 +2652,7 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, bool ov
         coinControl.Select(txin.prevout);
 
     CWalletTx wtx;
-    if (!CreateTransaction(vecSend, wtx, vpChangeKey, nFeeRet, nChangePosInOut, strFailReason, &coinControl, false))
+    if (!CreateTransaction(vecSend, wtx, vChangeKey, nFeeRet, nChangePosInOut, strFailReason, &coinControl, false))
         return false;
 
     // Wipe outputs and output witness and re-add one by one
@@ -2691,14 +2687,14 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, bool ov
 
     // optionally keep the change output key
     if (keepReserveKey) {
-        for (auto& changekey : vpChangeKey) {
-            changekey->KeepKey();
+        for (auto& changekey : vChangeKey) {
+            changekey.KeepKey();
         }
     }
     return true;
 }
 
-bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wtxNew, std::vector<CReserveKey*>& vpChangeKey, CAmount& nFeeRet,
+bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wtxNew, std::vector<CReserveKey>& vChangeKey, CAmount& nFeeRet,
                                 int& nChangePosInOut, std::string& strFailReason, const CCoinControl* coinControl, bool sign, std::vector<CAmount> *outAmounts, bool fBlindIssuances, const uint256* issuanceEntropy, const CAsset* reissuanceAsset, const CAsset* reissuanceToken, bool fIgnoreBlindFail)
 {
     // TODO re-enable to support multiple assets in a logical fashion, since the number of possible
@@ -2910,7 +2906,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                             // Reserve a new key pair from key pool
                             CPubKey vchPubKey;
                             bool ret;
-                            ret = vpChangeKey[changeCounter]->GetReservedKey(vchPubKey);
+                            ret = vChangeKey[changeCounter].GetReservedKey(vchPubKey);
                             if (!ret)
                             {
                                 strFailReason = _("Keypool ran out, please call keypoolrefill first");
@@ -2950,7 +2946,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                         {
                             nChangePosInOut = -1;
                             nFeeRet += it->second;
-                            vpChangeKey[changeCounter]->ReturnKey();
+                            vChangeKey[changeCounter].ReturnKey();
                         }
                         else
                         {
@@ -2979,8 +2975,9 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                             nChangePosInOut = -1;
                         }
                     }
-                    else
-                        vpChangeKey[changeCounter]->ReturnKey();
+                    else {
+                        vChangeKey[changeCounter].ReturnKey();
+                    }
                     changeCounter++;
                 }
 
@@ -3347,7 +3344,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
 /**
  * Call after CreateTransaction unless you want to abort
  */
-bool CWallet::CommitTransaction(CWalletTx& wtxNew, std::vector<CReserveKey*>& reservekey, CConnman* connman, CValidationState& state)
+bool CWallet::CommitTransaction(CWalletTx& wtxNew, std::vector<CReserveKey>& reservekey, CConnman* connman, CValidationState& state)
 {
     {
         LOCK2(cs_main, cs_wallet);
@@ -3355,7 +3352,7 @@ bool CWallet::CommitTransaction(CWalletTx& wtxNew, std::vector<CReserveKey*>& re
         {
             // Take key pair from key pool so it won't be used again
             for (auto&& key : reservekey)
-                key->KeepKey();
+                key.KeepKey();
 
             // Add tx to wallet, because if it has change it's also ours,
             // otherwise just for transaction history.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2388,7 +2388,6 @@ bool CWallet::SelectCoinsMinConf(const CAmountMap& mapTargetValue, const int nCo
 {
     setCoinsRet.clear();
     mapValueRet = CAmountMap();
-    assert(mapTargetValue >= CAmountMap());
     CAmountMap mapTotalLower;
     std::map<CAsset, std::vector<SelectCoin> > mapVValue;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -874,9 +874,9 @@ public:
      * selected by SelectCoins(); Also create the change output, when needed
      * @note passing nChangePosInOut as -1 will result in setting a random position
      */
-    bool CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletTx& wtxNew, std::vector<CReserveKey*>& vpChangeKey, CAmount& nFeeRet, int& nChangePosInOut,
+    bool CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletTx& wtxNew, std::vector<CReserveKey>& vChangeKey, CAmount& nFeeRet, int& nChangePosInOut,
                            std::string& strFailReason, const CCoinControl *coinControl = NULL, bool sign = true, std::vector<CAmount> *outAmounts = NULL, bool fBlindIssuances = true, const uint256* issuanceEntropy = NULL, const CAsset* reissuanceAsset = NULL, const CAsset* reissuanceToken = NULL, bool fIgnoreBlindFail = true);
-    bool CommitTransaction(CWalletTx& wtxNew, std::vector<CReserveKey*>& reservekey, CConnman* connman, CValidationState& state);
+    bool CommitTransaction(CWalletTx& wtxNew, std::vector<CReserveKey>& reservekey, CConnman* connman, CValidationState& state);
 
     void ListAccountCreditDebit(const std::string& strAccount, std::list<CAccountingEntry>& entries);
     bool AddAccountingEntry(const CAccountingEntry&);


### PR DESCRIPTION
This was causing segfault when funding multiple assets: https://github.com/ElementsProject/elements/issues/223

(upstream they are simply no longer copyable which should avoid things like this in future)