### PR TITLE
fix SetToAsset bug where vchCommitment wasn't cleared before writing

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -12,6 +12,7 @@
 
 void CConfidentialAsset::SetToAsset(const CAsset& asset)
 {
+    vchCommitment.clear();
     vchCommitment.reserve(nExplicitSize);
     vchCommitment.push_back(1);
     vchCommitment.insert(vchCommitment.end(), asset.begin(), asset.end());


### PR DESCRIPTION
clear the vchCommitment vector first, otherwise you'll end up appending to the end of what was already in it instead of replacing it