### PR TITLE
fix segfault when block from disk has pegin failure

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3117,13 +3117,13 @@ bool static ConnectTip(CValidationState& state, const CChainParams& chainparams,
                     pblocktree->ReadInvalidBlockQueue(vinvalidBlocks);
                     bool blockAlreadyInvalid = false;
                     BOOST_FOREACH(uint256& hash, vinvalidBlocks) {
-                        if (hash == pblock->GetHash()) {
+                        if (hash == blockConnecting.GetHash()) {
                             blockAlreadyInvalid = true;
                             break;
                         }
                     }
                     if (!blockAlreadyInvalid) {
-                        vinvalidBlocks.push_back(pblock->GetHash());
+                        vinvalidBlocks.push_back(blockConnecting.GetHash());
                         pblocktree->WriteInvalidBlockQueue(vinvalidBlocks);
                     }
                 }


### PR DESCRIPTION
pblock is nullptr in those cases

Follow-on PRs will introduce a way of inducing these failures more frequently for testing purposes.