### PR TITLE
Make the “21 m to op_true in coinbase” customizable per chain

### DIFF
--- a/contrib/assets_tutorial/elements1.conf
+++ b/contrib/assets_tutorial/elements1.conf
@@ -37,3 +37,6 @@ validatepegin=1
 mainchainrpcport=18888
 mainchainrpcuser=user3
 mainchainrpcpassword=password3
+
+# Free money to make testing easier
+initialfreecoins=2100000000000000

--- a/contrib/assets_tutorial/elements2.conf
+++ b/contrib/assets_tutorial/elements2.conf
@@ -16,3 +16,5 @@ mainchainrpcport=18888
 mainchainrpcuser=user3
 mainchainrpcpassword=password3
 validatepegin=1
+
+initialfreecoins=2100000000000000

--- a/qa/rpc-tests/pegging.py
+++ b/qa/rpc-tests/pegging.py
@@ -118,6 +118,7 @@ with open(os.path.join(sidechain_datadir, "elements.conf"), 'w') as f:
         f.write("connect=localhost:"+str(sidechain2_p2p_port)+"\n")
         f.write("listen=1\n")
         f.write("fallbackfee=0.0001\n")
+        f.write("initialfreecoins=2100000000000000\n")
 
 with open(os.path.join(sidechain2_datadir, "elements.conf"), 'w') as f:
         f.write("regtest=1\n")
@@ -137,6 +138,7 @@ with open(os.path.join(sidechain2_datadir, "elements.conf"), 'w') as f:
         f.write("connect=localhost:"+str(sidechain1_p2p_port)+"\n")
         f.write("listen=1\n")
         f.write("fallbackfee=0.0001\n")
+        f.write("initialfreecoins=2100000000000000\n")
 
 def test_pegout(parent_chain_addr, sidechain):
     pegout_txid = sidechain.sendtomainchain(parent_chain_addr, 1)

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -193,6 +193,7 @@ def initialize_datadir(dirname, n):
         f.write("port="+str(p2p_port(n))+"\n")
         f.write("rpcport="+str(rpc_port(n))+"\n")
         f.write("listenonion=0\n")
+        f.write("initialfreecoins=2100000000000000\n")
     return datadir
 
 def rpc_auth_pair(n):

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -10,7 +10,6 @@
 #include "tinyformat.h"
 #include "util.h"
 #include "utilstrencodings.h"
-#include "amount.h"
 #include "crypto/sha256.h"
 
 #include <assert.h>
@@ -133,6 +132,7 @@ protected:
         consensus.mandatory_coinbase_destination = StrHexToScriptWithDefault(GetArg("-con_mandatorycoinbase", ""), CScript()); // Blank script allows any coinbase destination
         // bitcoin regtest is the parent chain by default
         parentGenesisBlockHash = uint256S(GetArg("-parentgenesisblockhash", "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"));
+        initialFreeCoins = GetArg("-initialfreecoins", 0);
 
         nDefaultPort = GetArg("-ndefaultport", 7042);
         nPruneAfterHeight = GetArg("-npruneafterheight", 1000);
@@ -174,7 +174,9 @@ public:
         CalculateAsset(consensus.pegged_asset, entropy);
 
         genesis = CreateGenesisBlock(consensus, strNetworkID, 1296688602, genesisChallengeScript, 1);
-        AppendInitialIssuance(genesis, COutPoint(uint256(commit), 0), parentGenesisBlockHash, 100, 21000000000000, 0, 0, CScript() << OP_TRUE);
+        if (initialFreeCoins != 0) {
+            AppendInitialIssuance(genesis, COutPoint(uint256(commit), 0), parentGenesisBlockHash, 100, initialFreeCoins/100, 0, 0, CScript() << OP_TRUE);
+        }
         consensus.hashGenesisBlock = genesis.GetHash();
 
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -152,6 +152,11 @@ public:
         CScript genesisChallengeScript = StrHexToScriptWithDefault(GetArg("-signblockscript", ""), defaultRegtestScript);
         consensus.fedpegScript = StrHexToScriptWithDefault(GetArg("-fedpegscript", ""), defaultRegtestScript);
 
+        if (!anyonecanspend_aremine) {
+            assert("Anyonecanspendismine was marked as false, but they are in the genesis block"
+                    && initialFreeCoins == 0);
+        }
+
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 999999999999ULL;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_CHAINPARAMS_H
 #define BITCOIN_CHAINPARAMS_H
 
+#include "amount.h"
 #include "chainparamsbase.h"
 #include "consensus/params.h"
 #include "primitives/block.h"
@@ -103,6 +104,7 @@ protected:
     std::string strNetworkID;
     CBlock genesis;
     uint256 parentGenesisBlockHash;
+    CAmount initialFreeCoins;
     std::vector<SeedSpec6> vFixedSeeds;
     bool fMiningRequiresPeers;
     bool fDefaultConsistencyChecks;

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -51,6 +51,8 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::st
         if (!fedpegscript.empty()) {
             SoftSetArg("-fedpegscript", fedpegscript);
         }
+        // MAX_MONEY
+        SoftSetArg("-initialfreecoins", "2100000000000000");
         SelectParams(chainName);
         noui_connect();
 }


### PR DESCRIPTION
Default of 0.
Having free coins without a pegin may be useful for regtest-like networks, but for production or testnet-like networks, having 21 M extra allows anyone to empty the sidechain.

