### PR TITLE
QA: Chainparams: Run functional tests with custom chain 

### DIFF
--- a/contrib/devtools/check-doc.py
+++ b/contrib/devtools/check-doc.py
@@ -23,7 +23,7 @@ REGEX_DOC = re.compile(r'HelpMessageOpt\(\"(\-[^\"=]+?)(?:=|\")')
 # list unsupported, deprecated and duplicate args as they need no documentation
 SET_DOC_OPTIONAL = set(['-rpcssl', '-benchmark', '-h', '-help', '-socks', '-tor', '-debugnet', '-whitelistalwaysrelay', '-prematurewitness', '-walletprematurewitness', '-promiscuousmempoolflags', '-blockminsize'])
 
-SET_DOC_OPTIONAL.update(['-con_fpowallowmindifficultyblocks', '-con_fpownoretargeting', '-con_nsubsidyhalvinginterval', '-con_bip34height', '-con_bip65height', '-con_bip66height', '-con_npowtargettimespan', '-con_npowtargetspacing', '-con_nrulechangeactivationthreshold', '-con_nminerconfirmationwindow', '-con_powlimit', '-con_bip34hash', '-con_nminimumchainwork', '-con_defaultassumevalid', '-ndefaultport', '-npruneafterheight', '-fdefaultconsistencychecks', '-frequirestandard', '-fmineblocksondemand', '-mainchainrpccookiefile', '-testnet', '-ct_bits', '-ct_exponent', '-anyonecanspendaremine'])
+SET_DOC_OPTIONAL.update(['-con_fpowallowmindifficultyblocks', '-con_fpownoretargeting', '-con_nsubsidyhalvinginterval', '-con_bip34height', '-con_bip65height', '-con_bip66height', '-con_npowtargettimespan', '-con_npowtargetspacing', '-con_nrulechangeactivationthreshold', '-con_nminerconfirmationwindow', '-con_powlimit', '-con_bip34hash', '-con_nminimumchainwork', '-con_defaultassumevalid', '-ndefaultport', '-npruneafterheight', '-fdefaultconsistencychecks', '-frequirestandard', '-fmineblocksondemand', '-mainchainrpccookiefile', '-testnet', '-ct_bits', '-ct_exponent', '-anyonecanspendaremine', '-fminingrequirespeers'])
 
 def main():
   used = check_output(CMD_GREP_ARGS, shell=True)

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -163,6 +163,7 @@ testScripts = [
     'rpcnamedargs.py',
     'listsinceblock.py',
     'p2p-leaktests.py',
+    'anyonecanspend.py',
 ]
 if ENABLE_ZMQ:
     testScripts.append('zmq_test.py')

--- a/qa/rpc-tests/anyonecanspend.py
+++ b/qa/rpc-tests/anyonecanspend.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-2017 The Elements Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test custom -anyonecanspendaremine chainparams."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import start_nodes, connect_nodes_bi, assert_raises_jsonrpc
+
+class AnyoneCanSpendTest(BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+        self.extra_args = [["-anyonecanspendaremine=0"], ["-anyonecanspendaremine"]]
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, extra_args=self.extra_args)
+        connect_nodes_bi(self.nodes,0,1)
+        self.is_network_split=False
+        self.sync_all()
+
+    def run_test(self):
+        self.nodes[0].generate(100)
+        self.sync_all()
+
+        address = self.nodes[0].getnewaddress()
+        # Show error when disabled
+        assert_raises_jsonrpc(-6, 'Insufficient funds', self.nodes[0].sendtoaddress, address, 1)
+
+        # Using -anyonecanspendaremine bypasses the error
+        self.nodes[1].sendtoaddress(address, 1)
+
+if __name__ == '__main__':
+    AnyoneCanSpendTest().main()

--- a/qa/rpc-tests/pruning.py
+++ b/qa/rpc-tests/pruning.py
@@ -48,7 +48,7 @@ class PruneTest(BitcoinTestFramework):
 
         # Create node 2 to test pruning
         self.nodes.append(start_node(2, self.options.tmpdir, ["-debug","-maxreceivebuffer=20000","-prune=550"], timewait=900))
-        self.prunedir = self.options.tmpdir+"/node2/regtest/blocks/"
+        self.prunedir = self.options.tmpdir+"/node2/" + self.chain + " /blocks/"
 
         # Create nodes 3 and 4 to test manual pruning (they will be re-started with manual pruning later)
         self.nodes.append(start_node(3, self.options.tmpdir, ["-debug=0","-maxreceivebuffer=20000","-blockmaxsize=999000"], timewait=900))
@@ -264,7 +264,7 @@ class PruneTest(BitcoinTestFramework):
                 assert_equal(ret, expected_ret)
 
         def has_block(index):
-            return os.path.isfile(self.options.tmpdir + "/node{}/regtest/blocks/blk{:05}.dat".format(node_number, index))
+            return os.path.isfile(self.options.tmpdir + "/node{}/{}/blocks/blk{:05}.dat".format(node_number, self.chain, index))
 
         # should not prune because chain tip of node 3 (995) < PruneAfterHeight (1000)
         assert_raises_message(JSONRPCException, "Blockchain is too short for pruning", node.pruneblockchain, height(500))

--- a/qa/rpc-tests/replace-by-fee.py
+++ b/qa/rpc-tests/replace-by-fee.py
@@ -69,6 +69,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         super().__init__()
         self.num_nodes = 1
         self.setup_clean_chain = False
+        self.chain = "elementsregtest"
 
     def setup_network(self):
         self.nodes = []

--- a/qa/rpc-tests/replace-by-fee.py
+++ b/qa/rpc-tests/replace-by-fee.py
@@ -83,7 +83,13 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         self.is_network_split = False
 
     def run_test(self):
+        # Leave IBD
+        self.nodes[0].generate(1)
+
         make_utxo(self.nodes[0], 1*COIN)
+
+        # Ensure nodes are synced
+        self.sync_all()
 
         print("Running test simple doublespend...")
         self.test_simple_doublespend()
@@ -115,11 +121,18 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         """Simple doublespend"""
         tx0_outpoint = make_utxo(self.nodes[0], int(1.1*COIN))
 
+        # make_utxo may have generated a bunch of blocks, so we need to sync
+        # before we can spend the coins generated, or else the resulting
+        # transactions might not be accepted by our peers.
+        self.sync_all()
+
         tx1a = CTransaction()
         tx1a.vin = [CTxIn(tx0_outpoint, nSequence=0)]
         tx1a.vout = [CTxOut(1*COIN, CScript([b'a'])), CTxOut(int(0.1*COIN), b'')]
         tx1a_hex = txToHex(tx1a)
         tx1a_txid = self.nodes[0].sendrawtransaction(tx1a_hex, True)
+
+        self.sync_all()
 
         # Should fail because we haven't changed the fee
         tx1b = CTransaction()

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -35,6 +35,7 @@ class BitcoinTestFramework(object):
         self.num_nodes = 4
         self.setup_clean_chain = False
         self.nodes = None
+        self.chain = "elementsregtest"
 
     def run_test(self):
         raise NotImplementedError
@@ -45,9 +46,9 @@ class BitcoinTestFramework(object):
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)
         if self.setup_clean_chain:
-            initialize_chain_clean(self.options.tmpdir, self.num_nodes)
+            initialize_chain_clean(self.chain, self.options.tmpdir, self.num_nodes)
         else:
-            initialize_chain(self.options.tmpdir, self.num_nodes, self.options.cachedir)
+            initialize_chain(self.chain, self.options.tmpdir, self.num_nodes, self.options.cachedir)
 
     def stop_node(self, num_node):
         stop_node(self.nodes[num_node], num_node)
@@ -176,7 +177,7 @@ class BitcoinTestFramework(object):
                 # Dump the end of the debug logs, to aid in debugging rare
                 # travis failures.
                 import glob
-                filenames = glob.glob(self.options.tmpdir + "/node*/regtest/debug.log")
+                filenames = glob.glob(self.options.tmpdir + "/node*/" + self.chain + "/debug.log")
                 MAX_LINES_TO_PRINT = 1000
                 for f in filenames:
                     print("From" , f, ":")

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -35,7 +35,7 @@ class BitcoinTestFramework(object):
         self.num_nodes = 4
         self.setup_clean_chain = False
         self.nodes = None
-        self.chain = "elementsregtest"
+        self.chain = "custom"
 
     def run_test(self):
         raise NotImplementedError

--- a/qa/rpc-tests/wallet-hd.py
+++ b/qa/rpc-tests/wallet-hd.py
@@ -62,8 +62,8 @@ class WalletHDTest(BitcoinTestFramework):
 
         print("Restore backup ...")
         self.stop_node(1)
-        os.remove(self.options.tmpdir + "/node1/elementsregtest/wallet.dat")
-        shutil.copyfile(tmpdir + "/hd.bak", tmpdir + "/node1/elementsregtest/wallet.dat")
+        os.remove(self.options.tmpdir + "/node1/" + self.chain + "/wallet.dat")
+        shutil.copyfile(tmpdir + "/hd.bak", tmpdir + "/node1/" + self.chain + "/wallet.dat")
         self.nodes[1] = start_node(1, self.options.tmpdir, self.node_args[1])
         #connect_nodes_bi(self.nodes, 0, 1)
 

--- a/qa/rpc-tests/walletbackup.py
+++ b/qa/rpc-tests/walletbackup.py
@@ -97,9 +97,9 @@ class WalletBackupTest(BitcoinTestFramework):
         stop_node(self.nodes[2], 2)
 
     def erase_three(self):
-        os.remove(self.options.tmpdir + "/node0/regtest/wallet.dat")
-        os.remove(self.options.tmpdir + "/node1/regtest/wallet.dat")
-        os.remove(self.options.tmpdir + "/node2/regtest/wallet.dat")
+        os.remove(self.options.tmpdir + "/node0/" + self.chain + " /wallet.dat")
+        os.remove(self.options.tmpdir + "/node1/" + self.chain + " /wallet.dat")
+        os.remove(self.options.tmpdir + "/node2/" + self.chain + " /wallet.dat")
 
     def run_test(self):
         return #TODO
@@ -158,13 +158,13 @@ class WalletBackupTest(BitcoinTestFramework):
         self.erase_three()
 
         # Start node2 with no chain
-        shutil.rmtree(self.options.tmpdir + "/node2/regtest/blocks")
-        shutil.rmtree(self.options.tmpdir + "/node2/regtest/chainstate")
+        shutil.rmtree(self.options.tmpdir + "/node2/" + self.chain + " /blocks")
+        shutil.rmtree(self.options.tmpdir + "/node2/" + self.chain + " /chainstate")
 
         # Restore wallets from backup
-        shutil.copyfile(tmpdir + "/node0/wallet.bak", tmpdir + "/node0/regtest/wallet.dat")
-        shutil.copyfile(tmpdir + "/node1/wallet.bak", tmpdir + "/node1/regtest/wallet.dat")
-        shutil.copyfile(tmpdir + "/node2/wallet.bak", tmpdir + "/node2/regtest/wallet.dat")
+        shutil.copyfile(tmpdir + "/node0/wallet.bak", tmpdir + "/node0/" + self.chain + " /wallet.dat")
+        shutil.copyfile(tmpdir + "/node1/wallet.bak", tmpdir + "/node1/" + self.chain + " /wallet.dat")
+        shutil.copyfile(tmpdir + "/node2/wallet.bak", tmpdir + "/node2/" + self.chain + " /wallet.dat")
 
         logging.info("Re-starting nodes")
         self.start_three()
@@ -179,8 +179,8 @@ class WalletBackupTest(BitcoinTestFramework):
         self.erase_three()
 
         #start node2 with no chain
-        shutil.rmtree(self.options.tmpdir + "/node2/regtest/blocks")
-        shutil.rmtree(self.options.tmpdir + "/node2/regtest/chainstate")
+        shutil.rmtree(self.options.tmpdir + "/node2/" + self.chain + " /blocks")
+        shutil.rmtree(self.options.tmpdir + "/node2/" + self.chain + " /chainstate")
 
         self.start_three()
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -303,8 +303,6 @@ class CCustomParams : public CChainParams {
 
     void UpdateFromArgs()
     {
-        strNetworkID = GetArg("-chainpetname", "custom");
-
         consensus.fPowAllowMinDifficultyBlocks = GetBoolArg("-con_fpowallowmindifficultyblocks", true);
         consensus.fPowNoRetargeting = GetBoolArg("-con_fpownoretargeting", true);
         consensus.nSubsidyHalvingInterval = GetArg("-con_nsubsidyhalvinginterval", 150);
@@ -330,8 +328,10 @@ class CCustomParams : public CChainParams {
     }
 
 public:
-    CCustomParams()
+    CCustomParams(const std::string& chain)
     {
+        strNetworkID = chain;
+
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 999999999999ULL;
@@ -367,8 +367,7 @@ public:
 
 const std::vector<std::string> CChainParams::supportedChains =
     boost::assign::list_of
-    ( CHAINPARAMS_ELEMENTS )
-    ( CHAINPARAMS_REGTEST )
+    ( CHAINPARAMS_CUSTOM )
     ;
 
 static std::unique_ptr<CChainParams> globalChainParams;
@@ -386,10 +385,7 @@ std::unique_ptr<CChainParams> CreateChainParams(const std::string& chain)
         return std::unique_ptr<CChainParams>(new CElementsParams());
     else if (chain == CBaseChainParams::REGTEST)
         return std::unique_ptr<CChainParams>(new CRegTestParams());
-    else if (chain == CBaseChainParams::CUSTOM) {
-        return std::unique_ptr<CChainParams>(new CCustomParams());
-    }
-    throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
+    return std::unique_ptr<CChainParams>(new CCustomParams(chain));
 }
 
 void SelectParams(const std::string& network)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -319,11 +319,12 @@ class CCustomParams : public CChainParams {
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S(GetArg("-con_defaultassumevalid", "0x00"));
 
-        nDefaultPort = GetArg("-ndefaultport", 18444);
+        nDefaultPort = GetArg("-ndefaultport", 7042);
         nPruneAfterHeight = GetArg("-npruneafterheight", 1000);
         fDefaultConsistencyChecks = GetBoolArg("-fdefaultconsistencychecks", true);
         fRequireStandard = GetBoolArg("-frequirestandard", false);
         fMineBlocksOnDemand = GetBoolArg("-fmineblocksondemand", true);
+        fMiningRequiresPeers = GetBoolArg("-fminingrequirespeers", false);
         anyonecanspend_aremine = GetBoolArg("-anyonecanspendaremine", true);
     }
 
@@ -353,14 +354,37 @@ public:
             0,
             0
         };
-        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
-        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);
+        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,235);
+        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,75);
+        base58Prefixes[BLINDED_ADDRESS]= std::vector<unsigned char>(1,4);
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,239);
         base58Prefixes[EXT_PUBLIC_KEY] = boost::assign::list_of(0x04)(0x35)(0x87)(0xCF).convert_to_container<std::vector<unsigned char> >();
         base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x04)(0x35)(0x83)(0x94).convert_to_container<std::vector<unsigned char> >();
 
+        base58Prefixes[PARENT_PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
+        base58Prefixes[PARENT_SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);
+
         UpdateFromArgs();
+        const CScript defaultRegtestScript(CScript() << OP_TRUE);
+        CScript genesisChallengeScript = StrHexToScriptWithDefault(GetArg("-signblockscript", ""), defaultRegtestScript);
+        consensus.fedpegScript = StrHexToScriptWithDefault(GetArg("-fedpegscript", ""), defaultRegtestScript);
+        parentGenesisBlockHash = uint256S("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206");
+
+        // Generate pegged Bitcoin asset
+        std::vector<unsigned char> commit = CommitToArguments(consensus, strNetworkID, genesisChallengeScript);
+        uint256 entropy;
+        GenerateAssetEntropy(entropy,  COutPoint(uint256(commit), 0), parentGenesisBlockHash);
+        CalculateAsset(consensus.pegged_asset, entropy);
+
+        genesis = CreateGenesisBlock(consensus, strNetworkID, defaultRegtestScript, 1296688602, genesisChallengeScript, 1, MAX_MONEY, 100, consensus.pegged_asset);
         consensus.hashGenesisBlock = genesis.GetHash();
+
+        scriptCoinbaseDestination = CScript(); // Allow any coinbase destination
+
+        checkpointData = (CCheckpointData){
+            boost::assign::map_list_of
+            (     0, consensus.hashGenesisBlock),
+        };
     }
 };
 
@@ -398,4 +422,3 @@ void UpdateBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_
 {
     globalChainParams->UpdateBIP9Parameters(d, nStartTime, nTimeout);
 }
- 

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -70,7 +70,8 @@ class CBaseCustomParams : public CBaseChainParams
 public:
     CBaseCustomParams(const std::string& chain)
     {
-        nRPCPort = 18332;
+        nRPCPort = 7041;
+        nMainchainRPCPort = 18332;
         strDataDir = chain;
     }
 };

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -12,17 +12,14 @@
 
 const std::string CBaseChainParams::MAIN = CHAINPARAMS_OLD_MAIN;
 const std::string CBaseChainParams::REGTEST = CHAINPARAMS_REGTEST;
-const std::string CBaseChainParams::CUSTOM = "custom";
 
 void AppendParamsHelpMessages(std::string& strUsage, bool debugHelp)
 {
     strUsage += HelpMessageGroup(_("Chain selection options:"));
-    strUsage += HelpMessageOpt("-chain=<chain>", strprintf(_("Use the chain <chain> (default: %s). Allowed values: main, testnet, regtest, custom"), CHAINPARAMS_ELEMENTS));
+    strUsage += HelpMessageOpt("-chain=<chain>", strprintf(_("Use the chain <chain> (default: %s). Allowed values: anything except %s"), CHAINPARAMS_CUSTOM, CHAINPARAMS_OLD_MAIN));
     if (debugHelp) {
         strUsage += HelpMessageOpt("-regtest", "Enter regression test mode, which uses a special chain in which blocks can be solved instantly. "
                                    "This is intended for regression testing tools and app development.");
-        strUsage += HelpMessageGroup(_("Custom chain selection options (only for -chain=custom):"));
-        strUsage += HelpMessageOpt("-chainpetname=<name>", _("Alternative name for custom chain (default: custom). This changes the genesis block."));
     }
 }
 
@@ -71,10 +68,10 @@ public:
 class CBaseCustomParams : public CBaseChainParams
 {
 public:
-    CBaseCustomParams()
+    CBaseCustomParams(const std::string& chain)
     {
         nRPCPort = 18332;
-        strDataDir = "custom";
+        strDataDir = chain;
     }
 };
 
@@ -94,10 +91,7 @@ std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain
         return std::unique_ptr<CBaseChainParams>(new CBaseElementsParams());
     else if (chain == CBaseChainParams::REGTEST)
         return std::unique_ptr<CBaseChainParams>(new CBaseRegTestParams());
-    else if (chain == CBaseChainParams::CUSTOM)
-        return std::unique_ptr<CBaseChainParams>(new CBaseCustomParams());
-    else
-        throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
+    return std::unique_ptr<CBaseChainParams>(new CBaseCustomParams(chain));
 }
 
 void SelectBaseParams(const std::string& chain)
@@ -108,8 +102,8 @@ void SelectBaseParams(const std::string& chain)
 std::string ChainNameFromCommandLine()
 {
     if (GetBoolArg("-testnet", false))
-        throw std::runtime_error(strprintf("%s: Invalid option -testnet: elements/%s is a testchain too.", __func__, CHAINPARAMS_ELEMENTS));
+        throw std::runtime_error(strprintf("%s: Deprecated option -testnet: try -chain=%s instead.", __func__, CHAINPARAMS_CUSTOM));
     if (GetBoolArg("-regtest", false))
         return CBaseChainParams::REGTEST;
-    return GetArg("-chain", CHAINPARAMS_ELEMENTS);
+    return GetArg("-chain", CHAINPARAMS_CUSTOM);
 }

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -9,9 +9,10 @@
 #include <string>
 #include <vector>
 
-#define CHAINPARAMS_OLD_MAIN "main"
+#define CHAINPARAMS_OLD_MAIN "old_main"
 #define CHAINPARAMS_ELEMENTS "elements"
 #define CHAINPARAMS_REGTEST "elementsregtest"
+#define CHAINPARAMS_CUSTOM "custom"
 
 /**
  * CBaseChainParams defines the base parameters (shared between bitcoin-cli and bitcoind)
@@ -22,7 +23,6 @@ class CBaseChainParams
 public:
     static const std::string MAIN;
     static const std::string REGTEST;
-    static const std::string CUSTOM;
 
     const std::string& DataDir() const { return strDataDir; }
     int RPCPort() const { return nRPCPort; }

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -68,6 +68,7 @@ UniValue JSONRPCError(int code, const string& message)
 static const std::string COOKIEAUTH_USER = "__cookie__";
 /** Default name for auth cookie file */
 static const std::string COOKIEAUTH_FILE = ".cookie";
+static const std::string MAINCHAIN_COOKIEAUTH_FILE = "regtest/.cookie";
 
 boost::filesystem::path GetAuthCookieFile()
 {
@@ -78,9 +79,7 @@ boost::filesystem::path GetAuthCookieFile()
 
 boost::filesystem::path GetMainchainAuthCookieFile()
 {
-    boost::filesystem::path path(GetArg("-mainchainrpccookiefile", COOKIEAUTH_FILE));
-    if (!path.is_complete() && BaseParams().DataDir() == CHAINPARAMS_ELEMENTS) path = "testnet3" / path;
-    if (!path.is_complete() && BaseParams().DataDir() == CHAINPARAMS_REGTEST) path = "regtest" / path;
+    boost::filesystem::path path(GetArg("-mainchainrpccookiefile", MAINCHAIN_COOKIEAUTH_FILE));
     if (!path.is_complete()) path = GetDataDir(false) / path;
     return path;
 }


### PR DESCRIPTION
Like in https://github.com/bitcoin/bitcoin/pull/8994
The current elements is based on an older version of #8994 and we also skiped the tests part.

Additionally, include a test for #270 (the test needs to use custom chain in test to work and this depends on #270, that's why the test cannot be part of #270)

Dependencies:

- [x] Chainparams: decouple anyonecanspend are mine from regtest #270 
- [x] QA: Modernize confidential_transactions.py #275
- [x] 2WP: -mainchainrpccookiefile defaults to regtest/.cookie for all chains #286
