### PR TITLE
add command line arg to induce peg-in validation failure

### DIFF
--- a/src/callrpc.cpp
+++ b/src/callrpc.cpp
@@ -180,6 +180,10 @@ UniValue CallRPC(const std::string& strMethod, const UniValue& params, bool conn
 
 bool IsConfirmedBitcoinBlock(const uint256& hash, int nMinConfirmationDepth)
 {
+    // Argument for more robust testing of intermittant peg-in failures
+    int failure_chance = GetArg("-chanceofpeginfailure", 0);
+    if (failure_chance > rand()%100) return false;
+
     try {
         UniValue params(UniValue::VARR);
         params.push_back(hash.GetHex());

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -513,6 +513,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-fedpegscript=<hex>", _("Change federated peg to use a different script.") +
             " " + _("This creates a new chain with a different genesis block."));
         strUsage += HelpMessageOpt("-peginconfirmationdepth", strprintf(_("Pegin claims must be this deep to be considered valid. (default: %d)"), DEFAULT_PEGIN_CONFIRMATION_DEPTH));
+        strUsage += HelpMessageOpt("-chanceofpeginfailure", strprintf(_("Pegins will fail with the percent chance given this argument. This is used for testing robustness to intermittant bitcoind communication failures. (default :%d"), 0));
     }
     strUsage += HelpMessageOpt("-validatepegin", strprintf(_("Validate pegin claims. All functionaries must run this. (default: %u)"), DEFAULT_VALIDATE_PEGIN));
     strUsage += HelpMessageOpt("-mainchainrpchost=<addr>", strprintf("The address which the daemon will try to connect to validate peg-ins, if enabled. (default: cookie auth)"));


### PR DESCRIPTION
this allows the user to more directly test both the software itself and integrations using it for intermittent peg-in validation failures.

https://github.com/ElementsProject/elements/pull/320 exposed the need for this