### PR TITLE
Blocksign: Enter emergency mode when invalid blocks have a valid proof

### DIFF
--- a/contrib/devtools/check-doc.py
+++ b/contrib/devtools/check-doc.py
@@ -25,6 +25,8 @@ SET_DOC_OPTIONAL = set(['-rpcssl', '-benchmark', '-h', '-help', '-socks', '-tor'
 
 SET_DOC_OPTIONAL.update(['-con_fpowallowmindifficultyblocks', '-con_fpownoretargeting', '-con_nsubsidyhalvinginterval', '-con_bip34height', '-con_bip65height', '-con_bip66height', '-con_npowtargettimespan', '-con_npowtargetspacing', '-con_nrulechangeactivationthreshold', '-con_nminerconfirmationwindow', '-con_powlimit', '-con_parentpowlimit', '-con_bip34hash', '-con_nminimumchainwork', '-con_defaultassumevalid', '-parentgenesisblockhash', '-ndefaultport', '-npruneafterheight', '-fdefaultconsistencychecks', '-frequirestandard', '-fmineblocksondemand', '-mainchainrpccookiefile', '-testnet', '-ct_bits', '-ct_exponent', '-anyonecanspendaremine', '-fminingrequirespeers', '-fmineblocksondemand', '-con_mandatorycoinbase', '-con_has_parent_chain'])
 
+SET_DOC_OPTIONAL.update(['-testemergencymode', '-ignoreemergencymode'])
+
 def main():
   used = check_output(CMD_GREP_ARGS, shell=True)
   docd = check_output(CMD_GREP_DOCS, shell=True)

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -107,6 +107,7 @@ testScripts = [
     'feature_fedpeg.py',
     'default_asset_name.py',
     'assetdir.py',
+    'emergency.py',
 
     # Elements' specially adapted tests second
     'blockchain.py',

--- a/qa/rpc-tests/emergency.py
+++ b/qa/rpc-tests/emergency.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018-2018 The Elements Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    bitcoind_processes,
+    start_nodes,
+    start_node,
+    stop_nodes,
+)
+
+import os
+import tempfile
+import time
+
+class EmergencyModeTest(BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        # Both -testemergencymode and -ignoreemergencymode shouldn't do anything
+        self.extra_args = [['-debug', '-testemergencymode', '-ignoreemergencymode']]
+
+    def setup_network(self):
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args)
+
+    def run_test(self):
+
+        print("Ensure that node is not already in emergency mode.")
+        emergency_file_path = self.options.tmpdir + "/node0/elementsregtest/ERROR_elementsregtest_HAS_SUFFERED_A_CRITICAL_FAILURE_AND_MAY_BE_UNSAFE_CORRECT_ERROR_BEFORE_REMOVING_THIS_FILE"
+        assert(not os.path.isfile(emergency_file_path))
+        
+        self.nodes[0].generate(1) # Just to double-check the node works
+        stop_nodes(self.nodes)
+
+        self.extra_args = [['-debug', '-testemergencymode']]
+        log_stderr = tempfile.SpooledTemporaryFile(max_size=2**16)
+        try:
+            self.nodes[0] = start_node(0, self.options.tmpdir, self.extra_args[0], stderr=log_stderr)
+            raise Exception("Node shouldn't start correctly with -testemergencymode")
+        except Exception as e:
+            return_code = bitcoind_processes[0].wait()
+            assert(return_code == 1)
+            assert(str(e) == "bitcoind exited with status 1 during initialization")
+            assert(os.path.isfile(emergency_file_path))
+            log_stderr.seek(0)
+            stderr_out = log_stderr.read().decode('utf-8')
+            assert(stderr_out == 'Error: Using -testemergencymode\n'
+                   'Error: Error: A fatal internal error occurred, see debug.log for details\n')
+            log_stderr.close()
+
+        os.remove(emergency_file_path)
+        # Once the file is removed it starts normally again
+        self.extra_args = [['-debug']]
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args)
+        
+        print("Success!")
+
+if __name__ == '__main__':
+    EmergencyModeTest().main()

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -333,7 +333,7 @@ def _rpchost_to_args(rpchost):
         rv += ['-rpcport=' + rpcport]
     return rv
 
-def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=None, chain='elementsregtest'):
+def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=None, chain='elementsregtest', stderr=sys.stderr):
     """
     Start a bitcoind and return RPC connection to it
     """
@@ -342,7 +342,7 @@ def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=
         binary = os.getenv("ELEMENTSD", "elementsd")
     args = [ binary, '-chain='+chain, "-datadir="+datadir, "-server", "-keypool=1", "-discover=0", "-rest", "-mocktime="+str(get_mocktime()) ]
     if extra_args is not None: args.extend(extra_args)
-    bitcoind_processes[i] = subprocess.Popen(args)
+    bitcoind_processes[i] = subprocess.Popen(args, stderr=stderr)
     if os.getenv("PYTHON_DEBUG", ""):
         print("start_node: bitcoind started, waiting for RPC to come up")
     url = rpc_url(i, rpchost)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -904,6 +904,11 @@ bool AppInitParameterInteraction()
 {
     const CChainParams& chainparams = Params();
     // ********************************************************* Step 2: parameter interactions
+    CValidationState state;
+    if (GetBoolArg("-testemergencymode", false)) {
+        SetEmergencyMode(state, chainparams, "Testing emergency mode, the node should abort.", "Using -testemergencymode");
+    }
+    InitEmergencyMode(chainparams);
 
     // also see: InitParameterInteraction()
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -213,6 +213,16 @@ static const unsigned int DEFAULT_CHECKLEVEL = 3;
 // Setting the target to > than 550MB will make it likely we can respect the target.
 static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
 
+/**
+ * Create the emergency file and aborts the node.
+ */
+void SetEmergencyMode(CValidationState& state, const CChainParams& chainparams, const std::string& strMessage, const std::string& userMessage="");
+/**
+ * Checks if the emergency file exists and if so aborts the node. This
+ * is intended to be used on initialization.
+ */
+void InitEmergencyMode(const CChainParams& chainparams);
+
 /** 
  * Process an incoming block. This only returns after the best known valid
  * block is made active. Note that it does not, however, guarantee that the


### PR DESCRIPTION
If the block.scriptPubKey (aka proof.challenge) is OP_RETURN (the default for regtest-like chains), then the node doesn't enter emergency mode. 

Dependencies:

- [ ] Introduce emergency mode #323