### PR TITLE
Enable setting of default asset name and initial reissuance token count

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -102,6 +102,7 @@ testScripts = [
     # Elements-specific tests first
     'confidential_transactions.py',
     'signed_blockchain.py',
+    'initial_reissuance_token.py',
     'feature_blocksign.py',
     'default_asset_name.py',
 

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -103,6 +103,7 @@ testScripts = [
     'confidential_transactions.py',
     'signed_blockchain.py',
     'feature_blocksign.py',
+    'default_asset_name.py',
 
     # Elements' specially adapted tests second
     'blockchain.py',

--- a/qa/rpc-tests/default_asset_name.py
+++ b/qa/rpc-tests/default_asset_name.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test chain initialisation when specifying default asset name.
+#
+
+from decimal import Decimal
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.authproxy import JSONRPCException
+from test_framework.util import *
+
+class NamedDefaultAssetTest(BitcoinTestFramework):
+    """
+    Test creation of default asset is named according to defaultpeggedasset parameter
+
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+
+        #Set default asset name
+        self.node_args = [["-defaultpeggedassetname=testasset"], ["-defaultpeggedassetname=testasset"]]
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, self.node_args)
+        connect_nodes_bi(self.nodes,0,1)
+        self.is_network_split = False
+        self.sync_all()
+
+    def run_test(self):
+        #Claim all anyone-can-spend 'bitcoin'
+        self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 21000000, "", "", True, "testasset")
+        self.nodes[0].generate(101)
+        self.sync_all()
+
+        #Check the default asset is named correctly
+        walletinfo1 = self.nodes[0].getwalletinfo()
+        assert_equal(walletinfo1["balance"]["testasset"], 21000000)
+
+        #Send some of the default asset to the second node
+        self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1, "", "", False, "testasset")
+        self.nodes[0].generate(101)
+        self.sync_all()
+
+        #Check balances are correct and asset is named correctly
+        walletinfo1 = self.nodes[0].getwalletinfo()
+        assert_equal(walletinfo1["balance"]["testasset"], 20999999)
+
+        walletinfo2 = self.nodes[1].getwalletinfo()
+        assert_equal(walletinfo2["balance"]["testasset"], 1)
+
+if __name__ == '__main__':
+    NamedDefaultAssetTest().main()

--- a/qa/rpc-tests/initial_reissuance_token.py
+++ b/qa/rpc-tests/initial_reissuance_token.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test chain initialisation when specifying number of reissuance tokens to issue.
+#
+
+from decimal import Decimal
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.authproxy import JSONRPCException
+from test_framework.util import *
+
+class InitialReissuanceTokenTest(BitcoinTestFramework):
+    """
+    Test creation of initial reissuance token for default asset on chain set up
+
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+
+        #Set number of initial reissuance tokens and also set initial free coins less than max so we can reissue more later
+        self.node_args = [["-initialreissuancetokens=200000000", "-initialfreecoins=2000000000000000"], ["-initialreissuancetokens=200000000", "-initialfreecoins=2000000000000000"]]
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, self.node_args)
+        connect_nodes_bi(self.nodes,0,1)
+        self.is_network_split = False
+        self.sync_all()
+
+    def run_test(self):
+        #Claim all anyone-can-spend 'bitcoin'
+        self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 20000000, "", "", True)
+        self.nodes[0].generate(101)
+        self.sync_all()
+
+        walletinfo=self.nodes[0].getwalletinfo()
+        balance=walletinfo['balance']
+        token=""
+
+        #Get the hex of the reissuance token
+        for i in balance:
+            token = i
+            if token != "bitcoin":
+                break
+
+        #Claim all anyone-can-spend reissuance tokens
+        self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 2, "", "", False, token)
+        self.nodes[0].generate(101)
+        self.sync_all()
+
+        #Check balances
+        walletinfo1 = self.nodes[0].getwalletinfo()
+        assert_equal(walletinfo1["balance"]["bitcoin"], 20000000)
+        assert_equal(walletinfo1["balance"][token], 2)
+
+        #Reissue some of the default asset
+        self.nodes[0].reissueasset("bitcoin", 1234)
+        self.nodes[0].generate(101)
+        self.sync_all()
+
+        #Check the reissuance worked
+        walletinfo1 = self.nodes[0].getwalletinfo()
+        assert_equal(walletinfo1["balance"]["bitcoin"], 20001234)
+
+        #Send some 'bitcoin' to node 2 so they can fund a reissuance transaction
+        self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1, "", "", False)
+
+        #Send a reissuance token to node 2 so they can reissue the default asset
+        self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1, "", "", False, token)
+        self.nodes[0].generate(101)
+        self.sync_all()
+
+        #Reissue some of the default asset
+        self.nodes[1].reissueasset("bitcoin", 1000)
+        self.nodes[1].generate(101)
+        self.sync_all()
+
+        #Check balance is the 1 'bitcoin' sent from node 1 plus the 1000 'bitcoin' reissued by node 2
+        walletinfo2 = self.nodes[1].getwalletinfo()
+        assert_equal(walletinfo2["balance"]["bitcoin"], 1001)
+
+if __name__ == '__main__':
+    InitialReissuanceTokenTest().main()

--- a/src/assetsdir.cpp
+++ b/src/assetsdir.cpp
@@ -37,7 +37,7 @@ void CAssetsDir::SetHex(const std::string& assetHex, const std::string& label)
     Set(CAsset(uint256S(assetHex)), AssetMetadata(label));
 }
 
-void CAssetsDir::InitFromStrings(const std::vector<std::string>& assetsToInit)
+void CAssetsDir::InitFromStrings(const std::vector<std::string>& assetsToInit, const std::string& pegged_asset_name)
 {
     for (std::string strToSplit : assetsToInit) {
         std::vector<std::string> vAssets;
@@ -48,7 +48,7 @@ void CAssetsDir::InitFromStrings(const std::vector<std::string>& assetsToInit)
         SetHex(vAssets[0], vAssets[1]);
     }
     // Set "bitcoin" to the pegged asset for tests
-    Set(Params().GetConsensus().pegged_asset, AssetMetadata("bitcoin"));
+    Set(Params().GetConsensus().pegged_asset, AssetMetadata(pegged_asset_name));
 }
 
 CAsset CAssetsDir::GetAsset(const std::string& label) const

--- a/src/assetsdir.h
+++ b/src/assetsdir.h
@@ -30,7 +30,7 @@ class CAssetsDir
     void Set(const CAsset& asset, const AssetMetadata& metadata);
     void SetHex(const std::string& assetHex, const std::string& label);
 public:
-    void InitFromStrings(const std::vector<std::string>& assetsToInit);
+    void InitFromStrings(const std::vector<std::string>& assetsToInit, const std::string& pegged_asset_name);
 
     /**
      * @param  label A label string

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -133,6 +133,7 @@ protected:
         // bitcoin regtest is the parent chain by default
         parentGenesisBlockHash = uint256S(GetArg("-parentgenesisblockhash", "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"));
         initialFreeCoins = GetArg("-initialfreecoins", 0);
+        initial_reissuance_tokens = GetArg("-initialreissuancetokens", 0);
 
         const CScript default_script(CScript() << OP_TRUE);
         consensus.signblockscript = StrHexToScriptWithDefault(GetArg("-signblockscript", ""), default_script);
@@ -199,8 +200,8 @@ public:
         CalculateAsset(consensus.pegged_asset, entropy);
 
         genesis = CreateGenesisBlock(consensus, strNetworkID, 1296688602, 1);
-        if (initialFreeCoins != 0) {
-            AppendInitialIssuance(genesis, COutPoint(uint256(commit), 0), parentGenesisBlockHash, 1, initialFreeCoins, 0, 0, CScript() << OP_TRUE);
+        if (initialFreeCoins != 0 || initial_reissuance_tokens != 0) {
+            AppendInitialIssuance(genesis, COutPoint(uint256(commit), 0), parentGenesisBlockHash, (initialFreeCoins > 0) ? 1 : 0, initialFreeCoins, (initial_reissuance_tokens > 0) ? 1 : 0, initial_reissuance_tokens, CScript() << OP_TRUE);
         }
         consensus.hashGenesisBlock = genesis.GetHash();
 

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -105,6 +105,7 @@ protected:
     CBlock genesis;
     uint256 parentGenesisBlockHash;
     CAmount initialFreeCoins;
+    CAmount initial_reissuance_tokens;
     std::vector<SeedSpec6> vFixedSeeds;
     bool fMiningRequiresPeers;
     bool fDefaultConsistencyChecks;

--- a/src/global/common.cpp
+++ b/src/global/common.cpp
@@ -9,7 +9,7 @@
 CAssetsDir _gAssetsDir;
 const CAssetsDir& gAssetsDir = _gAssetsDir;
 
-void InitGlobalAssetDir(const std::vector<std::string>& assetsToInit)
+void InitGlobalAssetDir(const std::vector<std::string>& assetsToInit, const std::string& pegged_asset_name)
 {
-    _gAssetsDir.InitFromStrings(assetsToInit);
+    _gAssetsDir.InitFromStrings(assetsToInit, pegged_asset_name);
 }

--- a/src/global/common.h
+++ b/src/global/common.h
@@ -12,6 +12,6 @@ class CAssetsDir;
 
 extern const CAssetsDir& gAssetsDir;
 
-void InitGlobalAssetDir(const std::vector<std::string>& assetsToInit);
+void InitGlobalAssetDir(const std::vector<std::string>& assetsToInit, const std::string& pegged_asset_name);
 
 #endif // BITCOIN_GLOBAL_COMMON_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -513,6 +513,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-signblockscript=<hex>", _("Change chain to be signed and validated with a different script.") +
             " " + _(" This creates a new chain with a different genesis block."));
         strUsage += HelpMessageOpt("-peginconfirmationdepth", strprintf(_("Pegin claims must be this deep to be considered valid. (default: %d)"), DEFAULT_PEGIN_CONFIRMATION_DEPTH));
+        strUsage += HelpMessageOpt("-initialreissuancetokens", strprintf(_("The amount of reissuance tokens created in the genesis block. (default: %d)"), 0));
         strUsage += HelpMessageOpt("-initialfreecoins", strprintf(_("The amount of OP_TRUE coins created in the genesis block. Primarily for testing. (default: %d)"), 0));
         strUsage += HelpMessageOpt("-defaultpeggedassetname", strprintf("The name of the default asset created in the genesis block. (default: bitcoin)"));
         strUsage += HelpMessageOpt("-parentpubkeyprefix", strprintf(_("The byte prefix, in decimal, of the parent chain's base58 pubkey address. (default: %d)"), 111));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -514,6 +514,7 @@ std::string HelpMessage(HelpMessageMode mode)
             " " + _(" This creates a new chain with a different genesis block."));
         strUsage += HelpMessageOpt("-peginconfirmationdepth", strprintf(_("Pegin claims must be this deep to be considered valid. (default: %d)"), DEFAULT_PEGIN_CONFIRMATION_DEPTH));
         strUsage += HelpMessageOpt("-initialfreecoins", strprintf(_("The amount of OP_TRUE coins created in the genesis block. Primarily for testing. (default: %d)"), 0));
+        strUsage += HelpMessageOpt("-defaultpeggedassetname", strprintf("The name of the default asset created in the genesis block. (default: bitcoin)"));
         strUsage += HelpMessageOpt("-parentpubkeyprefix", strprintf(_("The byte prefix, in decimal, of the parent chain's base58 pubkey address. (default: %d)"), 111));
         strUsage += HelpMessageOpt("-parentscriptprefix", strprintf(_("The byte prefix, in decimal, of the parent chain's base58 script address. (default: %d)"), 196));
 
@@ -1090,7 +1091,8 @@ bool AppInitParameterInteraction()
     nMaxTipAge = GetArg("-maxtipage", DEFAULT_MAX_TIP_AGE);
 
     try {
-        InitGlobalAssetDir(mapMultiArgs.count("-assetdir") > 0 ? mapMultiArgs.at("-assetdir") : std::vector<std::string>());
+        const std::string default_asset_name = GetArg("-defaultpeggedassetname", "bitcoin");
+        InitGlobalAssetDir(mapMultiArgs.count("-assetdir") > 0 ? mapMultiArgs.at("-assetdir") : std::vector<std::string>(), default_asset_name);
     } catch (const std::exception& e) {
         return InitError(strprintf("Error in -assetdir: %s\n", e.what()));
     }

--- a/src/test/assetsdir_tests.cpp
+++ b/src/test/assetsdir_tests.cpp
@@ -23,11 +23,11 @@ BOOST_AUTO_TEST_CASE(assetsdirTests)
 
     for (std:: string protectedLabel : protectedLabels) {
         std::vector<std::string> assetsToInitProtected = {exampleAssetHex + ":" + protectedLabel};
-        BOOST_CHECK_THROW(tAssetsDir.InitFromStrings(assetsToInitProtected), std::runtime_error);
+        BOOST_CHECK_THROW(tAssetsDir.InitFromStrings(assetsToInitProtected, defaultPeggedLabel), std::runtime_error);
     }
 
     const std::vector<std::string> exAssetsToInit = {exampleAssetHex + ":other"};
-    tAssetsDir.InitFromStrings(exAssetsToInit);
+    tAssetsDir.InitFromStrings(exAssetsToInit, defaultPeggedLabel);
 
     BOOST_CHECK(exampleAsset == tAssetsDir.GetAsset("other"));
     BOOST_CHECK_EQUAL("other", tAssetsDir.GetLabel(exampleAsset));
@@ -37,10 +37,10 @@ BOOST_AUTO_TEST_CASE(assetsdirTests)
     BOOST_CHECK(defaultPeggedAsset == tAssetsDir.GetAsset(tAssetsDir.GetLabel(CAsset(uint256S(defaultPeggedAssetHex)))));
 
     const std::vector<std::string> assetsToInitRepeatedHex = {exampleAssetHex + ":other", exampleAssetHex + ":other2"};
-    BOOST_CHECK_THROW(tAssetsDir.InitFromStrings(assetsToInitRepeatedHex), std::runtime_error);
+    BOOST_CHECK_THROW(tAssetsDir.InitFromStrings(assetsToInitRepeatedHex, defaultPeggedLabel), std::runtime_error);
 
     const std::vector<std::string> assetsToInitRepeatedLabel = {exampleAssetHex + ":other", defaultPeggedAssetHex + ":other"};
-    BOOST_CHECK_THROW(tAssetsDir.InitFromStrings(assetsToInitRepeatedLabel), std::runtime_error);
+    BOOST_CHECK_THROW(tAssetsDir.InitFromStrings(assetsToInitRepeatedLabel, defaultPeggedLabel), std::runtime_error);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Changes to enable you to use Elements as a stand alone blockchain by setting new params:

-initialreissuancetokens
-defaultpeggedassetname

NOTES:
In order to use reissuance tokens for the default asset they must be moved from anyone-can-spend first. 

When using defaultpeggedassetname as a parameter: sendtoaddress, sendmany requires the asset name parameter passing in in order to use your default asset and not 'bitcoin'. Could change this at a later date as part of more serious decoupling, but might require a lot of knock on changes.

EXAMPLE USE:
(based on https://github.com/ElementsProject/elements/blob/elements-0.14.1/contrib/assets_tutorial/assets_tutorial.sh)

`
ASSET="mynewasset"
trap read debug
e1-dae -initialreissuancetokens=200000000 -defaultpeggedassetname=$ASSET
e2-dae -initialreissuancetokens=200000000 -defaultpeggedassetname=$ASSET

BALANCE=$(e1-cli getwalletinfo | jq '.balance')
TOKEN=$(echo $BALANCE | jq 'keys[0]' | tr -d '"') #Should be at [0] but just to be sure:
if [ "$ASSET" = "$TOKEN" ]; then
        TOKEN=$(echo $BALANCE | jq 'keys[1]' | tr -d '"')
fi

e1-cli sendtoaddress $(e1-cli getnewaddress) 21000000 "" "" true $ASSET
e1-cli generate 101
e1-cli sendtoaddress $(e2-cli getnewaddress) 10500000 "" "" false $ASSET
e1-cli generate 101

#Claim reissuance tokens from anyone can spend:
e1-cli sendtoaddress $(e1-cli getnewaddress) 2 "" "" false $TOKEN
e1-cli generate 101

e1-cli reissueasset $ASSET 1000
e1-cli generate 101

e1-cli sendtoaddress $(e2-cli getnewaddress) 1 "" "" false $TOKEN
e1-cli generate 101

e2-cli reissueasset $ASSET 100000
e2-cli generate 101

e1-cli getwalletinfo #Should be 1050100 mynewasset and 1 token
e2-cli getwalletinfo #Should be 1060000 mynewasset and 1 token

#Stop and start to test issue 378 has indeed been fixed for this (was causing errors):
e1-cli stop
e2-cli stop

e1-dae -initialreissuancetokens=200000000 -defaultpeggedassetname=$ASSET
e2-dae -initialreissuancetokens=200000000 -defaultpeggedassetname=$ASSET

e1-cli getwalletinfo #Should be 1050100 mynewasset and 1 token
e2-cli getwalletinfo #Should be 1060000 mynewasset and 1 token

#Done
e1-cli stop
e2-cli stop
`