### PR TITLE
Replace static BITCOINID with asset-derivation style generation

### DIFF
--- a/contrib/assets_tutorial/assets_tutorial.py
+++ b/contrib/assets_tutorial/assets_tutorial.py
@@ -211,7 +211,7 @@ e1.dumpassetlabels()
 # You can also filter calls using specific asset hex or labels:
 e1.getwalletinfo("bitcoin")
 # bitcoin's hex asset type
-e1.getwalletinfo("694d95345fcd292329b5fb4e465a48484c7e218f4d4f1f7a3bfea26dd2d8fc3d")
+e1.getwalletinfo("b2e15d0d7a0c94e4e2ce0fe6e8691b9e451377f6e46e8045a86f7c4b5d4f0f23")
 
 # We can also issue our own assets, 1 asset and 1 reissuance token in this case
 issue = e1.issueasset(1, 1)

--- a/contrib/assets_tutorial/assets_tutorial.py
+++ b/contrib/assets_tutorial/assets_tutorial.py
@@ -211,7 +211,7 @@ e1.dumpassetlabels()
 # You can also filter calls using specific asset hex or labels:
 e1.getwalletinfo("bitcoin")
 # bitcoin's hex asset type
-e1.getwalletinfo("09f663de96be771f50cab5ded00256ffe63773e2eaa9a604092951cc3d7c6621")
+e1.getwalletinfo("694d95345fcd292329b5fb4e465a48484c7e218f4d4f1f7a3bfea26dd2d8fc3d")
 
 # We can also issue our own assets, 1 asset and 1 reissuance token in this case
 issue = e1.issueasset(1, 1)

--- a/contrib/assets_tutorial/assets_tutorial.sh
+++ b/contrib/assets_tutorial/assets_tutorial.sh
@@ -144,7 +144,7 @@ e1-cli dumpassetlabels
 # You can also filter calls using specific asset hex or labels:
 e1-cli getwalletinfo bitcoin
 # bitcoin's hex asset type
-e1-cli getwalletinfo 09f663de96be771f50cab5ded00256ffe63773e2eaa9a604092951cc3d7c6621
+e1-cli getwalletinfo 694d95345fcd292329b5fb4e465a48484c7e218f4d4f1f7a3bfea26dd2d8fc3d
 
 # We can also issue our own assets, 1 asset and 1 reissuance token in this case
 ISSUE=$(e1-cli issueasset 1 1)

--- a/contrib/assets_tutorial/assets_tutorial.sh
+++ b/contrib/assets_tutorial/assets_tutorial.sh
@@ -144,7 +144,7 @@ e1-cli dumpassetlabels
 # You can also filter calls using specific asset hex or labels:
 e1-cli getwalletinfo bitcoin
 # bitcoin's hex asset type
-e1-cli getwalletinfo 694d95345fcd292329b5fb4e465a48484c7e218f4d4f1f7a3bfea26dd2d8fc3d
+e1-cli getwalletinfo b2e15d0d7a0c94e4e2ce0fe6e8691b9e451377f6e46e8045a86f7c4b5d4f0f23
 
 # We can also issue our own assets, 1 asset and 1 reissuance token in this case
 ISSUE=$(e1-cli issueasset 1 1)

--- a/src/amount.h
+++ b/src/amount.h
@@ -69,9 +69,6 @@ struct CAsset {
     }
 };
 
-/** The sha256 of Bitcoin genesis block, for easy reference **/
-static const CAsset BITCOINID(uint256S("09f663de96be771f50cab5ded00256ffe63773e2eaa9a604092951cc3d7c6621"));
-
 /** Used for consensus fee and general wallet accounting*/
 typedef std::map<CAsset, CAmount> CAmountMap;
 

--- a/src/assetsdir.cpp
+++ b/src/assetsdir.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "assetsdir.h"
+#include "chainparams.h"
 
 #include "tinyformat.h"
 #include "utilstrencodings.h"
@@ -47,7 +48,7 @@ void CAssetsDir::InitFromStrings(const std::vector<std::string>& assetsToInit)
         SetHex(vAssets[0], vAssets[1]);
     }
     // Set "bitcoin" to the pegged asset for tests
-    Set(BITCOINID, AssetMetadata("bitcoin"));
+    Set(Params().GetConsensus().pegged_asset, AssetMetadata("bitcoin"));
 }
 
 CAsset CAssetsDir::GetAsset(const std::string& label) const

--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "bench.h"
+#include "chainparams.h"
 #include "wallet/wallet.h"
 
 #include <boost/foreach.hpp>
@@ -51,10 +52,10 @@ static void CoinSelection(benchmark::State& state)
         std::set<std::pair<const CWalletTx*, unsigned int> > setCoinsRet;
         CAmountMap nValueRet;
         CAmountMap mapValue;
-        mapValue[BITCOINID] = 1003 * COIN;
+        mapValue[Params().GetConsensus().pegged_asset] = 1003 * COIN;
         bool success = wallet.SelectCoinsMinConf(mapValue, 1, 6, 0, vCoins, setCoinsRet, nValueRet);
         assert(success);
-        assert(nValueRet[BITCOINID] == 1003 * COIN);
+        assert(nValueRet[Params().GetConsensus().pegged_asset] == 1003 * COIN);
         assert(setCoinsRet.size() == 2);
     }
 }

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -321,7 +321,7 @@ static void MutateTxAddOutPubKey(CMutableTransaction& tx, const std::string& str
     }
 
     // construct TxOut, append to transaction output list
-    CTxOut txout(BITCOINID, value, scriptPubKey);
+    CTxOut txout(Params().GetConsensus().pegged_asset, value, scriptPubKey);
     tx.vout.push_back(txout);
 }
 
@@ -388,7 +388,7 @@ static void MutateTxAddOutMultiSig(CMutableTransaction& tx, const std::string& s
     }
 
     // construct TxOut, append to transaction output list
-    CTxOut txout(BITCOINID, value, scriptPubKey);
+    CTxOut txout(Params().GetConsensus().pegged_asset, value, scriptPubKey);
     tx.vout.push_back(txout);
 }
 
@@ -415,7 +415,7 @@ static void MutateTxAddOutData(CMutableTransaction& tx, const std::string& strIn
 
     std::vector<unsigned char> data = ParseHex(strData);
 
-    CTxOut txout(BITCOINID, value, CScript() << OP_RETURN << data);
+    CTxOut txout(Params().GetConsensus().pegged_asset, value, CScript() << OP_RETURN << data);
     tx.vout.push_back(txout);
 }
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -96,6 +96,9 @@ public:
         consensus.BIP65Height = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
         consensus.BIP66Height = 363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+
+        consensus.pegged_asset = BITCOINID;
+
         // Peg-ins Bitcoin headers must have higher difficulty target than this field
         // This value must be sufficiently small to not preclude realistic parent
         // chain difficulty during network lifespan yet sufficiently large to
@@ -242,6 +245,8 @@ public:
         pchMessageStart[3] = 0xda;
         nDefaultPort = 7042;
         nPruneAfterHeight = 1000;
+
+        consensus.pegged_asset = BITCOINID;
 
         genesis = CreateGenesisBlock(consensus, strNetworkID, defaultRegtestScript, 1296688602, genesisChallengeScript, 1, MAX_MONEY, 100, BITCOINID);
         consensus.hashGenesisBlock = genesis.GetHash();

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -18,6 +18,9 @@
 
 #include "chainparamsseeds.h"
 
+/** The sha256 of Bitcoin genesis block, for easy reference **/ 
+static const CAsset BITCOINID(uint256S("09f663de96be771f50cab5ded00256ffe63773e2eaa9a604092951cc3d7c6621"));
+
 // Safer for users if they load incorrect parameters via arguments.
 static std::vector<unsigned char> CommitToArguments(const Consensus::Params& params, const std::string& networkID, const CScript& signblockscript)
 {

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -8,6 +8,7 @@
 
 #include "script/script.h"
 #include "uint256.h"
+#include "amount.h"
 #include <map>
 #include <string>
 
@@ -65,6 +66,7 @@ struct Params {
     int64_t DifficultyAdjustmentInterval() const { return nPowTargetTimespan / nPowTargetSpacing; }
     uint256 nMinimumChainWork;
     CScript fedpegScript;
+    CAsset pegged_asset;
     uint256 defaultAssumeValid;
 };
 } // namespace Consensus

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -460,7 +460,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-maxsigcachesize=<n>", strprintf("Limit size of signature cache to <n> MiB (default: %u)", DEFAULT_MAX_SIG_CACHE_SIZE));
         strUsage += HelpMessageOpt("-maxtipage=<n>", strprintf("Maximum tip age in seconds to consider node in initial block download (default: %u)", DEFAULT_MAX_TIP_AGE));
     }
-    strUsage += HelpMessageOpt("-feeasset=<hex>", strprintf(_("Asset ID (hex) for mempool/relay fees (default: %s)"), DEFAULT_FEE_ASSET));
+    strUsage += HelpMessageOpt("-feeasset=<hex>", strprintf(_("Asset ID (hex) for mempool/relay fees (default: %s)"), defaultChainParams->GetConsensus().pegged_asset.GetHex()));
     strUsage += HelpMessageOpt("-minrelaytxfee=<amt>", strprintf(_("Fees (in %s/kB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)"),
         CURRENCY_UNIT, FormatMoney(DEFAULT_MIN_RELAY_TX_FEE)));
     strUsage += HelpMessageOpt("-maxtxfee=<amt>", strprintf(_("Maximum total fees (in %s) to use in a single wallet transaction or raw transaction; setting this too low may abort large transactions (default: %s)"),
@@ -1011,7 +1011,7 @@ bool AppInitParameterInteraction()
     if (nConnectTimeout <= 0)
         nConnectTimeout = DEFAULT_CONNECT_TIMEOUT;
 
-    policyAsset = CAsset(uint256S(GetArg("-feeasset", DEFAULT_FEE_ASSET)));
+    policyAsset = CAsset(uint256S(GetArg("-feeasset", chainparams.GetConsensus().pegged_asset.GetHex())));
     
     // Fee-per-kilobyte amount considered the same as "free"
     // If you are mining, be careful setting this:

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -17,7 +17,6 @@ class CCoinsViewCache;
 /** The sha256 of Bitcoin genesis block, for easy reference **/
 extern CAsset policyAsset;
 
-static const std::string DEFAULT_FEE_ASSET = "09f663de96be771f50cab5ded00256ffe63773e2eaa9a604092951cc3d7c6621";
 /** Default for -blockmaxsize, which controls the maximum size of block the mining code will create **/
 static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 1000000;
 /** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -431,7 +431,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
 
         if (amount > 0)
         {
-            CTxOut txout(BITCOINID, amount, (CScript)std::vector<unsigned char>(24, 0));
+            CTxOut txout(Params().GetConsensus().pegged_asset, amount, (CScript)std::vector<unsigned char>(24, 0));
             txDummy.vout.push_back(txout);
             if (txout.IsDust(dustRelayFee))
                fDust = true;
@@ -545,7 +545,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
             // Never create dust outputs; if we would, just add the dust to the fee.
             if (nChange > 0 && nChange < MIN_CHANGE)
             {
-                CTxOut txout(BITCOINID, nChange, (CScript)std::vector<unsigned char>(24, 0));
+                CTxOut txout(Params().GetConsensus().pegged_asset, nChange, (CScript)std::vector<unsigned char>(24, 0));
                 if (txout.IsDust(dustRelayFee))
                 {
                     if (CoinControlDialog::fSubtractFeeFromAmount) // dust-change will be raised until no dust

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -569,7 +569,7 @@ bool PaymentServer::processPaymentRequest(const PaymentRequestPlus& request, Sen
         }
 
         // Extract and check amounts
-        CTxOut txOut(BITCOINID, sendingTo.second, sendingTo.first);
+        CTxOut txOut(Params().GetConsensus().pegged_asset, sendingTo.second, sendingTo.first);
         if (txOut.IsDust(dustRelayFee)) {
             Q_EMIT message(tr("Payment request error"), tr("Requested payment amount of %1 is too small (considered dust).")
                 .arg(BitcoinUnits::formatWithUnit(optionsModel->getDisplayUnit(), sendingTo.second)),

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -56,8 +56,8 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
     strHTML += "<html><font face='verdana, arial, helvetica, sans-serif'>";
 
     int64_t nTime = wtx.GetTxTime();
-    CAmount nCredit = wtx.GetCredit(ISMINE_ALL)[BITCOINID];
-    CAmount nDebit = wtx.GetDebit(ISMINE_ALL)[BITCOINID];
+    CAmount nCredit = wtx.GetCredit(ISMINE_ALL)[Params().GetConsensus().pegged_asset];
+    CAmount nDebit = wtx.GetDebit(ISMINE_ALL)[Params().GetConsensus().pegged_asset];
     CAmount nNet = nCredit - nDebit;
 
     strHTML += "<b>" + tr("Status") + ":</b> " + FormatTxStatus(wtx);
@@ -132,7 +132,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
         //
         // Coinbase
         //
-        CAmount nUnmatured = wallet->GetCredit(wtx, ISMINE_ALL)[BITCOINID];
+        CAmount nUnmatured = wallet->GetCredit(wtx, ISMINE_ALL)[Params().GetConsensus().pegged_asset];
         strHTML += "<b>" + tr("Credit") + ":</b> ";
         if (wtx.IsInMainChain())
             strHTML += BitcoinUnits::formatHtmlWithUnit(unit, nUnmatured)+ " (" + tr("matures in %n more block(s)", "", wtx.GetBlocksToMaturity()) + ")";
@@ -205,13 +205,13 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
             if (fAllToMe)
             {
                 // Payment to self
-                CAmount nChange = wtx.GetChange()[BITCOINID];
+                CAmount nChange = wtx.GetChange()[Params().GetConsensus().pegged_asset];
                 CAmount nValue = nCredit - nChange;
                 strHTML += "<b>" + tr("Total debit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -nValue) + "<br>";
                 strHTML += "<b>" + tr("Total credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, nValue) + "<br>";
             }
 
-            CAmount nTxFee = wtx.tx->GetFee()[BITCOINID];
+            CAmount nTxFee = wtx.tx->GetFee()[Params().GetConsensus().pegged_asset];
             if (nTxFee > 0)
                 strHTML += "<b>" + tr("Transaction fee") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -nTxFee) + "<br>";
         }
@@ -222,7 +222,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
             //
             BOOST_FOREACH(const CTxIn& txin, wtx.tx->vin)
                 if (wallet->IsMine(txin))
-                    strHTML += "<b>" + tr("Debit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -wallet->GetDebit(txin, ISMINE_ALL)[BITCOINID]) + "<br>";
+                    strHTML += "<b>" + tr("Debit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -wallet->GetDebit(txin, ISMINE_ALL)[Params().GetConsensus().pegged_asset]) + "<br>";
             for (unsigned int i = 0; i < wtx.tx->vout.size(); i++)
                 if (wallet->IsMine(wtx.tx->vout[i]) & ISMINE_ALL)
                     strHTML += "<b>" + tr("Credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, wtx.GetOutputValueOut(i)) + "<br>";
@@ -277,10 +277,10 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
         strHTML += "<hr><br>" + tr("Debug information") + "<br><br>";
         BOOST_FOREACH(const CTxIn& txin, wtx.tx->vin)
             if(wallet->IsMine(txin))
-                strHTML += "<b>" + tr("Debit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -wallet->GetDebit(txin, ISMINE_ALL)[BITCOINID]) + "<br>";
+                strHTML += "<b>" + tr("Debit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -wallet->GetDebit(txin, ISMINE_ALL)[Params().GetConsensus().pegged_asset]) + "<br>";
         for (unsigned int i = 0; i < wtx.tx->vout.size(); i++)
             if(wallet->IsMine(wtx.tx->vout[i]) & ISMINE_ALL)
-                strHTML += "<b>" + tr("Credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, wtx.GetCredit(i)[BITCOINID]) + "<br>";
+                strHTML += "<b>" + tr("Credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, wtx.GetCredit(i)[Params().GetConsensus().pegged_asset]) + "<br>";
 
         strHTML += "<br><b>" + tr("Transaction") + ":</b><br>";
         strHTML += GUIUtil::HtmlEscape(wtx.tx->ToString(), true);

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -36,8 +36,8 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
 {
     QList<TransactionRecord> parts;
     int64_t nTime = wtx.GetTxTime();
-    CAmount nCredit = wtx.GetCredit(ISMINE_ALL)[BITCOINID];
-    CAmount nDebit = wtx.GetDebit(ISMINE_ALL)[BITCOINID];
+    CAmount nCredit = wtx.GetCredit(ISMINE_ALL)[Params().GetConsensus().pegged_asset];
+    CAmount nDebit = wtx.GetDebit(ISMINE_ALL)[Params().GetConsensus().pegged_asset];
     CAmount nNet = nCredit - nDebit;
     uint256 hash = wtx.GetHash();
     std::map<std::string, std::string> mapValue = wtx.mapValue;
@@ -102,7 +102,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
         if (fAllFromMe && fAllToMe)
         {
             // Payment to self
-            CAmount nChange = wtx.GetChange()[BITCOINID];
+            CAmount nChange = wtx.GetChange()[Params().GetConsensus().pegged_asset];
 
             parts.append(TransactionRecord(hash, nTime, TransactionRecord::SendToSelf, "",
                             -(nDebit - nChange), nCredit - nChange));
@@ -113,7 +113,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
             //
             // Debit
             //
-            CAmount nTxFee = wtx.tx->GetFee()[BITCOINID];
+            CAmount nTxFee = wtx.tx->GetFee()[Params().GetConsensus().pegged_asset];
 
             for (unsigned int nOut = 0; nOut < wtx.tx->vout.size(); nOut++)
             {

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -72,17 +72,17 @@ CAmount WalletModel::getBalance(const CCoinControl *coinControl) const
         return nBalance;
     }
 
-    return wallet->GetBalance()[BITCOINID];
+    return wallet->GetBalance()[Params().GetConsensus().pegged_asset];
 }
 
 CAmount WalletModel::getUnconfirmedBalance() const
 {
-    return wallet->GetUnconfirmedBalance()[BITCOINID];
+    return wallet->GetUnconfirmedBalance()[Params().GetConsensus().pegged_asset];
 }
 
 CAmount WalletModel::getImmatureBalance() const
 {
-    return wallet->GetImmatureBalance()[BITCOINID];
+    return wallet->GetImmatureBalance()[Params().GetConsensus().pegged_asset];
 }
 
 bool WalletModel::haveWatchOnly() const
@@ -92,17 +92,17 @@ bool WalletModel::haveWatchOnly() const
 
 CAmount WalletModel::getWatchBalance() const
 {
-    return wallet->GetWatchOnlyBalance()[BITCOINID];
+    return wallet->GetWatchOnlyBalance()[Params().GetConsensus().pegged_asset];
 }
 
 CAmount WalletModel::getWatchUnconfirmedBalance() const
 {
-    return wallet->GetUnconfirmedWatchOnlyBalance()[BITCOINID];
+    return wallet->GetUnconfirmedWatchOnlyBalance()[Params().GetConsensus().pegged_asset];
 }
 
 CAmount WalletModel::getWatchImmatureBalance() const
 {
-    return wallet->GetImmatureWatchOnlyBalance()[BITCOINID];
+    return wallet->GetImmatureWatchOnlyBalance()[Params().GetConsensus().pegged_asset];
 }
 
 void WalletModel::updateStatus()
@@ -225,7 +225,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
                 const unsigned char* scriptStr = (const unsigned char*)out.script().data();
                 CScript scriptPubKey(scriptStr, scriptStr+out.script().size());
                 CAmount nAmount = out.amount();
-                CRecipient recipient = {scriptPubKey, nAmount, BITCOINID, CPubKey(), rcp.fSubtractFeeFromAmount};
+                CRecipient recipient = {scriptPubKey, nAmount, Params().GetConsensus().pegged_asset, CPubKey(), rcp.fSubtractFeeFromAmount};
                 vecSend.push_back(recipient);
             }
             if (subtotal <= 0)
@@ -253,7 +253,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
             if (addr.IsBlinded()) {
                 confidentiality_pubkey = addr.GetBlindingKey();
             }
-            CRecipient recipient = {scriptPubKey, rcp.amount, BITCOINID, confidentiality_pubkey, rcp.fSubtractFeeFromAmount};
+            CRecipient recipient = {scriptPubKey, rcp.amount, Params().GetConsensus().pegged_asset, confidentiality_pubkey, rcp.fSubtractFeeFromAmount};
             vecSend.push_back(recipient);
 
             total += rcp.amount;

--- a/src/test/assetsdir_tests.cpp
+++ b/src/test/assetsdir_tests.cpp
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(assetsdirTests)
 {
     CAssetsDir tAssetsDir;
     const std::string defaultPeggedLabel = "bitcoin";
-    const std::string defaultPeggedAssetHex = "09f663de96be771f50cab5ded00256ffe63773e2eaa9a604092951cc3d7c6621";
+    const std::string defaultPeggedAssetHex = Params().GetConsensus().pegged_asset.GetHex();
     const CAsset defaultPeggedAsset = Params().GetConsensus().pegged_asset;
     const std::string exampleAssetHex = "fa821b0be5e1387adbcb69dbb3ad33edb5e470831c7c938c4e7b344edbe8bb11";
     const CAsset exampleAsset = CAsset(uint256S(exampleAssetHex));

--- a/src/test/assetsdir_tests.cpp
+++ b/src/test/assetsdir_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "assetsdir.h"
+#include "chainparams.h"
 
 #include "test/test_bitcoin.h"
 
@@ -15,7 +16,7 @@ BOOST_AUTO_TEST_CASE(assetsdirTests)
     CAssetsDir tAssetsDir;
     const std::string defaultPeggedLabel = "bitcoin";
     const std::string defaultPeggedAssetHex = "09f663de96be771f50cab5ded00256ffe63773e2eaa9a604092951cc3d7c6621";
-    const CAsset defaultPeggedAsset = BITCOINID;
+    const CAsset defaultPeggedAsset = Params().GetConsensus().pegged_asset;
     const std::string exampleAssetHex = "fa821b0be5e1387adbcb69dbb3ad33edb5e470831c7c938c4e7b344edbe8bb11";
     const CAsset exampleAsset = CAsset(uint256S(exampleAssetHex));
     const std::vector<std::string> protectedLabels = {"*", defaultPeggedLabel, "bitcoin", "Bitcoin", "btc"};

--- a/src/test/lockedutxo_tests.cpp
+++ b/src/test/lockedutxo_tests.cpp
@@ -32,13 +32,13 @@ BOOST_AUTO_TEST_CASE(Getlocked_validity)
     uint256 gen0 = uint256S("0");
 
     CMutableTransaction mtx0;
-    mtx0.vout.push_back(CTxOut(CConfidentialAsset(BITCOINID), CConfidentialValue(1000), CScript() << OP_TRUE));
+    mtx0.vout.push_back(CTxOut(CConfidentialAsset(Params().GetConsensus().pegged_asset), CConfidentialValue(1000), CScript() << OP_TRUE));
     CMutableTransaction mtx1;
-    mtx1.vout.push_back(CTxOut(CConfidentialAsset(BITCOINID), CConfidentialValue(100), CScript() << OP_TRUE));
+    mtx1.vout.push_back(CTxOut(CConfidentialAsset(Params().GetConsensus().pegged_asset), CConfidentialValue(100), CScript() << OP_TRUE));
     CMutableTransaction mtx2;
-    mtx2.vout.push_back(CTxOut(CConfidentialAsset(BITCOINID), CConfidentialValue(10), CScript() << OP_TRUE));
+    mtx2.vout.push_back(CTxOut(CConfidentialAsset(Params().GetConsensus().pegged_asset), CConfidentialValue(10), CScript() << OP_TRUE));
     CMutableTransaction mtx3;
-    mtx3.vout.push_back(CTxOut(CConfidentialAsset(BITCOINID), CConfidentialValue(1), CScript() << OP_TRUE));
+    mtx3.vout.push_back(CTxOut(CConfidentialAsset(Params().GetConsensus().pegged_asset), CConfidentialValue(1), CScript() << OP_TRUE));
 
     //Push vout of size 1 for each CCoin
     pcoinsTip->ModifyCoins(uint256S("0"))->FromTx(CTransaction(mtx0), 0);

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "chainparams.h"
 #include "consensus/validation.h"
 #include "data/sighash.json.h"
 #include "hash.h"
@@ -114,7 +115,7 @@ void static RandomTransaction(CMutableTransaction &tx, bool fSingle) {
         tx.vout.push_back(CTxOut());
         CTxOut &txout = tx.vout.back();
         txout.nValue = insecure_rand() % 100000000;
-        txout.nAsset = BITCOINID;
+        txout.nAsset = Params().GetConsensus().pegged_asset;
         RandomScript(txout.scriptPubKey);
     }
 }

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -7,6 +7,7 @@
 #include "test/test_bitcoin.h"
 
 #include "clientversion.h"
+#include "chainparams.h"
 #include "checkqueue.h"
 #include "consensus/validation.h"
 #include "core_io.h"
@@ -305,19 +306,19 @@ SetupDummyInputs(CBasicKeyStore& keystoreRet, CCoinsViewCache& coinsRet)
     dummyTransactions[0].vout.resize(2);
     dummyTransactions[0].vout[0].nValue = 11*CENT;
     dummyTransactions[0].vout[0].scriptPubKey << ToByteVector(key[0].GetPubKey()) << OP_CHECKSIG;
-    dummyTransactions[0].vout[0].nAsset = BITCOINID;
+    dummyTransactions[0].vout[0].nAsset = Params().GetConsensus().pegged_asset;
     dummyTransactions[0].vout[1].nValue = 50*CENT;
     dummyTransactions[0].vout[1].scriptPubKey << ToByteVector(key[1].GetPubKey()) << OP_CHECKSIG;
-    dummyTransactions[0].vout[1].nAsset = BITCOINID;
+    dummyTransactions[0].vout[1].nAsset = Params().GetConsensus().pegged_asset;
     coinsRet.ModifyCoins(dummyTransactions[0].GetHash())->FromTx(dummyTransactions[0], 0);
 
     dummyTransactions[1].vout.resize(2);
     dummyTransactions[1].vout[0].nValue = 21*CENT;
     dummyTransactions[1].vout[0].scriptPubKey = GetScriptForDestination(key[2].GetPubKey().GetID());
-    dummyTransactions[1].vout[0].nAsset = BITCOINID;
+    dummyTransactions[1].vout[0].nAsset = Params().GetConsensus().pegged_asset;
     dummyTransactions[1].vout[1].nValue = 22*CENT;
     dummyTransactions[1].vout[1].scriptPubKey = GetScriptForDestination(key[3].GetPubKey().GetID());
-    dummyTransactions[1].vout[1].nAsset = BITCOINID;
+    dummyTransactions[1].vout[1].nAsset = Params().GetConsensus().pegged_asset;
     coinsRet.ModifyCoins(dummyTransactions[1].GetHash())->FromTx(dummyTransactions[1], 0);
 
     return dummyTransactions;
@@ -344,11 +345,11 @@ BOOST_AUTO_TEST_CASE(test_Get)
     t1.vout.resize(2);
     t1.vout[0].nValue = 90*CENT;
     t1.vout[0].scriptPubKey << OP_1;
-    t1.vout[0].nAsset = BITCOINID;
+    t1.vout[0].nAsset = Params().GetConsensus().pegged_asset;
     t1.vout[1].nValue = (50+21+22)*CENT - 90*CENT;
     t1.vout[1].scriptPubKey = CScript();
-    t1.vout[1].nAsset = BITCOINID;
-    BOOST_CHECK(CTransaction(t1).GetFee()[BITCOINID] == (50+21+22)*CENT - 90*CENT);
+    t1.vout[1].nAsset = Params().GetConsensus().pegged_asset;
+    BOOST_CHECK(CTransaction(t1).GetFee()[Params().GetConsensus().pegged_asset] == (50+21+22)*CENT - 90*CENT);
 
     BOOST_CHECK(AreInputsStandard(t1, coins));
     BOOST_CHECK(VerifyAmounts(coins, t1));

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "chainparams.h"
 #include "consensus/validation.h"
 #include "key.h"
 #include "validation.h"
@@ -46,9 +47,9 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup)
         spends[i].vout.resize(2);
         spends[i].vout[0].nValue = 11*CENT;
         spends[i].vout[0].scriptPubKey = scriptPubKey;
-        spends[i].vout[0].nAsset = BITCOINID;
+        spends[i].vout[0].nAsset = Params().GetConsensus().pegged_asset;
         spends[i].vout[1].nValue = MAX_MONEY/100-11*CENT;
-        spends[i].vout[1].nAsset = BITCOINID;
+        spends[i].vout[1].nAsset = Params().GetConsensus().pegged_asset;
         spends[i].vout[1].scriptPubKey = CScript();
 
         // Sign:

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1697,7 +1697,7 @@ bool GetLockedOutputs(const uint256 &genesisHash, const CAmount &nAmount, std::v
                 }
 
                 // Only written locks are filtered previously for invalid type
-                if (txout.nValue.IsCommitment() || txout.nAsset.IsCommitment() || txout.nAsset.GetAsset() != BITCOINID) {
+                if (txout.nValue.IsCommitment() || txout.nAsset.IsCommitment() || txout.nAsset.GetAsset() != Params().GetConsensus().pegged_asset) {
                     continue;
                 }
 
@@ -2526,7 +2526,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             vPos.push_back(std::make_pair(tx.GetHash(), pos));
             for (unsigned int i = 0; i < tx.vout.size(); i++) {
                 CTxOut txout= tx.vout[i];
-                if (txout.scriptPubKey.IsWithdrawLock() && txout.nValue.IsExplicit() && txout.nAsset.IsExplicit() && txout.nAsset.GetAsset() == BITCOINID)
+                if (txout.scriptPubKey.IsWithdrawLock() && txout.nValue.IsExplicit() && txout.nAsset.IsExplicit() && txout.nAsset.GetAsset() == Params().GetConsensus().pegged_asset)
                     mLocksCreated.insert(std::make_pair(txout.scriptPubKey.GetWithdrawLockGenesisHash(), std::make_pair(COutPoint(tx.GetHash(), i), txout.nValue.GetAmount())));
             }
 
@@ -2718,7 +2718,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
         for (unsigned int j = 0; j < tx.vout.size(); j++) {
             CTxOut txout = tx.vout[j];
-            if (txout.scriptPubKey.IsWithdrawLock() && txout.nValue.IsExplicit() && txout.nAsset.IsExplicit() && txout.nAsset.GetAsset() == BITCOINID) {
+            if (txout.scriptPubKey.IsWithdrawLock() && txout.nValue.IsExplicit() && txout.nAsset.IsExplicit() && txout.nAsset.GetAsset() == Params().GetConsensus().pegged_asset) {
                 mLocksCreated.insert(std::make_pair(txout.scriptPubKey.GetWithdrawLockGenesisHash(), std::make_pair(COutPoint(tx.GetHash(), j), txout.nValue.GetAmount())));
             }
         }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3186,7 +3186,7 @@ UniValue bumpfee(const JSONRPCRequest& request)
     }
 
     // calculate the old fee and fee-rate
-    CAmount nOldFee = wtx.tx->GetFee()[BITCOINID];
+    CAmount nOldFee = wtx.tx->GetFee()[Params().GetConsensus().pegged_asset];
     CFeeRate nOldFeeRate(nOldFee, txSize);
     CAmount nNewFee;
     CFeeRate nNewFeeRate;
@@ -3576,7 +3576,7 @@ UniValue sendtomainchain(const JSONRPCRequest& request)
     EnsureWalletIsUnlocked();
 
     CWalletTx wtxNew;
-    SendMoney(scriptPubKey, nAmount, BITCOINID, false, CPubKey(), wtxNew, true);
+    SendMoney(scriptPubKey, nAmount, Params().GetConsensus().pegged_asset, false, CPubKey(), wtxNew, true);
 
     std::string blinds;
     for (unsigned int i=0; i<wtxNew.tx->vout.size(); i++) {
@@ -3700,7 +3700,7 @@ UniValue claimpegin(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_VERIFY_REJECTED, "IsStandard rules prevent pegging-in > 0.105 million BTC reliably at a time - please work with your functionary to mine a large lock-merge transaction first");
 
     //Pad the locked outputs by the IsStandard lock dust value
-    CTxOut dummyTxOut(BITCOINID, 0, relock_spk);
+    CTxOut dummyTxOut(Params().GetConsensus().pegged_asset, 0, relock_spk);
     CAmount lockDust(dummyTxOut.GetDustThreshold(withdrawLockTxFee));
 
     LOCK(cs_main);
@@ -3714,7 +3714,7 @@ UniValue claimpegin(const JSONRPCRequest& request)
         mtxn.vin.push_back(CTxIn(lockedUTXO[0].first.hash, lockedUTXO[0].first.n, CScript(), ~(uint32_t)0));
         mtxn.vin.push_back(CTxIn(lockedUTXO[1].first.hash, lockedUTXO[1].first.n, CScript(), ~(uint32_t)0));
         CAmount out_value = lockedUTXO[0].second + lockedUTXO[1].second;
-        mtxn.vout.push_back(CTxOut(BITCOINID, out_value, relock_spk));
+        mtxn.vout.push_back(CTxOut(Params().GetConsensus().pegged_asset, out_value, relock_spk));
 
         CValidationState state;
         bool fMissingInputs;
@@ -3747,8 +3747,8 @@ UniValue claimpegin(const JSONRPCRequest& request)
     //Build the transaction
     CMutableTransaction mtxn;
     CTxIn txin(utxo_txid, utxo_vout, scriptSig, ~(uint32_t)0);
-    CTxOut txout(BITCOINID, value, GetScriptForDestination(sidechainAddress.Get()));
-    CTxOut txrelock(BITCOINID, utxo_value - value, relock_spk);
+    CTxOut txout(Params().GetConsensus().pegged_asset, value, GetScriptForDestination(sidechainAddress.Get()));
+    CTxOut txrelock(Params().GetConsensus().pegged_asset, utxo_value - value, relock_spk);
     mtxn.vin.push_back(txin);
     mtxn.vout.push_back(txout);
     mtxn.vout.push_back(txrelock);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -892,9 +892,9 @@ UniValue getbalance(const JSONRPCRequest& request)
             "\nThe total amount in the wallet\n"
             + HelpExampleCli("getbalance", "") +
             "\nThe total amount in the wallet of the specified asset (leading 3 arguments are ignored)\n"
-            + HelpExampleCli("getbalance", "\"*\" 6 false \"09f663de96be771f50cab5ded00256ffe63773e2eaa9a604092951cc3d7c6621\"") +
+            + HelpExampleCli("getbalance", "\"*\" 6 false \"694d95345fcd292329b5fb4e465a48484c7e218f4d4f1f7a3bfea26dd2d8fc3d\"") +
             "\nAs a json rpc call\n"
-            + HelpExampleRpc("getbalance", "\"*\", 6 false \"09f663de96be771f50cab5ded00256ffe63773e2eaa9a604092951cc3d7c6621\"")
+            + HelpExampleRpc("getbalance", "\"*\", 6 false \"694d95345fcd292329b5fb4e465a48484c7e218f4d4f1f7a3bfea26dd2d8fc3d\"")
         );
 
     LOCK2(cs_main, pwalletMain->cs_wallet);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -892,9 +892,9 @@ UniValue getbalance(const JSONRPCRequest& request)
             "\nThe total amount in the wallet\n"
             + HelpExampleCli("getbalance", "") +
             "\nThe total amount in the wallet of the specified asset (leading 3 arguments are ignored)\n"
-            + HelpExampleCli("getbalance", "\"*\" 6 false \"694d95345fcd292329b5fb4e465a48484c7e218f4d4f1f7a3bfea26dd2d8fc3d\"") +
+            + HelpExampleCli("getbalance", "\"*\" 6 false \"b2e15d0d7a0c94e4e2ce0fe6e8691b9e451377f6e46e8045a86f7c4b5d4f0f23\"") +
             "\nAs a json rpc call\n"
-            + HelpExampleRpc("getbalance", "\"*\", 6 false \"694d95345fcd292329b5fb4e465a48484c7e218f4d4f1f7a3bfea26dd2d8fc3d\"")
+            + HelpExampleRpc("getbalance", "\"*\", 6 false \"b2e15d0d7a0c94e4e2ce0fe6e8691b9e451377f6e46e8045a86f7c4b5d4f0f23\"")
         );
 
     LOCK2(cs_main, pwalletMain->cs_wallet);


### PR DESCRIPTION
This makes each chain have its own pegged asset type that's based on the parent chain genesis hash. (this doesn't deal with BCH type spinoffs, clearly)

This sets the stage for giving proof that bitcoin is a "true" asset in and ASP proof that requires showing the pre-image.