### PR TITLE
make replace-by-fee.py a standard functional test

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -159,6 +159,7 @@ testScripts = [
     #'import-rescan.py',
     # TODO fix priority assumptions in test
     #'bumpfee.py',
+    'replace-by-fee.py',
     'rpcnamedargs.py',
     'listsinceblock.py',
     'p2p-leaktests.py',
@@ -193,7 +194,6 @@ testScriptsExt = [
     'invalidateblock.py',
     'maxblocksinflight.py',
     'p2p-acceptblock.py',
-    'replace-by-fee.py',
 ]
 
 


### PR DESCRIPTION
This is the only test that checks mininode serialization, and runs efficiently. This will help catch errors due to changes to serialization.