### PR TITLE
getnewblockhex: add ability to pass over transactions based on mempoo…

### DIFF
--- a/qa/rpc-tests/mempool_packages.py
+++ b/qa/rpc-tests/mempool_packages.py
@@ -42,6 +42,25 @@ class MempoolPackagesTest(BitcoinTestFramework):
         return (txid, send_value)
 
     def run_test(self):
+
+        # Create transaction with 3-second block delay, should fail to enter the template
+        txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
+        block = self.nodes[0].getnewblockhex(required_age=3)
+        self.nodes[0].submitblock(block)
+        assert(txid in self.nodes[0].getrawmempool())
+        time.sleep(3)
+        block = self.nodes[0].getnewblockhex(required_age=3)
+        self.nodes[0].submitblock(block)
+        assert(txid not in self.nodes[0].getrawmempool())
+        # Once more with no delay (default is 0, just testing default arg)
+        txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
+        block = self.nodes[0].getnewblockhex(required_age=0)
+        self.nodes[0].submitblock(block)
+        assert(txid not in self.nodes[0].getrawmempool())
+        assert_raises_message(JSONRPCException, "required_wait must be non-negative.", self.nodes[0].getnewblockhex, -1)
+
+        print("Rest of entire test is disabled due to fee outputs etc")
+
         return #TODO
         ''' Mine some blocks and have them mature. '''
         self.nodes[0].generate(101)
@@ -251,6 +270,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         self.nodes[1].invalidateblock(self.nodes[1].getbestblockhash())
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
         sync_blocks(self.nodes)
+
 
 if __name__ == '__main__':
     MempoolPackagesTest().main()

--- a/src/miner.h
+++ b/src/miner.h
@@ -165,7 +165,7 @@ private:
 public:
     BlockAssembler(const CChainParams& chainparams);
     /** Construct a new block template with coinbase to scriptPubKeyIn */
-    std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn, bool fMineWitnessTx=true);
+    std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn, bool fMineWitnessTx=true, int required_age_in_secs=0);
 
 private:
     // utility functions
@@ -180,7 +180,7 @@ private:
     /** Add transactions based on feerate including unconfirmed ancestors
       * Increments nPackagesSelected / nDescendantsUpdated with corresponding
       * statistics from the package selection (for logging statistics). */
-    void addPackageTxs(int &nPackagesSelected, int &nDescendantsUpdated);
+    void addPackageTxs(int &nPackagesSelected, int &nDescendantsUpdated, int required_age_in_secs=0);
 
     // helper function for addPriorityTxs
     /** Test if tx will still "fit" in the block */

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -138,6 +138,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "bumpfee", 1, "options" },
     { "testproposedblock", 1, "acceptnonstd" },
     { "sendtomainchain", 2, "subtractfeefromamount"},
+    { "getnewblockhex", 0, "required_age"},
     // Echo with conversion (For testing only)
     { "echojson", 0, "arg0" },
     { "echojson", 1, "arg1" },


### PR DESCRIPTION
…l age

Can be used to improve block convergence performance with compact blocks and other mempool sharing based schemes.

related to https://github.com/ElementsProject/elements/issues/338

