### PR TITLE
Chainparams: decouple anyonecanspend are mine from regtest

### DIFF
--- a/contrib/devtools/check-doc.py
+++ b/contrib/devtools/check-doc.py
@@ -21,8 +21,9 @@ CMD_GREP_DOCS = r"egrep -r -I 'HelpMessageOpt\(\"\-[^\"=]+?(=|\")' %s" % (CMD_RO
 REGEX_ARG = re.compile(r'(?:map(?:Multi)?Args(?:\.count\(|\[)|Get(?:Bool)?Arg\()\"(\-[^\"]+?)\"')
 REGEX_DOC = re.compile(r'HelpMessageOpt\(\"(\-[^\"=]+?)(?:=|\")')
 # list unsupported, deprecated and duplicate args as they need no documentation
-SET_DOC_OPTIONAL = set(['-rpcssl', '-benchmark', '-h', '-help', '-socks', '-tor', '-debugnet', '-whitelistalwaysrelay', '-prematurewitness', '-walletprematurewitness', '-promiscuousmempoolflags', '-blockminsize',
-                        '-con_fpowallowmindifficultyblocks', '-con_fpownoretargeting', '-con_nsubsidyhalvinginterval', '-con_bip34height', '-con_bip65height', '-con_bip66height', '-con_npowtargettimespan', '-con_npowtargetspacing', '-con_nrulechangeactivationthreshold', '-con_nminerconfirmationwindow', '-con_powlimit', '-con_bip34hash', '-con_nminimumchainwork', '-con_defaultassumevalid', '-ndefaultport', '-npruneafterheight', '-fdefaultconsistencychecks', '-frequirestandard', '-fmineblocksondemand', '-mainchainrpccookiefile', '-testnet', '-ct_bits', '-ct_exponent'])
+SET_DOC_OPTIONAL = set(['-rpcssl', '-benchmark', '-h', '-help', '-socks', '-tor', '-debugnet', '-whitelistalwaysrelay', '-prematurewitness', '-walletprematurewitness', '-promiscuousmempoolflags', '-blockminsize'])
+
+SET_DOC_OPTIONAL.update(['-con_fpowallowmindifficultyblocks', '-con_fpownoretargeting', '-con_nsubsidyhalvinginterval', '-con_bip34height', '-con_bip65height', '-con_bip66height', '-con_npowtargettimespan', '-con_npowtargetspacing', '-con_nrulechangeactivationthreshold', '-con_nminerconfirmationwindow', '-con_powlimit', '-con_bip34hash', '-con_nminimumchainwork', '-con_defaultassumevalid', '-ndefaultport', '-npruneafterheight', '-fdefaultconsistencychecks', '-frequirestandard', '-fmineblocksondemand', '-mainchainrpccookiefile', '-testnet', '-ct_bits', '-ct_exponent', '-anyonecanspendaremine'])
 
 def main():
   used = check_output(CMD_GREP_ARGS, shell=True)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -160,6 +160,7 @@ public:
         fDefaultConsistencyChecks = false;
         fRequireStandard = true;
         fMineBlocksOnDemand = false;
+        anyonecanspend_aremine = false;
 
         checkpointData = (CCheckpointData){
             boost::assign::map_list_of
@@ -271,6 +272,7 @@ public:
         fDefaultConsistencyChecks = true;
         fRequireStandard = false;
         fMineBlocksOnDemand = true;
+        anyonecanspend_aremine = true;
 
         checkpointData = (CCheckpointData){
             boost::assign::map_list_of
@@ -324,6 +326,7 @@ class CCustomParams : public CChainParams {
         fDefaultConsistencyChecks = GetBoolArg("-fdefaultconsistencychecks", true);
         fRequireStandard = GetBoolArg("-frequirestandard", false);
         fMineBlocksOnDemand = GetBoolArg("-fmineblocksondemand", true);
+        anyonecanspend_aremine = GetBoolArg("-anyonecanspendaremine", true);
     }
 
 public:

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -90,6 +90,7 @@ public:
     void UpdateBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout);
     /** All coinbase outputs (after genesis) must be to this destination */
     const CScript& CoinbaseDestination() const { return scriptCoinbaseDestination; }
+    bool anyonecanspend_aremine;
 protected:
     CChainParams() {}
 

--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -149,7 +149,7 @@ isminetype IsMine(const CKeyStore &keystore, const CScript& scriptPubKey, bool& 
         break;
     }
     case TX_TRUE:
-        if (Params().NetworkIDString() == CHAINPARAMS_REGTEST)
+        if (Params().anyonecanspend_aremine)
             return ISMINE_SPENDABLE;
     }
 


### PR DESCRIPTION
Spending op_true outputs has more to do with the wallet than with the chain. Perhaps this options should be per wallet in the multiwallet future?

Alternatively we can make it a field in CChainParams, but ```Params().NetworkIDString() == CHAINPARAMS_REGTEST``` defeats the whole point of having chainparams IMO.