### PR TITLE
NO-HF: Move block.proof.challenge to Consensus::Params::signblockscript

### DIFF
--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -71,6 +71,7 @@ struct Params {
     uint256 defaultAssumeValid;
     uint32_t pegin_min_depth;
     CScript mandatory_coinbase_destination;
+    CScript signblockscript;
 };
 } // namespace Consensus
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -150,14 +150,14 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     // Pad weight for challenge
     // We won't bother with serialization byte(s), we have room
-    nBlockWeight += pblock->proof.challenge.size()*WITNESS_SCALE_FACTOR;
+    nBlockWeight += chainparams.GetConsensus().signblockscript.size() * WITNESS_SCALE_FACTOR;
 
     // Pad weight for proof
     // Note: Assumes "naked" script template with pubkeys
     txnouttype dummy_type;
     std::vector<CTxDestination> dummy_addresses;
     int required_sigs = -1;
-    if (!ExtractDestinations(pblock->proof.challenge, dummy_type, dummy_addresses, required_sigs)) {
+    if (!ExtractDestinations(chainparams.GetConsensus().signblockscript, dummy_type, dummy_addresses, required_sigs)) {
         // No idea how to sign this... log error but return block.
         LogPrintf("CreateNewBlock: Can not extract destinations from signblockscript");
     } else {

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -21,11 +21,11 @@
 #include "wallet/wallet.h"
 #endif
 
-CScript CombineBlockSignatures(const CBlockHeader& header, const CScript& scriptSig1, const CScript& scriptSig2)
+CScript CombineBlockSignatures(const Consensus::Params& params, const CBlockHeader& header, const CScript& scriptSig1, const CScript& scriptSig2)
 {
     SignatureData sig1(scriptSig1);
     SignatureData sig2(scriptSig2);
-    return GenericCombineSignatures(header.proof.challenge, header, sig1, sig2).scriptSig;
+    return GenericCombineSignatures(params.signblockscript, header, sig1, sig2).scriptSig;
 }
 
 bool CheckChallenge(const CBlockHeader& block, const CBlockIndex& indexLast, const Consensus::Params& params)
@@ -82,14 +82,14 @@ bool CheckProof(const CBlockHeader& block, const Consensus::Params& params)
         | SCRIPT_VERIFY_LOW_S // Stop easiest signature fiddling
         | SCRIPT_VERIFY_WITNESS // Required for cleanstack eval in VerifyScript
         | SCRIPT_NO_SIGHASH_BYTE; // non-Check(Multi)Sig signatures will not have sighash byte
-    return GenericVerifyScript(block.proof.solution, block.proof.challenge, proof_flags, block);
+    return GenericVerifyScript(block.proof.solution, params.signblockscript, proof_flags, block);
 }
 
-bool MaybeGenerateProof(CBlockHeader *pblock, CWallet *pwallet)
+bool MaybeGenerateProof(const Consensus::Params& params, CBlockHeader *pblock, CWallet *pwallet)
 {
 #ifdef ENABLE_WALLET
     SignatureData solution(pblock->proof.solution);
-    bool res = GenericSignScript(*pwallet, *pblock, pblock->proof.challenge, solution);
+    bool res = GenericSignScript(*pwallet, *pblock, params.signblockscript, solution);
     pblock->proof.solution = solution.scriptSig;
     return res;
 #endif

--- a/src/pow.h
+++ b/src/pow.h
@@ -22,11 +22,12 @@ class uint256;
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
 bool CheckBitcoinProof(uint256 hash, unsigned int nBits);
 bool CheckProof(const CBlockHeader& block, const Consensus::Params&);
+/** Scans nonces looking for a hash with at least some zero bits */
+bool MaybeGenerateProof(const Consensus::Params& params, CBlockHeader* pblock, CWallet* pwallet);
 void ResetProof(CBlockHeader& block);
 bool CheckChallenge(const CBlockHeader& block, const CBlockIndex& indexLast, const Consensus::Params&);
 void ResetChallenge(CBlockHeader& block, const CBlockIndex& indexLast, const Consensus::Params&);
 
-bool MaybeGenerateProof(CBlockHeader* pblock, CWallet* pwallet);
-CScript CombineBlockSignatures(const CBlockHeader& header, const CScript& scriptSig1, const CScript& scriptSig2);
+CScript CombineBlockSignatures(const Consensus::Params& params, const CBlockHeader& header, const CScript& scriptSig1, const CScript& scriptSig2);
 
 #endif // BITCOIN_POW_H

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -11,6 +11,7 @@
 #include "consensus/validation.h"
 #include "core_io.h"
 #include "validation.h"
+#include "core_io.h"
 #include "policy/policy.h"
 #include "primitives/transaction.h"
 #include "rpc/server.h"
@@ -1065,6 +1066,7 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
             + HelpExampleRpc("getblockchaininfo", "")
         );
 
+    const Consensus::Params& consensusParams = Params().GetConsensus();
     LOCK(cs_main);
     CBlockIndex* tip = chainActive.Tip();
 
@@ -1076,10 +1078,9 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
     obj.push_back(Pair("mediantime",            (int64_t)tip->GetMedianTimePast()));
     obj.push_back(Pair("verificationprogress",  GuessVerificationProgress(Params().TxData(), tip)));
     obj.push_back(Pair("pruned",                fPruneMode));
-    obj.push_back(Pair("signblock_asm", ScriptToAsmStr(tip->proof.challenge)));
-    obj.push_back(Pair("signblock_hex", HexStr(tip->proof.challenge.begin(), tip->proof.challenge.end())));
+    obj.push_back(Pair("signblock_asm", ScriptToAsmStr(consensusParams.signblockscript)));
+    obj.push_back(Pair("signblock_hex", HexStr(consensusParams.signblockscript)));
 
-    const Consensus::Params& consensusParams = Params().GetConsensus();
     UniValue bip9_softforks(UniValue::VOBJ);
     BIP9SoftForkDescPushBack(bip9_softforks, "csv", consensusParams, Consensus::DEPLOYMENT_CSV);
     BIP9SoftForkDescPushBack(bip9_softforks, "segwit", consensusParams, Consensus::DEPLOYMENT_SEGWIT);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -223,14 +223,15 @@ UniValue combineblocksigs(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Block decode failed");
 
     UniValue result(UniValue::VOBJ);
+    const Consensus::Params& params = Params().GetConsensus();
     const UniValue& sigs = request.params[1].get_array();
     for (unsigned int i = 0; i < sigs.size(); i++) {
         const std::string& sig = sigs[i].get_str();
         if (!IsHex(sig))
             continue;
         std::vector<unsigned char> vchScript = ParseHex(sig);
-        block.proof.solution = CombineBlockSignatures(block, block.proof.solution, CScript(vchScript.begin(), vchScript.end()));
-        if (CheckProof(block, Params().GetConsensus())) {
+        block.proof.solution = CombineBlockSignatures(params, block, block.proof.solution, CScript(vchScript.begin(), vchScript.end()));
+        if (CheckProof(block, params)) {
             result.push_back(Pair("hex", EncodeHexBlock(block)));
             result.push_back(Pair("complete", true));
             return result;
@@ -774,8 +775,8 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
         result.push_back(Pair("weightlimit", (int64_t)MAX_BLOCK_WEIGHT));
     }
     result.push_back(Pair("curtime", pblock->GetBlockTime()));
-    result.push_back(Pair("signblock_asm", ScriptToAsmStr(pblock->proof.challenge)));
-    result.push_back(Pair("signblock_hex", HexStr(pblock->proof.challenge.begin(), pblock->proof.challenge.end())));
+    result.push_back(Pair("signblock_asm", ScriptToAsmStr(consensusParams.signblockscript)));
+    result.push_back(Pair("signblock_hex", HexStr(consensusParams.signblockscript.begin(), consensusParams.signblockscript.end())));
     result.push_back(Pair("height", (int64_t)(pindexPrev->nHeight+1)));
 
     if (!pblocktemplate->vchCoinbaseCommitment.empty() && fSupportsSegwit) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3374,7 +3374,7 @@ UniValue signblock(const JSONRPCRequest& request)
     }
 
     block.proof.solution = CScript();
-    MaybeGenerateProof(&block, pwalletMain);
+    MaybeGenerateProof(Params().GetConsensus(), &block, pwalletMain);
     return HexStr(block.proof.solution.begin(), block.proof.solution.end());
 }
 


### PR DESCRIPTION
Since the scriptPubKey for signing blocks never changes, there's no
point reading repeating it from every block header.

Subset of https://github.com/ElementsProject/elements/pull/313