### PR TITLE
Fix timing for bitcoin shutdown in pegging.py

### DIFF
--- a/qa/rpc-tests/pegging.py
+++ b/qa/rpc-tests/pegging.py
@@ -280,6 +280,8 @@ try:
 
     print ("Now test failure to validate peg-ins based on intermittant bitcoind rpc failure")
     bitcoin2.stop()
+    # give bitcoin2 time to stop
+    time.sleep(1)
     txid = bitcoin.sendtoaddress(addrs["mainchain_address"], 1)
     bitcoin.generate(12)
     proof = bitcoin.gettxoutproof([txid])


### PR DESCRIPTION
Without this commit pegging.py fails on my machine more than 50% of the cases.