### PR TITLE
RPC: getinfo: Replace testnet with more generic chain

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -108,7 +108,7 @@ UniValue getinfo(const JSONRPCRequest& request)
         obj.push_back(Pair("connections",   (int)g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL)));
     obj.push_back(Pair("proxy",         (proxy.IsValid() ? proxy.proxy.ToStringIPPort() : string())));
     obj.push_back(Pair("difficulty",    (double)GetDifficulty()));
-    obj.push_back(Pair("testnet",       Params().NetworkIDString() == CBaseChainParams::REGTEST));
+    obj.push_back(Pair("chain",         Params().NetworkIDString()));
 #ifdef ENABLE_WALLET
     if (pwalletMain) {
         obj.push_back(Pair("keypoololdest", pwalletMain->GetOldestKeyPoolTime()));


### PR DESCRIPTION
As in #270, ```Params().NetworkIDString() == CHAINPARAMS_REGTEST``` defeats the whole point of having chainparams IMO.

Note getinfo gets removed upstream and getblockchaininfo and getmininginfo already do this.
