### PR TITLE
Remove CHAINPARAMS_ELEMENTS 

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -117,7 +117,7 @@ public:
         defaultFedpegScript = CScript() << OP_2 << ParseHex("02d51090b27ca8f1cc04984614bd749d8bab6f2a3681318d3fd0dd43b2a39dd774") << ParseHex("03a75bd7ac458b19f98047c76a6ffa442e592148c5d23a1ec82d379d5d558f4fd8") << ParseHex("034c55bede1bce8e486080f8ebb7a0e8f106b49efb295a8314da0e1b1723738c66") << OP_3 << OP_CHECKMULTISIG;
         consensus.fedpegScript = StrHexToScriptWithDefault(GetArg("-fedpegscript", ""), defaultFedpegScript);
 
-        strNetworkID = CHAINPARAMS_ELEMENTS;
+        strNetworkID = CHAINPARAMS_OLD_MAIN;
         consensus.nSubsidyHalvingInterval = 210000;
         consensus.BIP34Height = 227931;
         consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
@@ -397,7 +397,6 @@ public:
 
 const std::vector<std::string> CChainParams::supportedChains =
     boost::assign::list_of
-    ( CHAINPARAMS_ELEMENTS )
     ( CHAINPARAMS_REGTEST )
     ;
 
@@ -412,8 +411,6 @@ std::unique_ptr<CChainParams> CreateChainParams(const std::string& chain)
 {
     if (chain == CBaseChainParams::MAIN)
         return std::unique_ptr<CChainParams>(new CMainParams());
-    else if (chain == CHAINPARAMS_ELEMENTS)
-        return std::unique_ptr<CChainParams>(new CElementsParams());
     else if (chain == CBaseChainParams::REGTEST)
         return std::unique_ptr<CChainParams>(new CRegTestParams());
     else if (chain == CBaseChainParams::CUSTOM) {

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -17,7 +17,7 @@ const std::string CBaseChainParams::CUSTOM = "custom";
 void AppendParamsHelpMessages(std::string& strUsage, bool debugHelp)
 {
     strUsage += HelpMessageGroup(_("Chain selection options:"));
-    strUsage += HelpMessageOpt("-chain=<chain>", strprintf(_("Use the chain <chain> (default: %s). Allowed values: main, testnet, regtest, custom"), CHAINPARAMS_ELEMENTS));
+    strUsage += HelpMessageOpt("-chain=<chain>", strprintf(_("Use the chain <chain> (default: %s). Allowed values: main, testnet, regtest, custom"), CHAINPARAMS_OLD_MAIN));
     if (debugHelp) {
         strUsage += HelpMessageOpt("-regtest", "Enter regression test mode, which uses a special chain in which blocks can be solved instantly. "
                                    "This is intended for regression testing tools and app development.");
@@ -36,20 +36,6 @@ public:
     {
         nRPCPort = 8332;
         strDataDir = CHAINPARAMS_OLD_MAIN;
-    }
-};
-
-/**
- * Main network for elements
- */
-class CBaseElementsParams : public CBaseChainParams
-{
-public:
-    CBaseElementsParams()
-    {
-        nRPCPort = 9041;
-        nMainchainRPCPort = 18332;
-        strDataDir = CHAINPARAMS_ELEMENTS;
     }
 };
 
@@ -90,8 +76,6 @@ std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain
 {
     if (chain == CBaseChainParams::MAIN)
         return std::unique_ptr<CBaseChainParams>(new CBaseMainParams());
-    else if (chain == CHAINPARAMS_ELEMENTS)
-        return std::unique_ptr<CBaseChainParams>(new CBaseElementsParams());
     else if (chain == CBaseChainParams::REGTEST)
         return std::unique_ptr<CBaseChainParams>(new CBaseRegTestParams());
     else if (chain == CBaseChainParams::CUSTOM)
@@ -108,8 +92,8 @@ void SelectBaseParams(const std::string& chain)
 std::string ChainNameFromCommandLine()
 {
     if (GetBoolArg("-testnet", false))
-        throw std::runtime_error(strprintf("%s: Invalid option -testnet: elements/%s is a testchain too.", __func__, CHAINPARAMS_ELEMENTS));
+        throw std::runtime_error(strprintf("%s: Invalid option -testnet: try -chain=%s instead.", __func__, CHAINPARAMS_REGTEST));
     if (GetBoolArg("-regtest", false))
         return CBaseChainParams::REGTEST;
-    return GetArg("-chain", CHAINPARAMS_ELEMENTS);
+    return GetArg("-chain", CHAINPARAMS_REGTEST);
 }

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -10,7 +10,6 @@
 #include <vector>
 
 #define CHAINPARAMS_OLD_MAIN "main"
-#define CHAINPARAMS_ELEMENTS "elements"
 #define CHAINPARAMS_REGTEST "elementsregtest"
 
 /**

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -79,7 +79,6 @@ boost::filesystem::path GetAuthCookieFile()
 boost::filesystem::path GetMainchainAuthCookieFile()
 {
     boost::filesystem::path path(GetArg("-mainchainrpccookiefile", COOKIEAUTH_FILE));
-    if (!path.is_complete() && BaseParams().DataDir() == CHAINPARAMS_ELEMENTS) path = "testnet3" / path;
     if (!path.is_complete() && BaseParams().DataDir() == CHAINPARAMS_REGTEST) path = "regtest" / path;
     if (!path.is_complete()) path = GetDataDir(false) / path;
     return path;


### PR DESCRIPTION
CHAINPARAMS_OLD_MAIN is meant to be used only for specific tests depending on base58, not as default for all unittests through CBaseChainParams::MAIN.
But that's not the reality, more tests are currenly dependent on CBaseChainParams::MAIN being equal to  CHAINPARAMS_OLD_MAIN or CHAINPARAMS_ELEMENTS 
So removing the constant CHAINPARAMS_ELEMENTS is moving forwards.

Also:
- [X] no point in CBaseChainParams::CUSTOM.
- [X] rename "main" to "old_main", just in case.
- [X] Chainparams: Custom: Remove -chainpetname like in upstream #8994 aftersome review
- [X] Remove CHAINPARAMS_ELEMENTS 

Dependencies:

- [x] Chainparams: decouple anyonecanspend are mine from regtest #270 
- [x] QA: Modernize confidential_transactions.py #275
~~- [ ] QA: Chainparams: Run functional tests with custom chain #274~~
