### PR TITLE
Fix claimpegins from mempool locks

### DIFF
--- a/qa/rpc-tests/pegging.py
+++ b/qa/rpc-tests/pegging.py
@@ -114,13 +114,17 @@ try:
 
     # Lockup some funds to unlock later
     sidechain.sendtomainchain(addr, 50)
-    sidechain.generate(101)
+    # Tests withdrawlock tracking in database
+    sidechain.generate(1)
+    # Tests withdrawlock in mempool
+    sidechain.sendtomainchain(addr, 50)
 
     addrs = sidechain.getpeginaddress()
-    txid = bitcoin.sendtoaddress(addrs["mainchain_address"], 49)
+    txid1 = bitcoin.sendtoaddress(addrs["mainchain_address"], 24)
+    txid2 = bitcoin.sendtoaddress(addrs["mainchain_address"], 24)
     bitcoin.generate(10)
-    proof = bitcoin.gettxoutproof([txid])
-    raw = bitcoin.getrawtransaction(txid)
+    proof = bitcoin.gettxoutproof([txid1])
+    raw = bitcoin.getrawtransaction(txid1)
 
     print("Attempting peg-in")
 
@@ -132,8 +136,13 @@ try:
         pass
 
     timeout = 20
-    # Should succeed via wallet lookup for address match
-    pegtxid = sidechain.claimpegin(raw, proof)
+    # Both should succeed via wallet lookup for address match, and when given
+    pegtxid1 = sidechain.claimpegin(raw, proof)
+
+    proof = bitcoin.gettxoutproof([txid2])
+    raw = bitcoin.getrawtransaction(txid2)
+    pegtxid2 = sidechain.claimpegin(raw, proof, addrs["sidechain_address"])
+
     while len(sidechain.getrawmempool()) != len(sidechain2.getrawmempool()):
         time.sleep(1)
         timeout -= 1
@@ -147,9 +156,10 @@ try:
             raise Exception("Blocks are not propagating.")
 
 
-    tx = sidechain.gettransaction(pegtxid)
+    tx1 = sidechain.gettransaction(pegtxid1)
+    tx2 = sidechain.gettransaction(pegtxid2)
 
-    if "confirmations" in tx and tx["confirmations"] > 0:
+    if "confirmations" in tx1 and tx1["confirmations"] > 0 and "confirmations" in tx2 and tx2["confirmations"] > 0:
         print("Peg-in is confirmed: Success!")
     else:
         raise Exception("Peg-in confirmation has failed.")


### PR DESCRIPTION
This PR also includes a change which changes free relay to only work for withdrawlock spends, since those cannot include a fee, and removes the rate limiting. Pegging transactions are already rate-limited by Bitcoin fees on the mainchain, and miners will select higher-fee transactions, so DoS is unlikely.