### PR TITLE
[WIP] Surjection support plus plus

### DIFF
--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -303,6 +303,37 @@ public:
     std::string ToString() const;
 };
 
+class CAssetDerivation
+{
+public:
+    // input and contract originally used for entropy
+    COutPoint m_prevout;
+    uint256 m_contract_hash;
+    // markers to indicate derivation path for asset type
+    bool m_is_reissue_token;
+    bool m_is_blinded_token;
+
+public:
+    CAssetDerivation()
+    {
+        SetNull();
+    }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(m_prevout);
+        READWRITE(m_contract_hash);
+        READWRITE(m_is_reissue_token);
+        READWRITE(m_is_blinded_token);
+    }
+
+    void SetNull() { m_prevout.SetNull(); m_contract_hash.SetNull(); m_is_reissue_token = false; m_is_blinded_token = false;}
+    bool IsNull() const { return (m_prevout.IsNull() && m_contract_hash.IsNull()) && m_is_reissue_token == false && m_is_blinded_token; }
+};
+
 /** A new asset issuance, or a reissuance (inflation) of an existing asset */
 class CAssetIssuance
 {
@@ -568,6 +599,12 @@ public:
     std::vector<CTxInWitness> vtxinwit;
     std::vector<CTxOutWitness> vtxoutwit;
 
+    // Transaction-level witness for surjection proofs.
+    // If this witness is non-empty, all outputs' surjection
+    // proofs are validated against this witness rather than input
+    // asset commtiments
+    std::vector<CAssetDerivation> m_surj_wit;
+
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
@@ -579,6 +616,7 @@ public:
         for (size_t n = 0; n < vtxoutwit.size(); n++) {
             READWRITE(vtxoutwit[n]);
         }
+        READWRITE(m_surj_wit);
         if (IsNull()) {
             /* It's illegal to encode a witness when all vtxinwit and vtxoutwit entries are empty. */
             throw std::ios_base::failure("Superfluous witness record");
@@ -587,7 +625,7 @@ public:
 
     bool IsEmpty() const
     {
-        return vtxinwit.empty() && vtxoutwit.empty();
+        return vtxinwit.empty() && vtxoutwit.empty() && m_surj_wit.empty();
     }
 
     bool IsNull() const
@@ -602,6 +640,9 @@ public:
                 return false;
             }
         }
+        if (!m_surj_wit.empty()) {
+            return false;
+        }
         return true;
     }
 
@@ -609,6 +650,7 @@ public:
     {
         vtxinwit.clear();
         vtxoutwit.clear();
+        m_surj_wit.clear();
     }
 };
 

--- a/src/secp256k1/include/secp256k1_surjectionproof.h
+++ b/src/secp256k1/include/secp256k1_surjectionproof.h
@@ -186,6 +186,51 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_surjectionproof_generat
   const unsigned char *output_blinding_key
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(5) SECP256K1_ARG_NONNULL(7) SECP256K1_ARG_NONNULL(8);
 
+/** Sorts a list of fixed tags in place so that the corresponding unblinded generators will be usable
+ *  for `secp256k1_surjectionproof_combine`. This function should only be used when all input generators
+ *  have zero blinding factor.
+ *
+ * Returns 0 on argument error, otherwise 1.
+ *
+ * Args:      ctx: a secp256k1 context object. Cannot be NULL.
+ * In/Out:   tags: tags to sort. Cannot be NULL.
+ * In:     n_tags: number of tags to sort
+ */
+SECP256K1_API int secp256k1_surjectionproof_sort_tags(
+  const secp256k1_context* ctx,
+  secp256k1_fixed_asset_tag* tags,
+  size_t n_tags
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2);
+
+/** Combines two surjection proofs so that they can be validated against the same input tag set.
+ *  Updates the proofs in place to index into the merged list. Input lists must be pre-sorted
+ *  using `secp256k1_surjectionproof_sort_input_tags`.
+ *
+ * Returns 0: proofs could not be merged
+ *         1: proofs were successfully merged
+ *
+ * Args:                    ctx: a secp256k1 context object. Cannot be NULL.
+ * In:    input_tags1: input tags for the first proof. Cannot be NULL.
+ *      n_input_tags1: number of input tags for the first proof
+ *        input_tags2: input tags for the second proof. Cannot be NULL.
+ *      n_input_tags2: number of input tags for the second proof
+ * Out:          tags: combined list of input tags. Cannot be NULL.
+ * In/Out:     n_tags: number of tags in the combined list. Cannot be NULL.
+ *                     May not alias either of the input lists.
+ *             proof1: first proof to be combined. Cannot be NULL.
+ *             proof2: second proof to be combined. Cannot be NULL.
+ */
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_surjectionproof_combine(
+  const secp256k1_context* ctx,
+  secp256k1_generator* tags,
+  size_t *n_tags,
+  secp256k1_surjectionproof* proof1,
+  secp256k1_surjectionproof* proof2,
+  const secp256k1_generator* input_tags1,
+  size_t n_input_tags1,
+  const secp256k1_generator* input_tags2,
+  size_t n_input_tags2
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4) SECP256K1_ARG_NONNULL(5) SECP256K1_ARG_NONNULL(6) SECP256K1_ARG_NONNULL(8);
 
 /** Surjection proof verification function
  * Returns 0: proof was invalid

--- a/src/secp256k1/src/modules/surjection/main_impl.h
+++ b/src/secp256k1/src/modules/surjection/main_impl.h
@@ -289,6 +289,107 @@ int secp256k1_surjectionproof_generate(const secp256k1_context* ctx, secp256k1_s
     return 1;
 }
 
+static int secp256k1_tag_cmp(const void *in1, const void *in2) {
+    secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
+    const secp256k1_fixed_asset_tag* tag1 = in1;
+    const secp256k1_fixed_asset_tag* tag2 = in2;
+    secp256k1_generator gen1;
+    secp256k1_generator gen2;
+    if (secp256k1_generator_generate(ctx, &gen1, tag1->data) == 0 ||
+        secp256k1_generator_generate(ctx, &gen2, tag2->data) == 0) {
+        return 1;
+    }
+    secp256k1_context_destroy(ctx);
+    return memcmp(gen1.data, gen2.data, sizeof(gen1.data));
+}
+
+int secp256k1_surjectionproof_sort_tags(const secp256k1_context* ctx, secp256k1_fixed_asset_tag* tags, size_t n_tags) {
+    VERIFY_CHECK(ctx != NULL);
+    ARG_CHECK(tags != NULL);
+    (void) ctx;
+    qsort(tags, n_tags, sizeof(*tags), secp256k1_tag_cmp);
+    return 1;
+}
+
+int secp256k1_surjectionproof_combine(const secp256k1_context* ctx, secp256k1_generator* tags, size_t *n_tags, secp256k1_surjectionproof* proof1, secp256k1_surjectionproof* proof2, const secp256k1_generator* input_tags1, size_t n_input_tags1, const secp256k1_generator* input_tags2, size_t n_input_tags2) {
+    size_t l_idx, r_idx, o_idx;
+    unsigned char used_inputs1[SECP256K1_SURJECTIONPROOF_MAX_N_INPUTS / 8] = { 0 };
+    unsigned char used_inputs2[SECP256K1_SURJECTIONPROOF_MAX_N_INPUTS / 8] = { 0 };
+
+    VERIFY_CHECK(ctx != NULL);
+    ARG_CHECK(tags != NULL);
+    ARG_CHECK(n_tags != NULL);
+    ARG_CHECK(proof1 != NULL);
+    ARG_CHECK(proof2 != NULL);
+    ARG_CHECK(input_tags1 != NULL);
+    ARG_CHECK(n_input_tags1 <= SECP256K1_SURJECTIONPROOF_MAX_N_INPUTS);
+    ARG_CHECK(n_input_tags2 <= SECP256K1_SURJECTIONPROOF_MAX_N_INPUTS);
+    ARG_CHECK(input_tags2 != NULL);
+    (void) ctx;
+
+    l_idx = r_idx = o_idx = 0;
+    while (1) {
+        enum { USE_NONE, USE_L, USE_R, USE_BOTH } use = USE_NONE;
+
+        if (l_idx < n_input_tags1 && r_idx < n_input_tags2) {
+            int res = memcmp(input_tags1[l_idx].data, input_tags2[r_idx].data, sizeof(input_tags1[l_idx].data));
+            if (res < 0) {
+                use = USE_L;
+            } else if (res > 0) {
+                use = USE_R;
+            } else {
+                use = USE_BOTH;
+            }
+        } else if (l_idx < n_input_tags1) {
+            use = USE_L;
+        } else if (r_idx < n_input_tags1) {
+            use = USE_R;
+        } else {
+            break;
+        }
+
+        if (o_idx >= *n_tags) {
+            return 0;
+        }
+
+        switch (use) {
+            case USE_NONE:
+                VERIFY_CHECK(0);
+                break;
+            case USE_L:
+            case USE_BOTH:
+                if (proof1->used_inputs[l_idx / 8] & (1 << (l_idx % 8))) {
+                    used_inputs1[o_idx / 8] |= 1 << (o_idx % 8);
+                }
+                memcpy(&tags[o_idx], &input_tags1[l_idx], sizeof(input_tags1[l_idx]));
+                l_idx++;
+                if (use == USE_BOTH) {
+                    if (proof2->used_inputs[r_idx / 8] & (1 << (r_idx % 8))) {
+                        used_inputs2[o_idx / 8] |= 1 << (o_idx % 8);
+                    }
+                    r_idx++;
+                }
+                break;
+            case USE_R:
+                if (proof2->used_inputs[r_idx / 8] & (1 << (r_idx % 8))) {
+                    used_inputs2[o_idx / 8] |= 1 << (o_idx % 8);
+                }
+                memcpy(&tags[o_idx], &input_tags2[r_idx], sizeof(input_tags2[r_idx]));
+                r_idx++;
+                break;
+        }
+        o_idx++;
+    }
+    memcpy(proof1->used_inputs, used_inputs1, sizeof(used_inputs1));
+    memcpy(proof2->used_inputs, used_inputs2, sizeof(used_inputs2));
+    proof1->n_inputs = o_idx;
+    proof2->n_inputs = o_idx;
+    *n_tags = o_idx;
+
+    return 1;
+}
+
+
 int secp256k1_surjectionproof_verify(const secp256k1_context* ctx, const secp256k1_surjectionproof* proof, const secp256k1_generator* ephemeral_input_tags, size_t n_ephemeral_input_tags, const secp256k1_generator* ephemeral_output_tag) {
     size_t rsizes[1];    /* array needed for borromean sig API */
     size_t i;

--- a/src/secp256k1/src/modules/surjection/main_impl.h
+++ b/src/secp256k1/src/modules/surjection/main_impl.h
@@ -271,7 +271,7 @@ int secp256k1_surjectionproof_generate(const secp256k1_context* ctx, secp256k1_s
     /* Produce signature */
     rsizes[0] = (int) n_used_pubkeys;
     indices[0] = (int) ring_input_index;
-    secp256k1_surjection_genmessage(msg32, inputs, n_total_pubkeys, &output);
+    secp256k1_surjection_genmessage(msg32, inputs, n_total_pubkeys, proof->used_inputs, &output);
     if (secp256k1_surjection_genrand(borromean_s, n_used_pubkeys, &blinding_key) == 0) {
         return 0;
     }
@@ -331,7 +331,7 @@ int secp256k1_surjectionproof_verify(const secp256k1_context* ctx, const secp256
             return 0;
         }
     }
-    secp256k1_surjection_genmessage(msg32, inputs, n_total_pubkeys, &output);
+    secp256k1_surjection_genmessage(msg32, inputs, n_total_pubkeys, proof->used_inputs, &output);
     return secp256k1_borromean_verify(&ctx->ecmult_ctx, NULL, &proof->data[0], borromean_s, ring_pubkeys, rsizes, 1, msg32, 32);
 }
 

--- a/src/secp256k1/src/modules/surjection/surjection.h
+++ b/src/secp256k1/src/modules/surjection/surjection.h
@@ -10,7 +10,7 @@
 #include "group.h"
 #include "scalar.h"
 
-SECP256K1_INLINE static int secp256k1_surjection_genmessage(unsigned char *msg32, secp256k1_ge *ephemeral_input_tags, size_t n_input_tags, secp256k1_ge *ephemeral_output_tag);
+SECP256K1_INLINE static void secp256k1_surjection_genmessage(unsigned char *msg32, secp256k1_ge *ephemeral_input_tags, size_t n_input_tags, const unsigned char *used_tags, secp256k1_ge *ephemeral_output_tag);
 
 SECP256K1_INLINE static int secp256k1_surjection_genrand(secp256k1_scalar *s, size_t ns, const secp256k1_scalar *blinding_key);
 

--- a/src/secp256k1/src/modules/surjection/surjection_impl.h
+++ b/src/secp256k1/src/modules/surjection/surjection_impl.h
@@ -15,7 +15,7 @@
 #include "scalar.h"
 #include "hash.h"
 
-SECP256K1_INLINE static void secp256k1_surjection_genmessage(unsigned char *msg32, secp256k1_ge *ephemeral_input_tags, size_t n_input_tags, secp256k1_ge *ephemeral_output_tag) {
+SECP256K1_INLINE static void secp256k1_surjection_genmessage(unsigned char *msg32, secp256k1_ge *ephemeral_input_tags, size_t n_input_tags, const unsigned char *used_tags, secp256k1_ge *ephemeral_output_tag) {
     /* compute message */
     size_t i;
     unsigned char pk_ser[33];
@@ -24,9 +24,11 @@ SECP256K1_INLINE static void secp256k1_surjection_genmessage(unsigned char *msg3
 
     secp256k1_sha256_initialize(&sha256_en);
     for (i = 0; i < n_input_tags; i++) {
-        secp256k1_eckey_pubkey_serialize(&ephemeral_input_tags[i], pk_ser, &pk_len, 1);
-        assert(pk_len == sizeof(pk_ser));
-        secp256k1_sha256_write(&sha256_en, pk_ser, pk_len);
+        if (used_tags[i / 8] & (1 << (i % 8))) {
+            secp256k1_eckey_pubkey_serialize(&ephemeral_input_tags[i], pk_ser, &pk_len, 1);
+            assert(pk_len == sizeof(pk_ser));
+            secp256k1_sha256_write(&sha256_en, pk_ser, pk_len);
+        }
     }
     secp256k1_eckey_pubkey_serialize(ephemeral_output_tag, pk_ser, &pk_len, 1);
     assert(pk_len == sizeof(pk_ser));

--- a/src/secp256k1/src/modules/surjection/tests_impl.h
+++ b/src/secp256k1/src/modules/surjection/tests_impl.h
@@ -155,6 +155,37 @@ static void test_surjectionproof_api(void) {
     CHECK(secp256k1_surjectionproof_parse(none, &proof, serialized_proof, 0) == 0);
     CHECK(ecount == 25);
 
+    /* check sort */
+    ecount = 0;
+    CHECK(secp256k1_surjectionproof_sort_tags(none, fixed_input_tags, n_inputs) == 1);
+    CHECK(secp256k1_surjectionproof_sort_tags(none, fixed_input_tags, 0) == 1);
+    CHECK(ecount == 0);
+    CHECK(secp256k1_surjectionproof_sort_tags(none, NULL, n_inputs) == 0);
+    CHECK(ecount == 1);
+
+    /* Check merge */
+    {
+        secp256k1_surjectionproof proof1;
+        secp256k1_generator ext[10];
+        size_t n = n_inputs;
+
+        memcpy(&proof1, &proof, sizeof(proof));
+        CHECK(secp256k1_surjectionproof_combine(none, ext, &n, &proof, &proof1, ephemeral_input_tags, n_inputs, ephemeral_input_tags, n_inputs) == 1);
+        CHECK(ecount == 1);
+        CHECK(secp256k1_surjectionproof_combine(none, NULL, &n, &proof, &proof1, ephemeral_input_tags, n_inputs, ephemeral_input_tags, n_inputs) == 0);
+        CHECK(ecount == 2);
+        CHECK(secp256k1_surjectionproof_combine(none, ext, NULL, &proof, &proof1, ephemeral_input_tags, n_inputs, ephemeral_input_tags, n_inputs) == 0);
+        CHECK(ecount == 3);
+        CHECK(secp256k1_surjectionproof_combine(none, ext, &n, NULL, &proof1, ephemeral_input_tags, n_inputs, ephemeral_input_tags, n_inputs) == 0);
+        CHECK(ecount == 4);
+        CHECK(secp256k1_surjectionproof_combine(none, ext, &n, &proof, NULL, ephemeral_input_tags, n_inputs, ephemeral_input_tags, n_inputs) == 0);
+        CHECK(ecount == 5);
+        CHECK(secp256k1_surjectionproof_combine(none, ext, &n, &proof, &proof1, NULL, n_inputs, ephemeral_input_tags, n_inputs) == 0);
+        CHECK(ecount == 6);
+        CHECK(secp256k1_surjectionproof_combine(none, ext, &n, &proof, &proof1, ephemeral_input_tags, n_inputs, NULL, n_inputs) == 0);
+        CHECK(ecount == 7);
+    }
+
     secp256k1_context_destroy(none);
     secp256k1_context_destroy(sign);
     secp256k1_context_destroy(vrfy);
@@ -439,6 +470,80 @@ static void test_no_used_inputs_verify(void) {
     CHECK(result == 0);
 }
 
+/* Build two proofs with exposed (0 blinding factor) inputs */
+static void test_surjectionproof_combine(void) {
+    unsigned char seed[32];
+    unsigned char zero_vch[32] = {0};
+    secp256k1_fixed_asset_tag fixed_tags1[10];
+    secp256k1_fixed_asset_tag fixed_tags2[10];
+    secp256k1_generator ephemeral_tags1[10];
+    secp256k1_generator ephemeral_tags2[10];
+    secp256k1_generator output1;
+    secp256k1_generator output2;
+    unsigned char output_blind1[32];
+    unsigned char output_blind2[32];
+    size_t input_idx1, input_idx2;
+    secp256k1_surjectionproof proof1, proof2;
+    const size_t n_inputs = sizeof(fixed_tags1) / sizeof(fixed_tags1[0]);
+    size_t i;
+
+    secp256k1_rand256(seed);
+    for (i = 0; i < n_inputs; i++) {
+        secp256k1_rand256(fixed_tags1[i].data);
+        if (i % 2 == 0) {
+            secp256k1_rand256(fixed_tags2[i].data);
+        } else {
+            memcpy(fixed_tags2[i].data, fixed_tags1[i].data, sizeof(fixed_tags1[i].data));
+        }
+    }
+    CHECK(secp256k1_surjectionproof_sort_tags(ctx, fixed_tags1, n_inputs) == 1);
+    CHECK(secp256k1_surjectionproof_sort_tags(ctx, fixed_tags2, n_inputs) == 1);
+    for (i = 0; i < n_inputs; i++) {
+        CHECK(secp256k1_generator_generate(ctx, &ephemeral_tags1[i], fixed_tags1[i].data));
+        CHECK(secp256k1_generator_generate(ctx, &ephemeral_tags2[i], fixed_tags2[i].data));
+    }
+
+    CHECK(secp256k1_surjectionproof_initialize(ctx, &proof1, &input_idx1, fixed_tags1, n_inputs, 3, &fixed_tags1[0], 100, seed) > 0);
+    CHECK(secp256k1_surjectionproof_initialize(ctx, &proof2, &input_idx2, fixed_tags2, n_inputs, 3, &fixed_tags2[5], 100, seed) > 0);
+    CHECK(input_idx1 == 0);
+    CHECK(input_idx2 == 5);
+
+    secp256k1_rand256(output_blind1);
+    secp256k1_rand256(output_blind2);
+    CHECK(secp256k1_generator_generate_blinded(ctx, &output1, fixed_tags1[0].data, output_blind1));
+    CHECK(secp256k1_generator_generate_blinded(ctx, &output2, fixed_tags2[5].data, output_blind2));
+
+    CHECK(secp256k1_surjectionproof_generate(ctx, &proof1, ephemeral_tags1, n_inputs, &output1, input_idx1, zero_vch, output_blind1) == 1);
+    CHECK(secp256k1_surjectionproof_generate(ctx, &proof2, ephemeral_tags2, n_inputs, &output2, input_idx2, zero_vch, output_blind2) == 1);
+
+    CHECK(secp256k1_surjectionproof_verify(ctx, &proof1, ephemeral_tags1, n_inputs, &output1) == 1);
+    CHECK(secp256k1_surjectionproof_verify(ctx, &proof2, ephemeral_tags2, n_inputs, &output2) == 1);
+
+    /* proofs created, verify correctly, great. try combining them */
+    {
+        secp256k1_surjectionproof dummy_proof1 = proof1, dummy_proof2 = proof2;
+        secp256k1_generator inputs[20];
+        size_t n_comb_inputs = sizeof(inputs) / sizeof(inputs[0]);
+        size_t n_insufficient_inputs = n_comb_inputs / 2;
+
+        CHECK(secp256k1_surjectionproof_n_total_inputs(ctx, &proof1) == n_inputs);
+        CHECK(secp256k1_surjectionproof_n_total_inputs(ctx, &proof2) == n_inputs);
+        CHECK(secp256k1_surjectionproof_n_used_inputs(ctx, &proof1) == 3);
+        CHECK(secp256k1_surjectionproof_n_used_inputs(ctx, &proof2) == 3);
+
+        CHECK(secp256k1_surjectionproof_combine(ctx, inputs, &n_insufficient_inputs, &dummy_proof1, &dummy_proof2, ephemeral_tags1, n_inputs, ephemeral_tags2, n_inputs) == 0);
+        CHECK(secp256k1_surjectionproof_combine(ctx, inputs, &n_comb_inputs, &proof1, &proof2, ephemeral_tags1, n_inputs, ephemeral_tags2, n_inputs) == 1);
+        CHECK(n_comb_inputs == n_inputs + n_inputs / 2);
+        CHECK(secp256k1_surjectionproof_n_total_inputs(ctx, &proof1) == n_comb_inputs);
+        CHECK(secp256k1_surjectionproof_n_total_inputs(ctx, &proof2) == n_comb_inputs);
+        CHECK(secp256k1_surjectionproof_n_used_inputs(ctx, &proof1) == 3);
+        CHECK(secp256k1_surjectionproof_n_used_inputs(ctx, &proof2) == 3);
+
+        CHECK(secp256k1_surjectionproof_verify(ctx, &proof1, inputs, n_comb_inputs, &output1) == 1);
+        CHECK(secp256k1_surjectionproof_verify(ctx, &proof2, inputs, n_comb_inputs, &output2) == 1);
+    }
+}
+
 void test_bad_serialize(void) {
     secp256k1_surjectionproof proof;
     unsigned char serialized_proof[SECP256K1_SURJECTIONPROOF_SERIALIZATION_BYTES_MAX];
@@ -480,6 +585,7 @@ void run_surjection_tests(void) {
     test_gen_verify(10, 3);
     test_gen_verify(SECP256K1_SURJECTIONPROOF_MAX_N_INPUTS, SECP256K1_SURJECTIONPROOF_MAX_N_INPUTS);
     test_no_used_inputs_verify();
+    test_surjectionproof_combine();
     test_bad_serialize();
     test_bad_parse();
 }

--- a/src/secp256k1/src/modules/surjection/tests_impl.h
+++ b/src/secp256k1/src/modules/surjection/tests_impl.h
@@ -430,7 +430,7 @@ static void test_no_used_inputs_verify(void) {
     /* create "borromean signature" which is just a hash of metadata (pubkeys, etc) in this case */
     secp256k1_generator_load(&output, &ephemeral_output_tag);
     secp256k1_generator_load(&inputs[0], &ephemeral_input_tags[0]);
-    secp256k1_surjection_genmessage(proof.data, inputs, 1, &output);
+    secp256k1_surjection_genmessage(proof.data, inputs, 1, proof.used_inputs, &output);
     secp256k1_sha256_initialize(&sha256_e0);
     secp256k1_sha256_write(&sha256_e0, proof.data, 32);
     secp256k1_sha256_finalize(&sha256_e0, proof.data);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -978,6 +978,28 @@ bool VerifyAmounts(const CCoinsViewCache& cache, const CTransaction& tx, std::ve
         if (secp256k1_surjectionproof_parse(secp256k1_ctx_verify_amounts, &proof, &ptxoutwit->vchSurjectionproof[0], ptxoutwit->vchSurjectionproof.size()) != 1)
             return false;
 
+        // If m_surj_wit is non-empty, validate using this list instead of input generators
+        if (!tx.wit.m_surj_wit.empty()) {
+            targetGenerators.resize(tx.wit.m_surj_wit.size());
+            for (size_t n = 0; n < tx.wit.m_surj_wit.size(); n++) {
+                const CAssetDerivation& asset_der = tx.wit.m_surj_wit[n];
+                uint256 entropy;
+                CAsset asset_type;
+                GenerateAssetEntropy(entropy, asset_der.m_prevout, asset_der.m_contract_hash);
+                if (asset_der.m_is_reissue_token) {
+                    CalculateReissuanceToken(asset_type, entropy, asset_der.m_is_blinded_token);
+                } else {
+                    CalculateAsset(asset_type, entropy);
+                }
+                secp256k1_generator gen;
+                if (secp256k1_generator_generate(secp256k1_ctx_verify_amounts, &gen, asset_type.begin()) == 0) {
+                    return false;
+                }
+                targetGenerators.push_back(gen);
+            }
+
+        }
+
         if (QueueCheck(pvChecks, new CSurjectionCheck(proof, targetGenerators, gen, cacheStore)) != SCRIPT_ERR_OK) {
             return false;
         }


### PR DESCRIPTION
This allows for more advanced surjection proof making when the outputs at signing time have assets the signer doesn't have access to. This is useful for CoinJoin style transactions, swaps, and MW transactions.

No wallet support or tests yet.

This makes sense to rebase on top of peg-in revamp as bitcoin is based on an actual issuance structure.

uses https://github.com/ElementsProject/secp256k1-zkp/pull/14