### PR TITLE
simplify non-depth peg-in validity checking

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2357,7 +2357,7 @@ CScript calculate_contract(const CScript& federationRedeemScript, const CScript&
     return scriptDestination;
 }
 
-bool IsValidPeginWitness(const CScriptWitness& pegin_witness, const COutPoint& prevout) {
+bool IsValidPeginWitness(const CScriptWitness& pegin_witness, const COutPoint& prevout, bool check_depth) {
 
     // Format on stack is as follows:
     // 1) value - the value of the pegin output
@@ -2473,8 +2473,7 @@ bool IsValidPeginWitness(const CScriptWitness& pegin_witness, const COutPoint& p
     }
 
     // Finally, validate peg-in via rpc call
-    if (GetBoolArg("-validatepegin", DEFAULT_VALIDATE_PEGIN)) {
-        // TODO-PEGIN return useful error message
+    if (check_depth && GetBoolArg("-validatepegin", DEFAULT_VALIDATE_PEGIN)) {
         return IsConfirmedBitcoinBlock(merkle_block.header.GetHash(), GetArg("-peginconfirmationdepth", DEFAULT_PEGIN_CONFIRMATION_DEPTH));
     }
     return true;

--- a/src/validation.h
+++ b/src/validation.h
@@ -263,7 +263,7 @@ void ThreadScriptCheck();
 /** Check if bitcoind connection via RPC is correctly working*/
 bool BitcoindRPCCheck(bool init);
 /** Checks pegin witness for validity */
-bool IsValidPeginWitness(const CScriptWitness& pegin_witness, const COutPoint& prevout);
+bool IsValidPeginWitness(const CScriptWitness& pegin_witness, const COutPoint& prevout, bool check_depth = true);
 /** Extracts an output from pegin witness for evaluation as a normal output */
 CTxOut GetPeginOutputFromWitness(const CScriptWitness& pegin_witness);
 /** Check whether we are doing an initial block download (synchronizing from disk or network) */

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3662,9 +3662,7 @@ UniValue createrawpegin(const JSONRPCRequest& request)
 
     // Peg-in witness isn't valid, even though the block header is(without depth check)
     // We re-check depth before returning with more descriptive result
-    if (GetBoolArg("-validatepegin", DEFAULT_VALIDATE_PEGIN) &&
-            !IsConfirmedBitcoinBlock(merkleBlock.header.GetHash(), 0) &&
-    !IsValidPeginWitness(pegin_witness, mtx.vin[0].prevout)) {
+    if (!IsValidPeginWitness(pegin_witness, mtx.vin[0].prevout, false)) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Constructed peg-in witness is invalid.");
     }
 


### PR DESCRIPTION
previous claimpegin logic was simply wrong(if user isn't validating peg-in depth, it silently squashes other issues), and this is more modular.