### PR TITLE
BIP90: Make buried deployments slightly more easily extensible

### DIFF
--- a/contrib/devtools/check-doc.py
+++ b/contrib/devtools/check-doc.py
@@ -23,7 +23,7 @@ REGEX_DOC = re.compile(r'HelpMessageOpt\(\"(\-[^\"=]+?)(?:=|\")')
 # list unsupported, deprecated and duplicate args as they need no documentation
 SET_DOC_OPTIONAL = set(['-rpcssl', '-benchmark', '-h', '-help', '-socks', '-tor', '-debugnet', '-whitelistalwaysrelay', '-prematurewitness', '-walletprematurewitness', '-promiscuousmempoolflags', '-blockminsize'])
 
-SET_DOC_OPTIONAL.update(['-con_fpowallowmindifficultyblocks', '-con_fpownoretargeting', '-con_nsubsidyhalvinginterval', '-con_bip34height', '-con_bip65height', '-con_bip66height', '-con_npowtargettimespan', '-con_npowtargetspacing', '-con_nrulechangeactivationthreshold', '-con_nminerconfirmationwindow', '-con_powlimit', '-con_nminimumchainwork', '-con_defaultassumevalid', '-ndefaultport', '-npruneafterheight', '-fdefaultconsistencychecks', '-frequirestandard', '-fmineblocksondemand', '-mainchainrpccookiefile', '-testnet', '-ct_bits', '-ct_exponent', '-anyonecanspendaremine'])
+SET_DOC_OPTIONAL.update(['-con_fpowallowmindifficultyblocks', '-con_fpownoretargeting', '-con_nsubsidyhalvinginterval', '-con_bip16height', '-con_bip34height', '-con_bip65height', '-con_bip66height', '-con_npowtargettimespan', '-con_npowtargetspacing', '-con_nrulechangeactivationthreshold', '-con_nminerconfirmationwindow', '-con_powlimit', '-con_nminimumchainwork', '-con_defaultassumevalid', '-ndefaultport', '-npruneafterheight', '-fdefaultconsistencychecks', '-frequirestandard', '-fmineblocksondemand', '-mainchainrpccookiefile', '-testnet', '-ct_bits', '-ct_exponent', '-anyonecanspendaremine'])
 
 def main():
   used = check_output(CMD_GREP_ARGS, shell=True)

--- a/contrib/devtools/check-doc.py
+++ b/contrib/devtools/check-doc.py
@@ -23,7 +23,7 @@ REGEX_DOC = re.compile(r'HelpMessageOpt\(\"(\-[^\"=]+?)(?:=|\")')
 # list unsupported, deprecated and duplicate args as they need no documentation
 SET_DOC_OPTIONAL = set(['-rpcssl', '-benchmark', '-h', '-help', '-socks', '-tor', '-debugnet', '-whitelistalwaysrelay', '-prematurewitness', '-walletprematurewitness', '-promiscuousmempoolflags', '-blockminsize'])
 
-SET_DOC_OPTIONAL.update(['-con_fpowallowmindifficultyblocks', '-con_fpownoretargeting', '-con_nsubsidyhalvinginterval', '-con_bip34height', '-con_bip65height', '-con_bip66height', '-con_npowtargettimespan', '-con_npowtargetspacing', '-con_nrulechangeactivationthreshold', '-con_nminerconfirmationwindow', '-con_powlimit', '-con_bip34hash', '-con_nminimumchainwork', '-con_defaultassumevalid', '-ndefaultport', '-npruneafterheight', '-fdefaultconsistencychecks', '-frequirestandard', '-fmineblocksondemand', '-mainchainrpccookiefile', '-testnet', '-ct_bits', '-ct_exponent', '-anyonecanspendaremine'])
+SET_DOC_OPTIONAL.update(['-con_fpowallowmindifficultyblocks', '-con_fpownoretargeting', '-con_nsubsidyhalvinginterval', '-con_bip34height', '-con_bip65height', '-con_bip66height', '-con_npowtargettimespan', '-con_npowtargetspacing', '-con_nrulechangeactivationthreshold', '-con_nminerconfirmationwindow', '-con_powlimit', '-con_nminimumchainwork', '-con_defaultassumevalid', '-ndefaultport', '-npruneafterheight', '-fdefaultconsistencychecks', '-frequirestandard', '-fmineblocksondemand', '-mainchainrpccookiefile', '-testnet', '-ct_bits', '-ct_exponent', '-anyonecanspendaremine'])
 
 def main():
   used = check_output(CMD_GREP_ARGS, shell=True)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -90,9 +90,9 @@ public:
 
         strNetworkID = CHAINPARAMS_ELEMENTS;
         consensus.nSubsidyHalvingInterval = 210000;
-        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP34] = 227931;
-        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP65] = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
-        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP66] = 363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
+        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP34] = 0;
+        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP65] = 0;
+        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP66] = 0;
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
         // Peg-ins Bitcoin headers must have higher difficulty target than this field
@@ -215,9 +215,9 @@ public:
 
         strNetworkID = CHAINPARAMS_REGTEST;
         consensus.nSubsidyHalvingInterval = 150;
-        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP34] = 100000000; // BIP34 has not activated on regtest (far in the future so block v1 are not rejected in tests)
-        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP65] = 1351; // BIP65 activated on regtest (Used in rpc activation tests)
-        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP66] = 1251; // BIP66 activated on regtest (Used in rpc activation tests)
+        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP34] = 0;
+        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP65] = 0;
+        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP66] = 0;
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.parentChainPowLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -306,9 +306,9 @@ class CCustomParams : public CChainParams {
         consensus.fPowAllowMinDifficultyBlocks = GetBoolArg("-con_fpowallowmindifficultyblocks", true);
         consensus.fPowNoRetargeting = GetBoolArg("-con_fpownoretargeting", true);
         consensus.nSubsidyHalvingInterval = GetArg("-con_nsubsidyhalvinginterval", 150);
-        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP34] = GetArg("-con_bip34height", 100000000);
-        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP65] = GetArg("-con_bip65height", 1351);
-        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP66] = GetArg("-con_bip66height", 1251);
+        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP34] = GetArg("-con_bip34height", 0);
+        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP65] = GetArg("-con_bip65height", 0);
+        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP66] = GetArg("-con_bip66height", 0);
         consensus.nPowTargetTimespan = GetArg("-con_npowtargettimespan", 14 * 24 * 60 * 60); // two weeks
         consensus.nPowTargetSpacing = GetArg("-con_npowtargetspacing", 10 * 60);
         consensus.nRuleChangeActivationThreshold = GetArg("-con_nrulechangeactivationthreshold", 108); // 75% for testchains

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -91,7 +91,6 @@ public:
         strNetworkID = CHAINPARAMS_ELEMENTS;
         consensus.nSubsidyHalvingInterval = 210000;
         consensus.BIP34Height = 227931;
-        consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
         consensus.BIP65Height = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
         consensus.BIP66Height = 363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
@@ -217,7 +216,6 @@ public:
         strNetworkID = CHAINPARAMS_REGTEST;
         consensus.nSubsidyHalvingInterval = 150;
         consensus.BIP34Height = 100000000; // BIP34 has not activated on regtest (far in the future so block v1 are not rejected in tests)
-        consensus.BIP34Hash = uint256();
         consensus.BIP65Height = 1351; // BIP65 activated on regtest (Used in rpc activation tests)
         consensus.BIP66Height = 1251; // BIP66 activated on regtest (Used in rpc activation tests)
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
@@ -316,7 +314,6 @@ class CCustomParams : public CChainParams {
         consensus.nRuleChangeActivationThreshold = GetArg("-con_nrulechangeactivationthreshold", 108); // 75% for testchains
         consensus.nMinerConfirmationWindow = GetArg("-con_nminerconfirmationwindow", 144); // Faster than normal for custom (144 instead of 2016)
         consensus.powLimit = uint256S(GetArg("-con_powlimit", "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
-        consensus.BIP34Hash = uint256S(GetArg("-con_bip34hash", "0x0"));
         consensus.nMinimumChainWork = uint256S(GetArg("-con_nminimumchainwork", "0x0"));
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S(GetArg("-con_defaultassumevalid", "0x00"));

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -90,6 +90,7 @@ public:
 
         strNetworkID = CHAINPARAMS_ELEMENTS;
         consensus.nSubsidyHalvingInterval = 210000;
+        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP16] = 1333238400; // Apr 1 2012
         consensus.buried_deployments[Consensus::DEPLOYMENT_BIP34] = 0;
         consensus.buried_deployments[Consensus::DEPLOYMENT_BIP65] = 0;
         consensus.buried_deployments[Consensus::DEPLOYMENT_BIP66] = 0;
@@ -215,6 +216,7 @@ public:
 
         strNetworkID = CHAINPARAMS_REGTEST;
         consensus.nSubsidyHalvingInterval = 150;
+        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP16] = 1333238400; // Apr 1 2012
         consensus.buried_deployments[Consensus::DEPLOYMENT_BIP34] = 0;
         consensus.buried_deployments[Consensus::DEPLOYMENT_BIP65] = 0;
         consensus.buried_deployments[Consensus::DEPLOYMENT_BIP66] = 0;
@@ -306,6 +308,7 @@ class CCustomParams : public CChainParams {
         consensus.fPowAllowMinDifficultyBlocks = GetBoolArg("-con_fpowallowmindifficultyblocks", true);
         consensus.fPowNoRetargeting = GetBoolArg("-con_fpownoretargeting", true);
         consensus.nSubsidyHalvingInterval = GetArg("-con_nsubsidyhalvinginterval", 150);
+        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP16] = GetArg("-con_bip16height", 1333238400); // Apr 1 2012
         consensus.buried_deployments[Consensus::DEPLOYMENT_BIP34] = GetArg("-con_bip34height", 0);
         consensus.buried_deployments[Consensus::DEPLOYMENT_BIP65] = GetArg("-con_bip65height", 0);
         consensus.buried_deployments[Consensus::DEPLOYMENT_BIP66] = GetArg("-con_bip66height", 0);

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -90,9 +90,9 @@ public:
 
         strNetworkID = CHAINPARAMS_ELEMENTS;
         consensus.nSubsidyHalvingInterval = 210000;
-        consensus.BIP34Height = 227931;
-        consensus.BIP65Height = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
-        consensus.BIP66Height = 363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
+        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP34] = 227931;
+        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP65] = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
+        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP66] = 363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
         // Peg-ins Bitcoin headers must have higher difficulty target than this field
@@ -215,9 +215,9 @@ public:
 
         strNetworkID = CHAINPARAMS_REGTEST;
         consensus.nSubsidyHalvingInterval = 150;
-        consensus.BIP34Height = 100000000; // BIP34 has not activated on regtest (far in the future so block v1 are not rejected in tests)
-        consensus.BIP65Height = 1351; // BIP65 activated on regtest (Used in rpc activation tests)
-        consensus.BIP66Height = 1251; // BIP66 activated on regtest (Used in rpc activation tests)
+        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP34] = 100000000; // BIP34 has not activated on regtest (far in the future so block v1 are not rejected in tests)
+        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP65] = 1351; // BIP65 activated on regtest (Used in rpc activation tests)
+        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP66] = 1251; // BIP66 activated on regtest (Used in rpc activation tests)
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.parentChainPowLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -306,9 +306,9 @@ class CCustomParams : public CChainParams {
         consensus.fPowAllowMinDifficultyBlocks = GetBoolArg("-con_fpowallowmindifficultyblocks", true);
         consensus.fPowNoRetargeting = GetBoolArg("-con_fpownoretargeting", true);
         consensus.nSubsidyHalvingInterval = GetArg("-con_nsubsidyhalvinginterval", 150);
-        consensus.BIP34Height = GetArg("-con_bip34height", 100000000);
-        consensus.BIP65Height = GetArg("-con_bip65height", 1351);
-        consensus.BIP66Height = GetArg("-con_bip66height", 1251);
+        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP34] = GetArg("-con_bip34height", 100000000);
+        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP65] = GetArg("-con_bip65height", 1351);
+        consensus.buried_deployments[Consensus::DEPLOYMENT_BIP66] = GetArg("-con_bip66height", 1251);
         consensus.nPowTargetTimespan = GetArg("-con_npowtargettimespan", 14 * 24 * 60 * 60); // two weeks
         consensus.nPowTargetSpacing = GetArg("-con_npowtargetspacing", 10 * 60);
         consensus.nRuleChangeActivationThreshold = GetArg("-con_nrulechangeactivationthreshold", 108); // 75% for testchains

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -65,7 +65,7 @@ struct Params {
     int64_t nPowTargetSpacing;
     int64_t nPowTargetTimespan;
     /** BIP90: Block height at which buried deployments becomes active */
-    int buried_deployments[MAX_BURIED_DEPLOYMENTS];
+    uint32_t buried_deployments[MAX_BURIED_DEPLOYMENTS];
     int64_t DifficultyAdjustmentInterval() const { return nPowTargetTimespan / nPowTargetSpacing; }
     uint256 nMinimumChainWork;
     CScript fedpegScript;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -16,6 +16,7 @@ namespace Consensus {
 
 enum BuriedDeploymentPos
 {
+    DEPLOYMENT_BIP16,
     DEPLOYMENT_BIP34,
     DEPLOYMENT_BIP65,
     DEPLOYMENT_BIP66,

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -41,9 +41,8 @@ struct BIP9Deployment {
 struct Params {
     uint256 hashGenesisBlock;
     int nSubsidyHalvingInterval;
-    /** Block height and hash at which BIP34 becomes active */
+    /** Block height at which BIP34 becomes active */
     int BIP34Height;
-    uint256 BIP34Hash;
     /** Block height at which BIP65 becomes active */
     int BIP65Height;
     /** Block height at which BIP66 becomes active */

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -14,6 +14,14 @@
 
 namespace Consensus {
 
+enum BuriedDeploymentPos
+{
+    DEPLOYMENT_BIP34,
+    DEPLOYMENT_BIP65,
+    DEPLOYMENT_BIP66,
+    MAX_BURIED_DEPLOYMENTS
+};
+
 enum DeploymentPos
 {
     DEPLOYMENT_TESTDUMMY,
@@ -41,12 +49,6 @@ struct BIP9Deployment {
 struct Params {
     uint256 hashGenesisBlock;
     int nSubsidyHalvingInterval;
-    /** Block height at which BIP34 becomes active */
-    int BIP34Height;
-    /** Block height at which BIP65 becomes active */
-    int BIP65Height;
-    /** Block height at which BIP66 becomes active */
-    int BIP66Height;
     /**
      * Minimum blocks including miner confirmation of the total of 2016 blocks in a retargeting period,
      * (nPowTargetTimespan / nPowTargetSpacing) which is also used for BIP9 deployments.
@@ -62,6 +64,8 @@ struct Params {
     bool fPowNoRetargeting;
     int64_t nPowTargetSpacing;
     int64_t nPowTargetTimespan;
+    /** BIP90: Block height at which buried deployments becomes active */
+    int buried_deployments[MAX_BURIED_DEPLOYMENTS];
     int64_t DifficultyAdjustmentInterval() const { return nPowTargetTimespan / nPowTargetSpacing; }
     uint256 nMinimumChainWork;
     CScript fedpegScript;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2587,7 +2587,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     // time BIP34 activated, in each of the existing pairs the duplicate coinbase had overwritten the first
     // before the first had been spent.  Since those coinbases are sufficiently buried its no longer possible to create further
     // duplicate transactions descending from the known pairs either.
-    fEnforceBIP30 = fEnforceBIP30 && pindex->nHeight > chainparams.GetConsensus().BIP34Height;
+    fEnforceBIP30 = fEnforceBIP30 && pindex->nHeight > chainparams.GetConsensus().buried_deployments[Consensus::DEPLOYMENT_BIP34];
 
     if (fEnforceBIP30) {
         for (const auto& tx : block.vtx) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2587,10 +2587,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     // time BIP34 activated, in each of the existing pairs the duplicate coinbase had overwritten the first
     // before the first had been spent.  Since those coinbases are sufficiently buried its no longer possible to create further
     // duplicate transactions descending from the known pairs either.
-    // If we're on the known chain at height greater than where BIP34 activated, we can save the db accesses needed for the BIP30 check.
-    CBlockIndex *pindexBIP34height = pindex->pprev->GetAncestor(chainparams.GetConsensus().BIP34Height);
-    //Only continue to enforce if we're below BIP34 activation height or the block hash at that height doesn't correspond.
-    fEnforceBIP30 = fEnforceBIP30 && (!pindexBIP34height || !(pindexBIP34height->GetBlockHash() == chainparams.GetConsensus().BIP34Hash));
+    fEnforceBIP30 = fEnforceBIP30 && pindex->nHeight > chainparams.GetConsensus().BIP34Height;
 
     if (fEnforceBIP30) {
         for (const auto& tx : block.vtx) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2599,7 +2599,8 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     }
 
     //P2SH is a requirement for segwit + CT
-    unsigned int flags = SCRIPT_VERIFY_P2SH;
+    bool fStrictPayToScriptHash = pindex->GetBlockTime() >= chainparams.GetConsensus().buried_deployments[Consensus::DEPLOYMENT_BIP16];
+    unsigned int flags = fStrictPayToScriptHash ? SCRIPT_VERIFY_P2SH : SCRIPT_VERIFY_NONE;
 
     // Start enforcing the DERSIG (BIP66) rule
     if (pindex->nHeight >= chainparams.GetConsensus().buried_deployments[Consensus::DEPLOYMENT_BIP66]) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2602,10 +2602,13 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     unsigned int flags = SCRIPT_VERIFY_P2SH;
 
     // Start enforcing the DERSIG (BIP66) rule
-    flags |= SCRIPT_VERIFY_DERSIG;
-
+    if (pindex->nHeight >= chainparams.GetConsensus().buried_deployments[Consensus::DEPLOYMENT_BIP66]) {
+        flags |= SCRIPT_VERIFY_DERSIG;
+    }
     // Start enforcing CHECKLOCKTIMEVERIFY (BIP65) rule
-    flags |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
+    if (pindex->nHeight >= chainparams.GetConsensus().buried_deployments[Consensus::DEPLOYMENT_BIP65]) {
+        flags |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
+    }
 
     // Start enforcing BIP68 (sequence locks) and BIP112 (CHECKSEQUENCEVERIFY) using versionbits logic.
     int nLockTimeFlags = 0;
@@ -3849,8 +3852,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, const Co
     }
 
     // Enforce rule that the coinbase starts with serialized block height
-    if (block.nVersion >= 2)
-    {
+    if (nHeight > consensusParams.buried_deployments[Consensus::DEPLOYMENT_BIP34]) {
         CScript expect = CScript() << nHeight;
         if (block.vtx[0]->vin[0].scriptSig.size() < expect.size() ||
             !std::equal(expect.begin(), expect.end(), block.vtx[0]->vin[0].scriptSig.begin())) {


### PR DESCRIPTION
Similar to https://github.com/bitcoin/bitcoin/pull/11426 but based on Based on https://github.com/ElementsProject/elements/pull/276

EDIT: while also:

- BIP90: Restore rebase compatibility
- Elements: BIP90: Enforce all buried deployments from block 0
- Also backport configurable bip16 ( https://github.com/bitcoin/bitcoin/pull/11430 )
