### PR TITLE
[WIP] Move "nonce" field to witness field, rename it "memo"

### DIFF
--- a/src/blind.h
+++ b/src/blind.h
@@ -24,7 +24,7 @@ void CreateValueCommitment(CConfidentialValue& value, secp256k1_pedersen_commitm
  * Currently there is only a sidechannel message in the rangeproof so a valid rangeproof must
  * be included in the pair to recover value and asset data.
  */
-bool UnblindConfidentialPair(const CKey& blinding_key, const CConfidentialValue& value, const CConfidentialAsset& asset, const CConfidentialNonce& nNonce, const CScript& committedScript, const std::vector<unsigned char>& vchRangeproof, CAmount& amount_out, uint256& blinding_factor_out, CAsset& asset_out, uint256& asset_blinding_factor_out);
+bool UnblindConfidentialPair(const CKey& blinding_key, const CConfidentialValue& value, const CConfidentialAsset& asset, const CConfidentialMemo& memo, const CScript& committedScript, const std::vector<unsigned char>& vchRangeproof, CAmount& amount_out, uint256& blinding_factor_out, CAsset& asset_out, uint256& asset_blinding_factor_out);
 
 /* Returns the number of ouputs that were successfully blinded.
  * In many cases a `0` can be fixed by adding an additional output.

--- a/src/coins.h
+++ b/src/coins.h
@@ -90,9 +90,6 @@ public:
     void FromTx(const CTransaction &tx, int nHeightIn) {
         fCoinBase = tx.IsCoinBase();
         vout = tx.vout;
-        for (size_t i = 0; i < vout.size(); i++) {
-            vout[i].nNonce.SetNull();
-        }
         nHeight = nHeightIn;
         nVersion = tx.nVersion;
         ClearUnspendable();

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -132,10 +132,10 @@ public:
  * A 33-byte data field that typically is used to convey to the
  * recipient the ECDH ephemeral key (an EC point) for deriving the
  * transaction output blinding factor. */
-class CConfidentialNonce : public CConfidentialCommitment<33, 2, 3>
+class CConfidentialMemo : public CConfidentialCommitment<33, 2, 3>
 {
 public:
-    CConfidentialNonce() { SetNull(); }
+    CConfidentialMemo() { SetNull(); }
 };
 
 /** An output of a transaction.  It contains the public key that the next input
@@ -146,7 +146,6 @@ class CTxOut
 public:
     CConfidentialAsset nAsset;
     CConfidentialValue nValue;
-    CConfidentialNonce nNonce;
     CScript scriptPubKey;
 
     CTxOut()
@@ -162,7 +161,6 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(nAsset);
         READWRITE(nValue);
-        READWRITE(nNonce);
         READWRITE(*(CScriptBase*)(&scriptPubKey));
     }
 
@@ -170,13 +168,12 @@ public:
     {
         nAsset.SetNull();
         nValue.SetNull();
-        nNonce.SetNull();
         scriptPubKey.clear();
     }
 
     bool IsNull() const
     {
-        return nAsset.IsNull() && nValue.IsNull() && nNonce.IsNull() && scriptPubKey.empty();
+        return nAsset.IsNull() && nValue.IsNull() && scriptPubKey.empty();
     }
 
     CAmount GetDustThreshold(const CFeeRate &minRelayTxFee) const
@@ -231,7 +228,6 @@ public:
     {
         return (a.nAsset == b.nAsset &&
                 a.nValue == b.nValue &&
-                a.nNonce == b.nNonce &&
                 a.scriptPubKey == b.scriptPubKey);
     }
 
@@ -544,6 +540,7 @@ class CTxOutWitness
 public:
     std::vector<unsigned char> vchSurjectionproof;
     std::vector<unsigned char> vchRangeproof;
+    CConfidentialMemo m_memo;
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -149,8 +149,6 @@ public:
     CConfidentialNonce nNonce;
     CScript scriptPubKey;
 
-    // FIXME: Inventory the places this constructor is called, and make sure
-    //        that `nAsset` is being set appropriately.
     CTxOut()
     {
         SetNull();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -905,12 +905,9 @@ bool VerifyAmounts(const CCoinsViewCache& cache, const CTransaction& tx, std::ve
     {
         const CConfidentialValue& val = tx.vout[i].nValue;
         const CConfidentialAsset& asset = tx.vout[i].nAsset;
-        if (!asset.IsValid())
+        if (!asset.IsValid() || !val.IsValid()) {
             return false;
-        if (!val.IsValid())
-            return false;
-        if (!tx.vout[i].nNonce.IsValid())
-            return false;
+        }
 
         if (asset.IsExplicit()) {
             ret = secp256k1_generator_generate(secp256k1_ctx_verify_amounts, &gen, asset.GetAsset().begin());

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -456,7 +456,7 @@ private:
     * @param[in]    nonce - The nonce used to ECDH with the blinding key. This is null for issuance as blinding key is directly used as nonce
     * @param[in]    scriptPubKey - The script being committed to by the rangeproof
     */
-    void GetBlindingData(const unsigned int mapIndex, const std::vector<unsigned char>& vchRangeproof, const CConfidentialValue& confValue, const CConfidentialAsset& confAsset, const CConfidentialNonce nonce, const CScript& scriptPubKey, CAmount* pamountOut, CPubKey* ppubkeyOut, uint256* pblindingfactorOut, CAsset* pAssetOut, uint256* passetBlindingFactorOut) const;
+    void GetBlindingData(const unsigned int mapIndex, const std::vector<unsigned char>& vchRangeproof, const CConfidentialValue& confValue, const CConfidentialAsset& confAsset, const CConfidentialMemo& nonce, const CScript& scriptPubKey, CAmount* pamountOut, CPubKey* ppubkeyOut, uint256* pblindingfactorOut, CAsset* pAssetOut, uint256* passetBlindingFactorOut) const;
     void WipeUnknownBlindingData() const;
 
 public:
@@ -1023,7 +1023,7 @@ public:
     CKey GetBlindingKey(const CScript* script) const;
     CPubKey GetBlindingPubKey(const CScript& script) const;
 
-    void ComputeBlindingData(const CConfidentialValue& confValue, const CConfidentialAsset& confAsset, const CConfidentialNonce& nonce, const CScript& scriptPubKey, const std::vector<unsigned char>& vchRangeproof, CAmount& amount, CPubKey& pubkey, uint256& blindingfactor, CAsset& asset, uint256& assetBlindingFactor) const;
+    void ComputeBlindingData(const CConfidentialValue& confValue, const CConfidentialAsset& confAsset, const CConfidentialMemo& nonce, const CScript& scriptPubKey, const std::vector<unsigned char>& vchRangeproof, CAmount& amount, CPubKey& pubkey, uint256& blindingfactor, CAsset& asset, uint256& assetBlindingFactor) const;
 
     /** Mark a transaction as replaced by another transaction (e.g., BIP 125). */
     bool MarkReplaced(const uint256& originalHash, const uint256& newHash);


### PR DESCRIPTION
This is the free-form field that allows recipients of outputs to do ECDH and recover their blinding factors/amounts. Previously consensus only cared that the field was of a valid format.

This field was serialized inside the witness at one point but was not put under any signature, resulting in malleability, so it was switched back to the CTxOut structure up until now which makes input signatures cover it.

This PR completely removes the format of this field from consensus purview, and moves it into the output witness structure.

TODO:
1) Make tests pass
2) Put this field under the rangeproof signature to avoid malleability
3) Only allow non-null values when rangeproof exists
4) Copy constructor of the memo field seems to result in a segfault in some cases. This was happened when the wallet was making copies accidentally to deblind the values of the genesis block(they are unblinded, but it went down this code path). I'd like to resolve this as well.