### PR TITLE
Chainparams: Unify CRegTestParams and CCustomParams

### DIFF
--- a/contrib/devtools/check-doc.py
+++ b/contrib/devtools/check-doc.py
@@ -23,7 +23,7 @@ REGEX_DOC = re.compile(r'HelpMessageOpt\(\"(\-[^\"=]+?)(?:=|\")')
 # list unsupported, deprecated and duplicate args as they need no documentation
 SET_DOC_OPTIONAL = set(['-rpcssl', '-benchmark', '-h', '-help', '-socks', '-tor', '-debugnet', '-whitelistalwaysrelay', '-prematurewitness', '-walletprematurewitness', '-promiscuousmempoolflags', '-blockminsize'])
 
-SET_DOC_OPTIONAL.update(['-con_fpowallowmindifficultyblocks', '-con_fpownoretargeting', '-con_nsubsidyhalvinginterval', '-con_bip34height', '-con_bip65height', '-con_bip66height', '-con_npowtargettimespan', '-con_npowtargetspacing', '-con_nrulechangeactivationthreshold', '-con_nminerconfirmationwindow', '-con_powlimit', '-con_bip34hash', '-con_nminimumchainwork', '-con_defaultassumevalid', '-ndefaultport', '-npruneafterheight', '-fdefaultconsistencychecks', '-frequirestandard', '-fmineblocksondemand', '-mainchainrpccookiefile', '-testnet', '-ct_bits', '-ct_exponent', '-anyonecanspendaremine'])
+SET_DOC_OPTIONAL.update(['-con_fpowallowmindifficultyblocks', '-con_fpownoretargeting', '-con_nsubsidyhalvinginterval', '-con_bip34height', '-con_bip65height', '-con_bip66height', '-con_npowtargettimespan', '-con_npowtargetspacing', '-con_nrulechangeactivationthreshold', '-con_nminerconfirmationwindow', '-con_powlimit', '-con_parentpowlimit', '-con_bip34hash', '-con_nminimumchainwork', '-con_defaultassumevalid', '-ndefaultport', '-npruneafterheight', '-fdefaultconsistencychecks', '-frequirestandard', '-fmineblocksondemand', '-mainchainrpccookiefile', '-testnet', '-ct_bits', '-ct_exponent', '-anyonecanspendaremine', '-fminingrequirespeers', '-fmineblocksondemand'])
 
 def main():
   used = check_output(CMD_GREP_ARGS, shell=True)

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -92,7 +92,8 @@ public:
     const CScript& CoinbaseDestination() const { return scriptCoinbaseDestination; }
     bool anyonecanspend_aremine;
 protected:
-    CChainParams() {}
+    CChainParams() = delete;
+    CChainParams(const std::string& chain) : strNetworkID(chain) {}
 
     Consensus::Params consensus;
     CMessageHeader::MessageStartChars pchMessageStart;

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -12,7 +12,6 @@
 
 const std::string CBaseChainParams::MAIN = CHAINPARAMS_OLD_MAIN;
 const std::string CBaseChainParams::REGTEST = CHAINPARAMS_REGTEST;
-const std::string CBaseChainParams::CUSTOM = "custom";
 
 void AppendParamsHelpMessages(std::string& strUsage, bool debugHelp)
 {
@@ -26,44 +25,6 @@ void AppendParamsHelpMessages(std::string& strUsage, bool debugHelp)
     }
 }
 
-/**
- * Old Main network
- */
-class CBaseMainParams : public CBaseChainParams
-{
-public:
-    CBaseMainParams()
-    {
-        nRPCPort = 8332;
-        strDataDir = CHAINPARAMS_OLD_MAIN;
-    }
-};
-
-/**
- * Regression test
- */
-class CBaseRegTestParams : public CBaseChainParams
-{
-public:
-    CBaseRegTestParams()
-    {
-        nRPCPort = 7041;
-        nMainchainRPCPort = 18332;
-        strDataDir = CHAINPARAMS_REGTEST;
-    }
-};
-
-/** Custom tests */
-class CBaseCustomParams : public CBaseChainParams
-{
-public:
-    CBaseCustomParams()
-    {
-        nRPCPort = 18332;
-        strDataDir = "custom";
-    }
-};
-
 static std::unique_ptr<CBaseChainParams> globalChainBaseParams;
 
 const CBaseChainParams& BaseParams()
@@ -75,13 +36,8 @@ const CBaseChainParams& BaseParams()
 std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain)
 {
     if (chain == CBaseChainParams::MAIN)
-        return std::unique_ptr<CBaseChainParams>(new CBaseMainParams());
-    else if (chain == CBaseChainParams::REGTEST)
-        return std::unique_ptr<CBaseChainParams>(new CBaseRegTestParams());
-    else if (chain == CBaseChainParams::CUSTOM)
-        return std::unique_ptr<CBaseChainParams>(new CBaseCustomParams());
-    else
-        throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
+        return std::unique_ptr<CBaseChainParams>(new CBaseChainParams(chain, 8332, 18332));
+    return std::unique_ptr<CBaseChainParams>(new CBaseChainParams(chain, 7041, 18332));
 }
 
 void SelectBaseParams(const std::string& chain)

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -21,14 +21,15 @@ class CBaseChainParams
 public:
     static const std::string MAIN;
     static const std::string REGTEST;
-    static const std::string CUSTOM;
 
     const std::string& DataDir() const { return strDataDir; }
     int RPCPort() const { return nRPCPort; }
     int MainchainRPCPort() const { return nMainchainRPCPort; }
-protected:
-    CBaseChainParams() {}
+    CBaseChainParams() = delete;
+    CBaseChainParams(const std::string& data_dir, int rpc_port, int mainchain_rpc_port) :
+        nRPCPort(rpc_port), nMainchainRPCPort(mainchain_rpc_port), strDataDir(data_dir) {}
 
+private:
     int nRPCPort;
     int nMainchainRPCPort;
     std::string strDataDir;


### PR DESCRIPTION
Any class extending CChainParams directly should be fine.
Any class extending CRegTestParams should be fine, just extend CCustomParams instead (or just use the custom params if that's enough for your chain).

Dependencies:

~~- [ ] Chainparams: Every chain should have a name #307~~ 
- [x] Chainparams: Remove CElementsParams #266
