### PR TITLE
Cache latest successful testproposedblock txns, use in compact blocks

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -342,6 +342,9 @@ std::string gbt_vb_name(const Consensus::DeploymentPos pos) {
     return s;
 }
 
+extern void AddToCompactBlockProposal(const CTransactionRef& tx);
+extern void ClearCompactBlockProposal();
+
 UniValue testproposedblock(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
@@ -378,6 +381,12 @@ UniValue testproposedblock(const JSONRPCRequest& request)
         if (strRejectReason.empty())
             throw JSONRPCError(RPC_VERIFY_ERROR, state.IsInvalid() ? "Block proposal was invalid" : "Error checking block proposal");
         throw JSONRPCError(RPC_VERIFY_ERROR, strRejectReason);
+    }
+
+    // Cache the block; we're going to almost certainly use the contents
+    ClearCompactBlockProposal();
+    for (auto& transaction : block.vtx) {
+        AddToCompactBlockProposal(transaction);
     }
 
     const CChainParams& chainparams = Params();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3074,6 +3074,8 @@ struct ConnectTrace {
     std::vector<std::pair<CBlockIndex*, std::shared_ptr<const CBlock> > > blocksConnected;
 };
 
+extern void ClearCompactBlockProposal();
+
 /**
  * Connect a new block to chainActive. pblock is either NULL or a pointer to a CBlock
  * corresponding to pindexNew, to bypass loading it again from disk.
@@ -3132,6 +3134,8 @@ bool static ConnectTip(CValidationState& state, const CChainParams& chainparams,
 
             return error("ConnectTip(): ConnectBlock %s failed", pindexNew->GetBlockHash().ToString());
         }
+        // We connected a block, clear out the proposal cache as it's likely useless
+        ClearCompactBlockProposal();
         nTime3 = GetTimeMicros(); nTimeConnectTotal += nTime3 - nTime2;
         LogPrint("bench", "  - Connect total: %.2fms [%.2fs]\n", (nTime3 - nTime2) * 0.001, nTimeConnectTotal * 0.000001);
         bool flushed = view.Flush();


### PR DESCRIPTION
This should result in "perfect" compact blocks, assuming whichever block was most recently tested becomes the finalized block after signing.

For high bandwidth compact block peers in a federation setting this should result in 0.5 RTT for all block announcements.
