### PR TITLE
[build] Add missing stuff to clean-local

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -236,4 +236,4 @@ DISTCHECK_CONFIGURE_FLAGS = --enable-man
 
 clean-local:
 	rm -rf coverage_percent.txt test_bitcoin.coverage/ total.coverage/ qa/tmp/ cache/ $(OSX_APP)
-	rm -rf qa/pull-tester/__pycache__
+	rm -rf qa/pull-tester/__pycache__ qa/rpc-tests/test_framework/__pycache__ src/test/__pycache__ qa/cache


### PR DESCRIPTION
Remaining of cache may interfere the expected execution of the ```rpc-test.py```
Recently, it occurred after pull #355 (and ```make clean``` et al.) to my enviroment.
This patch make ```make clean-local``` remove the ```qa/cache``` and ```__pycache__``` folders.

cherry-picking form: https://github.com/bitcoin/bitcoin/pull/11842