### PR TITLE
fix standardness check ordering of scriptpubkey

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -88,7 +88,7 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason, const bool witnes
     unsigned int nDataOut = 0;
     txnouttype whichType;
     BOOST_FOREACH(const CTxOut& txout, tx.vout) {
-        if (!txout.IsFee() && !::IsStandard(txout.scriptPubKey, whichType, witnessEnabled)) {
+        if (!::IsStandard(txout.scriptPubKey, whichType, witnessEnabled) && !txout.IsFee()) {
             reason = "scriptpubkey";
             return false;
         }


### PR DESCRIPTION
Currently if it encounters something like an OP_RETURN output, then hits a fee output, it will count another OP_RETURN output.

We may want to completely relax the OP_RETURN requirement, since we make those outputs for blinder-balancing as well.