### PR TITLE
correctly account for witness data in peg-in fee calc, add test

### DIFF
--- a/qa/rpc-tests/pegging.py
+++ b/qa/rpc-tests/pegging.py
@@ -7,6 +7,7 @@ import sys
 import time
 import subprocess
 import shutil
+from decimal import Decimal
 
 if len(sys.argv) < 2:
     print("path to bitcoind must be included as argument")
@@ -108,6 +109,7 @@ with open(os.path.join(sidechain_datadir, "elements.conf"), 'w') as f:
         f.write("port="+str(sidechain1_p2p_port)+"\n")
         f.write("connect=localhost:"+str(sidechain2_p2p_port)+"\n")
         f.write("listen=1\n")
+        f.write("fallbackfee=0.0001\n")
 
 with open(os.path.join(sidechain2_datadir, "elements.conf"), 'w') as f:
         f.write("regtest=1\n")
@@ -127,6 +129,7 @@ with open(os.path.join(sidechain2_datadir, "elements.conf"), 'w') as f:
         f.write("port="+str(sidechain2_p2p_port)+"\n")
         f.write("connect=localhost:"+str(sidechain1_p2p_port)+"\n")
         f.write("listen=1\n")
+        f.write("fallbackfee=0.0001\n")
 
 try:
 
@@ -210,6 +213,12 @@ try:
     decoded = sidechain.decoderawtransaction(tx1["hex"])
     assert decoded["vin"][0]["is_pegin"] == True
     assert len(decoded["vin"][0]["pegin_witness"]) > 0
+    # Check that there's sufficient fee for the peg-in
+    vsize = decoded["vsize"]
+    fee_output = decoded["vout"][1]
+    fallbackfee_pervbyte = Decimal("0.00001")/Decimal("1000")
+    assert fee_output["scriptPubKey"]["type"] == "fee"
+    assert fee_output["value"] >= fallbackfee_pervbyte*vsize
 
     # Quick reorg checks of pegs
     sidechain.invalidateblock(blockhash[0])

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3669,8 +3669,9 @@ UniValue createrawpegin(const JSONRPCRequest& request)
     txinwit.m_pegin_witness = pegin_witness;
     mtx.wit.vtxinwit.push_back(txinwit);
 
-    // Estimate fee for transaction, decrement fee output(including estimated signature)
-    unsigned int nBytes = GetVirtualTransactionSize(mtx)+(72/WITNESS_SCALE_FACTOR);
+    // Estimate fee for transaction, decrement fee output(including witness data)
+    unsigned int nBytes = GetVirtualTransactionSize(mtx) +
+        (1+1+72+1+33/WITNESS_SCALE_FACTOR);
     CAmount nFeeNeeded = CWallet::GetMinimumFee(nBytes, nTxConfirmTarget, mempool);
 
     mtx.vout[0].nValue = mtx.vout[0].nValue.GetAmount() - nFeeNeeded;


### PR DESCRIPTION
Test sniped from @jonasnick 

this will only work for p2wpkh v0, so test should catch regressions that underpay