### PR TITLE
remove unnecessary code in IsFee() method

### DIFF
--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -235,10 +235,7 @@ public:
 
     bool IsFee() const
     {
-        CAsset asset;
-        if (scriptPubKey == CScript() && nValue.IsExplicit() && nAsset.IsExplicit())
-            return true;
-        return false;
+        return scriptPubKey == CScript() && nValue.IsExplicit() && nAsset.IsExplicit();
     }
 
     friend bool operator==(const CTxOut& a, const CTxOut& b)


### PR DESCRIPTION
Just some code clean up. The CAsset `asset` was used.