### PR TITLE
RPC: If a scriptPubKey is a pegout, show pegout info too

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -476,9 +476,10 @@ UniValue createrawtransaction(const JSONRPCRequest& request)
             "     ]\n"
             "2. \"outputs\"               (object, required) a json object with outputs\n"
             "    {\n"
-            "      \"address\": x.xxx,    (numeric or string, required) The key is the bitcoin address, the numeric value (can be string) is the " + CURRENCY_UNIT + " amount\n"
-            "      \"data\": \"hex\"      (string, required) The key is \"data\", the value is hex encoded data\n"
-            "      \"fee\": x.xxx           (numeric or string, required) The key is \"fee\", the value the fee output you want to add.\n"
+            "      \"address\": x.xxx,    (numeric or string, optional) The key is the bitcoin address, the numeric value (can be string) is the " + CURRENCY_UNIT + " amount\n"
+            "      \"data\": \"hex\"      (string, optional) The key is \"data\", the value is hex encoded data\n"
+            "      \"vdata\": \"hex\"     (string, optional) The key is \"vdata\", the value is an array of hex encoded data\n"
+            "      \"fee\": x.xxx         (numeric or string, optional) The key is \"fee\", the value the fee output you want to add.\n"
             "      ,...\n"
             "    }\n"
             "3. locktime                  (numeric, optional, default=0) Raw locktime. Non-0 value also locktime-activates inputs\n"
@@ -570,6 +571,16 @@ UniValue createrawtransaction(const JSONRPCRequest& request)
             std::vector<unsigned char> data = ParseHexV(sendTo[name_].getValStr(),"Data");
 
             CTxOut out(asset, 0, CScript() << OP_RETURN << data);
+            rawTx.vout.push_back(out);
+        } else if (name_ == "vdata") {
+            UniValue vdata = sendTo[name_].get_array();
+            CScript datascript = CScript() << OP_RETURN;
+            for (size_t i = 0; i < vdata.size(); i++) {
+                std::vector<unsigned char> data = ParseHexV(vdata[i].get_str(), "Data");
+                datascript << data;
+            }
+
+            CTxOut out(asset, 0, datascript);
             rawTx.vout.push_back(out);
         } else if (name_ == "fee") {
             CAmount nAmount = AmountFromValue(sendTo[name_]);

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -215,6 +215,43 @@ unsigned int CScript::GetSigOpCount(const CScript& scriptSig) const
     return subscript.GetSigOpCount(true);
 }
 
+bool CScript::IsPegoutScript(uint256& genesis_hash, CScript& pegout_scriptpubkey) const
+{
+    const_iterator pc = begin();
+    std::vector<unsigned char> data;
+    opcodetype opcode;
+
+    // OP_RETURN
+    if (!GetOp(pc, opcode, data) || opcode != OP_RETURN) {
+        return false;
+    }
+
+    if (!GetOp(pc, opcode, data) || data.size() != 32 ) {
+        return false;
+    }
+    genesis_hash = uint256(data);
+  
+    // Read in parent chain destination scriptpubkey
+    if (!GetOp(pc, opcode, data) || data.size() == 0 ) {
+        return false;
+    }
+    pegout_scriptpubkey = CScript(data.begin(), data.end());
+
+    return true;
+}
+
+bool CScript::IsPegoutScript(const uint256& genesis_hash_check) const
+{
+    uint256 genesis_hash;
+    CScript pegout_scriptpubkey;
+    // Ensure hash matches parent chain genesis block
+    if (this->IsPegoutScript(genesis_hash, pegout_scriptpubkey) &&
+        genesis_hash_check == genesis_hash) {
+        return true;
+    }
+    return false;
+}
+
 bool CScript::IsPayToScriptHash() const
 {
     // Extra-fast test for pay-to-script-hash CScripts:

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -637,6 +637,18 @@ public:
     bool IsPayToWitnessScriptHash() const;
     bool IsWitnessProgram(int& version, std::vector<unsigned char>& program) const;
 
+    /**
+     * Returns true if script follows OP_RETURN <genesis_block_hash> <pegout_scriptpubkey>
+     * and if correct it returns both things in the output parameters.
+     */
+    bool IsPegoutScript(uint256& genesis_hash, CScript& pegout_scriptpubkey) const;
+    /**
+     * Returns true if script follows OP_RETURN <genesis_block_hash> <destination_scriptpubkey>
+     * it may also have additional pushes at the end. It checks
+     * the genesis hash matches the specified one.
+     */
+    bool IsPegoutScript(const uint256& genesis_hash) const;
+
     /** Called by IsStandardTx and P2SH/BIP62 VerifyScript (which makes it consensus-critical). */
     bool IsPushOnly(const_iterator pc) const;
     bool IsPushOnly() const;


### PR DESCRIPTION
This is to give more rich info on RPC calls that return info about scriptPubKey's in outputs if the scriptPubKey is a pegout.

~~Needs tests.~~