### PR TITLE
p2p: Remove opt-in part of RBF

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1080,35 +1080,8 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
     BOOST_FOREACH(const CTxIn &txin, tx.vin)
     {
         auto itConflicting = pool.mapNextTx.find(txin.prevout);
-        if (itConflicting != pool.mapNextTx.end())
-        {
-            const CTransaction *ptxConflicting = itConflicting->second;
-            if (!setConflicts.count(ptxConflicting->GetHash()))
-            {
-                // Allow opt-out of transaction replacement by setting
-                // nSequence >= maxint-1 on all inputs.
-                //
-                // maxint-1 is picked to still allow use of nLockTime by
-                // non-replaceable transactions. All inputs rather than just one
-                // is for the sake of multi-party protocols, where we don't
-                // want a single party to be able to disable replacement.
-                //
-                // The opt-out ignores descendants as anyone relying on
-                // first-seen mempool behavior should be checking all
-                // unconfirmed ancestors anyway; doing otherwise is hopelessly
-                // insecure.
-                bool fReplacementOptOut = true;
-                BOOST_FOREACH(const CTxIn &_txin, ptxConflicting->vin) {
-                    if (_txin.nSequence < std::numeric_limits<unsigned int>::max()-1) {
-                        fReplacementOptOut = false;
-                        break;
-                    }
-                }
-                if (fReplacementOptOut)
-                    return state.Invalid(false, REJECT_CONFLICT, "txn-mempool-conflict");
-
-                setConflicts.insert(ptxConflicting->GetHash());
-            }
+        if (itConflicting != pool.mapNextTx.end()) {
+            setConflicts.insert(itConflicting->second->GetHash());
         }
     }
     }


### PR DESCRIPTION
We can remove this independently of the removal on the wallet safely. We will break elements expecting the opt-in sequences to mean anything, but this is just a bad assumption.

EDIT: Rebased on top of #248