### PR TITLE
RPC: Signblock: Support signblock info on rpc/blockchain

### DIFF
--- a/qa/rpc-tests/blockchain.py
+++ b/qa/rpc-tests/blockchain.py
@@ -48,7 +48,13 @@ class BlockchainTest(BitcoinTestFramework):
         self._test_getblockheader()
         self._test_getblockheader(getblock=True)
         self._test_getblockchaininfo()
+        self._test_getdifficulty()
         self.nodes[0].verifychain(4, 0)
+
+    def _test_getdifficulty(self):
+        assert_raises_message(JSONRPCException,
+                              "getdifficulty is DEPRECATED for elements (which lacks pow), always returns this error",
+                              self.nodes[0].getdifficulty)
 
     def _test_gettxoutsetinfo(self):
         node = self.nodes[0]
@@ -86,18 +92,18 @@ class BlockchainTest(BitcoinTestFramework):
         assert isinstance(header['mediantime'], int)
         assert isinstance(header['version'], int)
         assert isinstance(int(header['versionHex'], 16), int)
-        assert 'nonce' in header
-        assert 'bits' in header
-        assert 'difficulty' in header
-        assert 'chainwork' in header
+        assert 'nonce' not in header
+        assert 'bits' not in header
+        assert 'difficulty' not in header
+        assert 'chainwork' not in header
 
     def _test_getblockchaininfo(self):
         besthash = self.nodes[0].getbestblockhash()
         res = self.nodes[0].getblockchaininfo()
 
         assert_equal(res['chain'], 'elementsregtest')
-        assert 'difficulty' in res
-        assert 'chainwork' in res
+        assert 'difficulty' not in res
+        assert 'chainwork' not in res
         assert_equal(res['blocks'], 200)
         assert_equal(res['headers'], 200)
         assert_equal(res['bestblockhash'], besthash)

--- a/qa/rpc-tests/blockchain.py
+++ b/qa/rpc-tests/blockchain.py
@@ -96,12 +96,16 @@ class BlockchainTest(BitcoinTestFramework):
         assert 'bits' not in header
         assert 'difficulty' not in header
         assert 'chainwork' not in header
+        assert 'signblock_witness_asm' in header
+        assert 'signblock_witness_hex' in header
 
     def _test_getblockchaininfo(self):
         besthash = self.nodes[0].getbestblockhash()
         res = self.nodes[0].getblockchaininfo()
 
         assert_equal(res['chain'], 'elementsregtest')
+        assert_equal(res['signblock_asm'], '1')
+        assert_equal(res['signblock_hex'], '51')
         assert 'difficulty' not in res
         assert 'chainwork' not in res
         assert_equal(res['blocks'], 200)

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -100,27 +100,3 @@ void ResetProof(CBlockHeader& block)
 {
     block.proof.solution.clear();
 }
-
-double GetChallengeDifficulty(const CBlockIndex* blockindex)
-{
-    return 1;
-}
-
-std::string GetChallengeStr(const CBlockIndex& block)
-{
-    return ScriptToAsmStr(block.proof.challenge);
-}
-
-std::string GetChallengeStrHex(const CBlockIndex& block)
-{
-    return ScriptToAsmStr(block.proof.challenge);
-}
-
-uint32_t GetNonce(const CBlockHeader& block)
-{
-    return 1;
-}
-
-void SetNonce(CBlockHeader& block, uint32_t nNonce)
-{
-}

--- a/src/pow.h
+++ b/src/pow.h
@@ -19,23 +19,14 @@ class CScript;
 class CWallet;
 class uint256;
 
-
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
 bool CheckBitcoinProof(uint256 hash, unsigned int nBits);
 bool CheckProof(const CBlockHeader& block, const Consensus::Params&);
-/** Scans nonces looking for a hash with at least some zero bits */
-bool MaybeGenerateProof(CBlockHeader* pblock, CWallet* pwallet);
 void ResetProof(CBlockHeader& block);
 bool CheckChallenge(const CBlockHeader& block, const CBlockIndex& indexLast, const Consensus::Params&);
 void ResetChallenge(CBlockHeader& block, const CBlockIndex& indexLast, const Consensus::Params&);
 
+bool MaybeGenerateProof(CBlockHeader* pblock, CWallet* pwallet);
 CScript CombineBlockSignatures(const CBlockHeader& header, const CScript& scriptSig1, const CScript& scriptSig2);
-
-/** Avoid using these functions when possible */
-double GetChallengeDifficulty(const CBlockIndex* blockindex);
-std::string GetChallengeStr(const CBlockIndex& block);
-std::string GetChallengeStrHex(const CBlockIndex& block);
-uint32_t GetNonce(const CBlockHeader& block);
-void SetNonce(CBlockHeader& block, uint32_t nNonce);
 
 #endif // BITCOIN_POW_H

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -9,6 +9,7 @@
 #include "checkpoints.h"
 #include "coins.h"
 #include "consensus/validation.h"
+#include "core_io.h"
 #include "validation.h"
 #include "policy/policy.h"
 #include "primitives/transaction.h"
@@ -45,20 +46,6 @@ static CUpdatedBlock latestblock;
 extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry);
 void ScriptPubKeyToJSON(const CScript& scriptPubKey, UniValue& out, bool fIncludeHex);
 
-double GetDifficulty(const CBlockIndex* blockindex)
-{
-    // Floating point number that is a multiple of the minimum difficulty,
-    // minimum difficulty = 1.0.
-    if (blockindex == NULL)
-    {
-        if (chainActive.Tip() == NULL)
-            return 1.0;
-        else
-            blockindex = chainActive.Tip();
-    }
-    return GetChallengeDifficulty(blockindex);
-}
-
 UniValue blockheaderToJSON(const CBlockIndex* blockindex)
 {
     UniValue result(UniValue::VOBJ);
@@ -74,10 +61,6 @@ UniValue blockheaderToJSON(const CBlockIndex* blockindex)
     result.push_back(Pair("merkleroot", blockindex->hashMerkleRoot.GetHex()));
     result.push_back(Pair("time", (int64_t)blockindex->nTime));
     result.push_back(Pair("mediantime", (int64_t)blockindex->GetMedianTimePast()));
-    result.push_back(Pair("nonce", (uint64_t)GetNonce(blockindex->GetBlockHeader())));
-    result.push_back(Pair("bits", GetChallengeStr(blockindex->GetBlockHeader())));
-    result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
-    result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));
 
     if (blockindex->pprev)
         result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));
@@ -118,10 +101,6 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     result.push_back(Pair("tx", txs));
     result.push_back(Pair("time", block.GetBlockTime()));
     result.push_back(Pair("mediantime", (int64_t)blockindex->GetMedianTimePast()));
-    result.push_back(Pair("nonce", (uint64_t)GetNonce(block)));
-    result.push_back(Pair("bits", GetChallengeStr(block)));
-    result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
-    result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));
 
     if (blockindex->pprev)
         result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));
@@ -299,19 +278,7 @@ UniValue waitforblockheight(const JSONRPCRequest& request)
 
 UniValue getdifficulty(const JSONRPCRequest& request)
 {
-    if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
-            "getdifficulty\n"
-            "\nReturns the proof-of-work difficulty as a multiple of the minimum difficulty.\n"
-            "\nResult:\n"
-            "n.nnn       (numeric) the proof-of-work difficulty as a multiple of the minimum difficulty.\n"
-            "\nExamples:\n"
-            + HelpExampleCli("getdifficulty", "")
-            + HelpExampleRpc("getdifficulty", "")
-        );
-
-    LOCK(cs_main);
-    return GetDifficulty();
+    throw runtime_error("getdifficulty is DEPRECATED for elements (which lacks pow), always returns this error");
 }
 
 std::string EntryDescriptionString()
@@ -633,10 +600,6 @@ UniValue getblockheader(const JSONRPCRequest& request)
             "  \"merkleroot\" : \"xxxx\", (string) The merkle root\n"
             "  \"time\" : ttt,          (numeric) The block time in seconds since epoch (Jan 1 1970 GMT)\n"
             "  \"mediantime\" : ttt,    (numeric) The median block time in seconds since epoch (Jan 1 1970 GMT)\n"
-            "  \"nonce\" : n,           (numeric) The nonce\n"
-            "  \"bits\" : \"1d00ffff\", (string) The bits\n"
-            "  \"difficulty\" : x.xxx,  (numeric) The difficulty\n"
-            "  \"chainwork\" : \"0000...1f3\"     (string) Expected number of hashes required to produce the current chain (in hex)\n"
             "  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n"
             "  \"nextblockhash\" : \"hash\",      (string) The hash of the next block\n"
             "}\n"
@@ -721,10 +684,6 @@ static UniValue getblock(const JSONRPCRequest& request)
             "  ],\n"
             "  \"time\" : ttt,          (numeric) The block time in seconds since epoch (Jan 1 1970 GMT)\n"
             "  \"mediantime\" : ttt,    (numeric) The median block time in seconds since epoch (Jan 1 1970 GMT)\n"
-            "  \"nonce\" : n,           (numeric) The nonce\n"
-            "  \"bits\" : \"1d00ffff\", (string) The bits\n"
-            "  \"difficulty\" : x.xxx,  (numeric) The difficulty\n"
-            "  \"chainwork\" : \"xxxx\",  (string) Expected number of hashes required to produce the chain up to this block (in hex)\n"
             "  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n"
             "  \"nextblockhash\" : \"hash\"       (string) The hash of the next block\n"
             "}\n"
@@ -1077,21 +1036,10 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
             "  \"blocks\": xxxxxx,         (numeric) the current number of blocks processed in the server\n"
             "  \"headers\": xxxxxx,        (numeric) the current number of headers we have validated\n"
             "  \"bestblockhash\": \"...\", (string) the hash of the currently best block\n"
-            "  \"difficulty\": xxxxxx,     (numeric) the current difficulty\n"
             "  \"mediantime\": xxxxxx,     (numeric) median time for the current best block\n"
             "  \"verificationprogress\": xxxx, (numeric) estimate of verification progress [0..1]\n"
-            "  \"chainwork\": \"xxxx\"     (string) total amount of work in active chain, in hexadecimal\n"
             "  \"pruned\": xx,             (boolean) if the blocks are subject to pruning\n"
             "  \"pruneheight\": xxxxxx,    (numeric) lowest-height complete block stored\n"
-            "  \"softforks\": [            (array) status of softforks in progress\n"
-            "     {\n"
-            "        \"id\": \"xxxx\",        (string) name of softfork\n"
-            "        \"version\": xx,         (numeric) block version\n"
-            "        \"reject\": {            (object) progress toward rejecting pre-softfork blocks\n"
-            "           \"status\": xx,       (boolean) true if threshold reached\n"
-            "        },\n"
-            "     }, ...\n"
-            "  ],\n"
             "  \"bip9_softforks\": {          (object) status of BIP9 softforks in progress\n"
             "     \"xxxx\" : {                (string) name of the softfork\n"
             "        \"status\": \"xxxx\",    (string) one of \"defined\", \"started\", \"locked_in\", \"active\", \"failed\"\n"
@@ -1108,16 +1056,15 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
         );
 
     LOCK(cs_main);
+    CBlockIndex* tip = chainActive.Tip();
 
     UniValue obj(UniValue::VOBJ);
     obj.push_back(Pair("chain",                 Params().NetworkIDString()));
     obj.push_back(Pair("blocks",                (int)chainActive.Height()));
     obj.push_back(Pair("headers",               pindexBestHeader ? pindexBestHeader->nHeight : -1));
-    obj.push_back(Pair("bestblockhash",         chainActive.Tip()->GetBlockHash().GetHex()));
-    obj.push_back(Pair("difficulty",            (double)GetDifficulty()));
-    obj.push_back(Pair("mediantime",            (int64_t)chainActive.Tip()->GetMedianTimePast()));
-    obj.push_back(Pair("verificationprogress",  GuessVerificationProgress(Params().TxData(), chainActive.Tip())));
-    obj.push_back(Pair("chainwork",             chainActive.Tip()->nChainWork.GetHex()));
+    obj.push_back(Pair("bestblockhash",         tip->GetBlockHash().GetHex()));
+    obj.push_back(Pair("mediantime",            (int64_t)tip->GetMedianTimePast()));
+    obj.push_back(Pair("verificationprogress",  GuessVerificationProgress(Params().TxData(), tip)));
     obj.push_back(Pair("pruned",                fPruneMode));
 
     const Consensus::Params& consensusParams = Params().GetConsensus();
@@ -1128,7 +1075,7 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
 
     if (fPruneMode)
     {
-        CBlockIndex *block = chainActive.Tip();
+        CBlockIndex *block = tip;
         while (block && block->pprev && (block->pprev->nStatus & BLOCK_HAVE_DATA))
             block = block->pprev;
 
@@ -1602,7 +1549,7 @@ static UniValue getblockstats(const JSONRPCRequest& request)
         if (tx->IsCoinBase()) {
             continue;
         }
-        
+
         if (loop_outputs) {
             for (const CTxOut& out : tx->vout) {
                 if (out.IsFee() && out.nAsset.GetAsset() == asset) {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -61,6 +61,8 @@ UniValue blockheaderToJSON(const CBlockIndex* blockindex)
     result.push_back(Pair("merkleroot", blockindex->hashMerkleRoot.GetHex()));
     result.push_back(Pair("time", (int64_t)blockindex->nTime));
     result.push_back(Pair("mediantime", (int64_t)blockindex->GetMedianTimePast()));
+    result.push_back(Pair("signblock_witness_asm", ScriptToAsmStr(blockindex->proof.solution)));
+    result.push_back(Pair("signblock_witness_hex", HexStr(blockindex->proof.solution.begin(), blockindex->proof.solution.end())));
 
     if (blockindex->pprev)
         result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));
@@ -101,6 +103,8 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     result.push_back(Pair("tx", txs));
     result.push_back(Pair("time", block.GetBlockTime()));
     result.push_back(Pair("mediantime", (int64_t)blockindex->GetMedianTimePast()));
+    result.push_back(Pair("signblock_witness_asm", ScriptToAsmStr(blockindex->proof.solution)));
+    result.push_back(Pair("signblock_witness_hex", HexStr(blockindex->proof.solution.begin(), blockindex->proof.solution.end())));
 
     if (blockindex->pprev)
         result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));
@@ -600,6 +604,8 @@ UniValue getblockheader(const JSONRPCRequest& request)
             "  \"merkleroot\" : \"xxxx\", (string) The merkle root\n"
             "  \"time\" : ttt,          (numeric) The block time in seconds since epoch (Jan 1 1970 GMT)\n"
             "  \"mediantime\" : ttt,    (numeric) The median block time in seconds since epoch (Jan 1 1970 GMT)\n"
+            "  \"signblock_witness_asm\":\"asm\", (string) scriptSig for block signing (asm)'\n"
+            "  \"signblock_witness_hex\":\"hex\", (string) scriptSig for block signing (hex)'\n"
             "  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n"
             "  \"nextblockhash\" : \"hash\",      (string) The hash of the next block\n"
             "}\n"
@@ -684,6 +690,8 @@ static UniValue getblock(const JSONRPCRequest& request)
             "  ],\n"
             "  \"time\" : ttt,          (numeric) The block time in seconds since epoch (Jan 1 1970 GMT)\n"
             "  \"mediantime\" : ttt,    (numeric) The median block time in seconds since epoch (Jan 1 1970 GMT)\n"
+            "  \"signblock_witness_asm\":\"asm\", (string) scriptSig for block signing (asm)'\n"
+            "  \"signblock_witness_hex\":\"hex\", (string) scriptSig for block signing (hex)'\n"
             "  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n"
             "  \"nextblockhash\" : \"hash\"       (string) The hash of the next block\n"
             "}\n"
@@ -1033,6 +1041,8 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
             "\nResult:\n"
             "{\n"
             "  \"chain\": \"xxxx\",        (string) current network name as defined in BIP70 (main, test, regtest)\n"
+            "  \"signblock_asm\":\"asm\",  (string) scriptPubKey for block signing (asm)'\n"
+            "  \"signblock_hex\":\"hex\",  (string) scriptPubKey for block signing (hex)'\n"
             "  \"blocks\": xxxxxx,         (numeric) the current number of blocks processed in the server\n"
             "  \"headers\": xxxxxx,        (numeric) the current number of headers we have validated\n"
             "  \"bestblockhash\": \"...\", (string) the hash of the currently best block\n"
@@ -1066,6 +1076,8 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
     obj.push_back(Pair("mediantime",            (int64_t)tip->GetMedianTimePast()));
     obj.push_back(Pair("verificationprogress",  GuessVerificationProgress(Params().TxData(), tip)));
     obj.push_back(Pair("pruned",                fPruneMode));
+    obj.push_back(Pair("signblock_asm", ScriptToAsmStr(tip->proof.challenge)));
+    obj.push_back(Pair("signblock_hex", HexStr(tip->proof.challenge.begin(), tip->proof.challenge.end())));
 
     const Consensus::Params& consensusParams = Params().GetConsensus();
     UniValue bip9_softforks(UniValue::VOBJ);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -273,7 +273,6 @@ UniValue getmininginfo(const JSONRPCRequest& request)
     obj.push_back(Pair("currentblocksize", (uint64_t)nLastBlockSize));
     obj.push_back(Pair("currentblockweight", (uint64_t)nLastBlockWeight));
     obj.push_back(Pair("currentblocktx",   (uint64_t)nLastBlockTx));
-    obj.push_back(Pair("difficulty",       (double)GetDifficulty()));
     obj.push_back(Pair("errors",           GetWarnings("statusbar")));
     obj.push_back(Pair("networkhashps",    getnetworkhashps(request)));
     obj.push_back(Pair("pooledtx",         (uint64_t)mempool.size()));
@@ -759,7 +758,6 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     result.push_back(Pair("coinbaseaux", aux));
     result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0]->vout[0].nValue.GetAmount()));
     result.push_back(Pair("longpollid", chainActive.Tip()->GetBlockHash().GetHex() + i64tostr(nTransactionsUpdatedLast)));
-    result.push_back(Pair("target", GetChallengeStrHex(*pblock)));
     result.push_back(Pair("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1));
     result.push_back(Pair("mutable", aMutable));
     result.push_back(Pair("noncerange", "00000000ffffffff"));
@@ -776,7 +774,6 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
         result.push_back(Pair("weightlimit", (int64_t)MAX_BLOCK_WEIGHT));
     }
     result.push_back(Pair("curtime", pblock->GetBlockTime()));
-    result.push_back(Pair("bits", GetChallengeStr(*pblock)));
     result.push_back(Pair("height", (int64_t)(pindexPrev->nHeight+1)));
 
     if (!pblocktemplate->vchCoinbaseCommitment.empty() && fSupportsSegwit) {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -774,6 +774,8 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
         result.push_back(Pair("weightlimit", (int64_t)MAX_BLOCK_WEIGHT));
     }
     result.push_back(Pair("curtime", pblock->GetBlockTime()));
+    result.push_back(Pair("signblock_asm", ScriptToAsmStr(pblock->proof.challenge)));
+    result.push_back(Pair("signblock_hex", HexStr(pblock->proof.challenge.begin(), pblock->proof.challenge.end())));
     result.push_back(Pair("height", (int64_t)(pindexPrev->nHeight+1)));
 
     if (!pblocktemplate->vchCoinbaseCommitment.empty() && fSupportsSegwit) {

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -107,7 +107,6 @@ UniValue getinfo(const JSONRPCRequest& request)
     if(g_connman)
         obj.push_back(Pair("connections",   (int)g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL)));
     obj.push_back(Pair("proxy",         (proxy.IsValid() ? proxy.proxy.ToStringIPPort() : string())));
-    obj.push_back(Pair("difficulty",    (double)GetDifficulty()));
     obj.push_back(Pair("chain",         Params().NetworkIDString()));
 #ifdef ENABLE_WALLET
     if (pwalletMain) {

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -198,7 +198,6 @@ extern std::vector<unsigned char> ParseHexO(const UniValue& o, std::string strKe
 extern int64_t nWalletUnlockTime;
 extern CAmount AmountFromValue(const UniValue& value);
 extern UniValue ValueFromAmount(const CAmount& amount);
-extern double GetDifficulty(const CBlockIndex* blockindex = NULL);
 extern std::string HelpRequiringPassphrase();
 extern std::string HelpExampleCli(const std::string& methodname, const std::string& args);
 extern std::string HelpExampleRpc(const std::string& methodname, const std::string& args);


### PR DESCRIPTION
Bigger refactor than I initially thought.
But basically still cleaning up pow stuff we don't need, and including a few new blocksign-related fields that replace those and document them. 

Doesn't come with tests, but if it's not only rpc, then nack, please.

Dependencies:

- [x] QA: Reactivate and improve rpc_blockchain tests https://github.com/ElementsProject/elements/pull/365
~~- [ ] RPC: Stop providing useless fake pow data #366~~
