### PR TITLE
support new multisig template in wallet for Solver, signing, and sign…

### DIFF
--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -55,6 +55,7 @@ enum txnouttype
     TX_WITNESS_V0_KEYHASH,
     TX_TRUE,
     TX_FEE,
+    TX_MONSTER,
 };
 
 class CNoDestination {


### PR DESCRIPTION
…ature combining

This gets us to a maximum of n-of-67ish multisigs within segwit, I cap it at 50 in case someone wants to pattern match this inside additional logic, eg CSV backoffs.