### PR TITLE
Remove overflow checks for explicit input amounts

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1851,7 +1851,6 @@ bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoins
         if (!inputs.HaveInputs(tx))
             return state.Invalid(false, 0, "", "Inputs unavailable");
 
-        CAmount nValueIn = 0;
         for (unsigned int i = 0; i < tx.vin.size(); i++)
         {
             const COutPoint &prevout = tx.vin[i].prevout;
@@ -1880,14 +1879,6 @@ bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoins
                             REJECT_INVALID, "bad-txns-premature-spend-of-coinbase",
                             strprintf("tried to spend coinbase at depth %d", nSpendHeight - coins->nHeight));
                 }
-
-                // Check for negative or overflow input values
-                const CConfidentialValue& value = coins->vout[prevout.n].nValue;
-                if (value.IsExplicit()) {
-                    nValueIn += value.GetAmount();
-                    if (!MoneyRange(value.GetAmount()) || !MoneyRange(nValueIn))
-                        return state.DoS(100, false, REJECT_INVALID, "bad-txns-inputvalues-outofrange");
-                }
             }
 
         }
@@ -1897,8 +1888,7 @@ bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoins
             return state.DoS(100, false, REJECT_INVALID, "bad-txns-fee-outofrange");
         }
         if (fScriptChecks && !VerifyAmounts(inputs, tx, pvChecks, cacheStore)) {
-            return state.DoS(100, false, REJECT_INVALID, "bad-txns-in-ne-out", false,
-                strprintf("value in (%s) != value out", FormatMoney(nValueIn)));
+            return state.DoS(100, false, REJECT_INVALID, "bad-txns-in-ne-out", false, "value in != value out");
         }
 
     return true;


### PR DESCRIPTION
This removes checks from the pre-asset era that reject amounts on the
input side of a transaction if these amounts overflow. The checks are
superficial because VerifyAmounts() already rejects input amounts that
could potentially overflow.

One of the removed checks is wrong because it rejects legitimate
transactions that spend more than MAX_MONEY asset units altogether,
even if those units belong to different assets. For example, a
transaction spending MAX_MONEY units of an asset "apple" and MAX_MONEY
units of an asset "orange" was previously rejected because the code
literally added apples and oranges in this case.