### PR TITLE
WIP: RPC: Make generate work with a single signer

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -104,6 +104,7 @@ testScripts = [
     'signed_blockchain.py',
     'initial_reissuance_token.py',
     'feature_blocksign.py',
+    'feature_onesigner.py',
     'default_asset_name.py',
     'assetdir.py',
 

--- a/qa/rpc-tests/feature_blocksign.py
+++ b/qa/rpc-tests/feature_blocksign.py
@@ -20,6 +20,13 @@ def wif(pk):
 # The signblockscript is a Bitcoin Script k-of-n multisig script.
 def make_signblockscript(num_nodes, required_signers, keys):
     assert(num_nodes >= required_signers)
+
+    if num_nodes == 1 and required_signers == 1:
+        # OP_CHECKSIG = ac
+        script = '41' + codecs.encode(keys[0].get_pubkey(), 'hex_codec').decode("utf-8") + 'ac'
+        print('signblockscript', script)
+        return script
+
     script = "{}".format(50 + required_signers)
     for i in range(num_nodes):
         k = keys[i]
@@ -80,6 +87,11 @@ class BlockSignTest(test_framework.BitcoinTestFramework):
             util.assert_equal(n.getblockcount(), expected_height)
 
     def mine_block(self):
+        # Special simpler case for 1-of-1
+        if self.num_nodes == 1 and self.required_signers == 1:
+            self.nodes[0].generate(1)
+            return
+
         # mine block in round robin sense: depending on the block number, a node
         # is selected to create the block, others sign it and the selected node
         # broadcasts it

--- a/qa/rpc-tests/feature_onesigner.py
+++ b/qa/rpc-tests/feature_onesigner.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+from feature_blocksign import BlockSignTest
+
+if __name__ == '__main__':
+    BlockSignTest(num_nodes=1, required_signers=1).main()


### PR DESCRIPTION
It would simplify and optimize things for a single signer chain by using generate with OP_CHECKSIG (there's no gain in p2pkh since the pubkey is public after signing block 1) compared to using  signblock + combineblocksigs + submitblock with OP_CHECKMULTISIG 1 of 1 (which seems a little bit absurd in principle, but it is the only option avaliable now for single signer chains afaik).

This will currently fail its own tests, I don't quite get why this isn't working.

Suggestions welcomed, or if you find the bug, that would be much better.