### PR TITLE
Rework control flow in VerifyAmount()

### DIFF
--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -43,8 +43,6 @@ public:
                     return;
                 /* Explicit value */
                 case 1:
-                /* Trust-me! asset generation */
-                case 0xff:
                     vchCommitment.resize(nExplicitSize);
                     break;
                 /* Confidential commitment */
@@ -79,8 +77,7 @@ public:
 
     bool IsValid() const
     {
-        return IsNull() || IsExplicit() || IsCommitment()
-            || (vchCommitment.size()==nExplicitSize && vchCommitment[0]==0xff);
+        return IsNull() || IsExplicit() || IsCommitment();
     }
 
     friend bool operator==(const CConfidentialCommitment& a, const CConfidentialCommitment& b)

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -657,6 +657,8 @@ public:
      * Returns whether the script is guaranteed to fail at execution,
      * regardless of the initial stack. This allows outputs to be pruned
      * instantly when entering the UTXO set. This includes fee outputs.
+     *
+     * This is consensus-critical because it is called by VerifyAmounts().
      */
     bool IsUnspendable() const
     {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -805,46 +805,44 @@ bool VerifyAmounts(const CCoinsViewCache& cache, const CTransaction& tx, std::ve
         }
 
         // Process issuance of asset
-        if (!issuance.nAmount.IsNull()) {
 
+        if (!issuance.nAmount.IsValid()) {
+            return false;
+        }
+        if (!issuance.nAmount.IsNull()) {
             // Generate asset generator and add to list of surjection targets
             ret = secp256k1_generator_generate(secp256k1_ctx_verify_amounts, &gen, assetID.begin());
             assert(ret == 1);
-            CConfidentialAsset issuanceAsset;
-            issuanceAsset.vchCommitment.resize(CConfidentialAsset::nCommittedSize);
-            secp256k1_generator_serialize(secp256k1_ctx_verify_amounts, &issuanceAsset.vchCommitment[0], &gen);
             targetGenerators.push_back(gen);
 
             // Build value commitment and add to tally
             if (issuance.nAmount.IsExplicit()) {
-                if (!MoneyRange(issuance.nAmount.GetAmount())) {
+                if (!MoneyRange(issuance.nAmount.GetAmount()) || issuance.nAmount.GetAmount() == 0) {
                     return false;
-                }
-
-                if (issuance.nAmount.GetAmount() == 0) {
-                    continue;
                 }
 
                 ret = secp256k1_pedersen_commit(secp256k1_ctx_verify_amounts, &commit, explBlinds, issuance.nAmount.GetAmount(), &gen);
                 // The explBlinds are all 0, and the amount is not 0. So secp256k1_pedersen_commit does not fail.
                 assert(ret == 1);
             }
-            else if (issuance.nAmount.IsCommitment()) {
+            else {
+                assert(issuance.nAmount.IsCommitment());
+                // Verify range proof
+                std::vector<unsigned char> vchAssetCommitment(CConfidentialAsset::nExplicitSize);
+                secp256k1_generator_serialize(secp256k1_ctx_verify_amounts, &vchAssetCommitment[0], &gen);
+                if (QueueCheck(pvChecks, new CRangeCheck(&issuance.nAmount, tx.wit.vtxinwit[i].vchIssuanceAmountRangeproof, vchAssetCommitment, CScript(), cacheStore)) != SCRIPT_ERR_OK) {
+                    return false;
+                }
+
+                // Here we have issuance.nAmount.IsCommitment() == true
                 if (secp256k1_pedersen_commitment_parse(secp256k1_ctx_verify_amounts, &commit, &issuance.nAmount.vchCommitment[0]) != 1) {
                     return false;
                 }
-            } else {
-                return false;
             }
 
             vData.push_back(commit);
             vpCommitsIn.push_back(p);
             p++;
-
-            // Rangecheck must be done for blinded amount
-            if (issuance.nAmount.IsCommitment() && QueueCheck(pvChecks, new CRangeCheck(&issuance.nAmount, tx.wit.vtxinwit[i].vchIssuanceAmountRangeproof, issuanceAsset.vchCommitment, CScript(), cacheStore)) != SCRIPT_ERR_OK) {
-                return false;
-            }
         }
 
         // Only initial issuance can have reissuance tokens

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -825,9 +825,9 @@ bool VerifyAmounts(const CCoinsViewCache& cache, const CTransaction& tx, std::ve
                     continue;
                 }
 
-                if (secp256k1_pedersen_commit(secp256k1_ctx_verify_amounts, &commit, explBlinds, issuance.nAmount.GetAmount(), &gen) != 1) {
-                    return false;
-                }
+                ret = secp256k1_pedersen_commit(secp256k1_ctx_verify_amounts, &commit, explBlinds, issuance.nAmount.GetAmount(), &gen);
+                // The explBlinds are all 0, and the amount is not 0. So secp256k1_pedersen_commit does not fail.
+                assert(ret == 1);
             }
             else if (issuance.nAmount.IsCommitment()) {
                 if (secp256k1_pedersen_commitment_parse(secp256k1_ctx_verify_amounts, &commit, &issuance.nAmount.vchCommitment[0]) != 1) {
@@ -867,9 +867,10 @@ bool VerifyAmounts(const CCoinsViewCache& cache, const CTransaction& tx, std::ve
                     continue;
                 }
 
-                if (secp256k1_pedersen_commit(secp256k1_ctx_verify_amounts, &commit, explBlinds, issuance.nInflationKeys.GetAmount(), &gen) != 1) {
-                    return false;
-                }
+                // Here we have issuance.nAmount.IsCommitment() == true
+                ret = secp256k1_pedersen_commit(secp256k1_ctx_verify_amounts, &commit, explBlinds, issuance.nInflationKeys.GetAmount(), &gen);
+                // The explBlinds are all 0, and the amount is not 0. So secp256k1_pedersen_commit does not fail.
+                assert(ret == 1);
             }
             else if (issuance.nInflationKeys.IsCommitment()) {
                 if (secp256k1_pedersen_commitment_parse(secp256k1_ctx_verify_amounts, &commit, &issuance.nInflationKeys.vchCommitment[0]) != 1) {
@@ -928,8 +929,9 @@ bool VerifyAmounts(const CCoinsViewCache& cache, const CTransaction& tx, std::ve
                 }
             }
 
-            if (secp256k1_pedersen_commit(secp256k1_ctx_verify_amounts, &commit, explBlinds, val.GetAmount(), &gen) != 1)
-                return false;
+            ret = secp256k1_pedersen_commit(secp256k1_ctx_verify_amounts, &commit, explBlinds, val.GetAmount(), &gen);
+            // The explBlinds are all 0, and the amount is not 0. So secp256k1_pedersen_commit does not fail.
+            assert(ret == 1);
         }
         else if (val.IsCommitment()) {
             if (secp256k1_pedersen_commitment_parse(secp256k1_ctx_verify_amounts, &commit, &val.vchCommitment[0]) != 1)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -854,6 +854,9 @@ bool VerifyAmounts(const CCoinsViewCache& cache, const CTransaction& tx, std::ve
             return false;
         }
         if (!issuance.nAmount.IsNull()) {
+            if (i >= tx.wit.vtxinwit.size()) {
+                return false;
+            }
             if (!VerifyIssuanceAmount(commit, gen, assetID, issuance.nAmount, tx.wit.vtxinwit[i].vchIssuanceAmountRangeproof, pvChecks, cacheStore)) {
                 return false;
             }
@@ -878,6 +881,9 @@ bool VerifyAmounts(const CCoinsViewCache& cache, const CTransaction& tx, std::ve
                 return false;
             }
 
+            if (i >= tx.wit.vtxinwit.size()) {
+                return false;
+            }
             if (!VerifyIssuanceAmount(commit, gen, assetTokenID, issuance.nInflationKeys, tx.wit.vtxinwit[i].vchInflationKeysRangeproof, pvChecks, cacheStore)) {
                 return false;
             }

--- a/src/validation.h
+++ b/src/validation.h
@@ -399,11 +399,14 @@ bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoins
 /**
  * Verify the transaction's outputs spend exactly what its inputs provide, plus some excess amount.
  *
+ * This also checks rangeproofs, surjection proofs, and issuances of assets and re-issuance tokens.
+ * The function assumes that IsValidPeginWitness() returns true on all peg-in inputs.
+ *
  * @param[in] view   CCoinsViewCache to find necessary outputs
  * @param[in] tx     transaction for which we are checking totals
- * @param[in] pvChecks  multithreaded rangeproof and commitment checker
- * @param[in] cacheStore signal if rangeproof verification should be cached
- * @return  True if totals are identical
+ * @param[in] pvChecks  multithreaded rangeproof, surjection proof and commitment checker
+ * @param[in] cacheStore signal if rangeproof and surjection proof verification should be cached
+ * @return  True if verification was not aborted and totals are identical
 */
 bool VerifyAmounts(const CCoinsViewCache& cache, const CTransaction& tx, std::vector<CCheck*>* pvChecks = NULL, const bool cacheStore = false);
 


### PR DESCRIPTION
This mainly improves and simplifies the logic control flow VerifyAmount(). It fixes an issue that appeared when 0 units of an asset (or a re-issuance token) are issued using an explicit commitment. In this case, we skipped over some checks that should be present for correct verification.

Since the issue is present both when issuing assets and when issuing re-issuance tokens, and the code is similar, this PR extracts the relevant code into a (non-exported) helper function.

On the way, it fixes a potential access to a non-existent input witness.
