### PR TITLE
Fix mainchain host arg name from mainchainhost to mainchainrpchost

### DIFF
--- a/src/callrpc.cpp
+++ b/src/callrpc.cpp
@@ -86,7 +86,7 @@ UniValue CallRPC(const std::string& strMethod, const UniValue& params, bool conn
     int port = GetArg(strport, BaseParams().RPCPort());
 
     if (connectToMainchain) {
-        strhost = "-mainchainhost";
+        strhost = "-mainchainrpchost";
         strport = "-mainchainrpcport";
         strpassword = "-mainchainrpcpassword";
         struser = "-mainchainrpcuser";


### PR DESCRIPTION
In the help message and the description of the [project site](https://www.elementsproject.org/sidechains/creating-your-own.html), the argument name which specify the host of the mainchain is `-mainchainrpchost`, but in the implementation it is `-mainchainhost`.

So change it from `-mainchainhost` to `-mainchainrpchost`.