### PR TITLE
Add ability to use listissuance with label as param. Plus tests.

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -105,6 +105,7 @@ testScripts = [
     'initial_reissuance_token.py',
     'feature_blocksign.py',
     'default_asset_name.py',
+    'assetdir.py',
 
     # Elements' specially adapted tests second
     'blockchain.py',

--- a/qa/rpc-tests/assetdir.py
+++ b/qa/rpc-tests/assetdir.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test use of assetdir to locally label assets.
+# Test listissuances returns a list of all issuances or specific issuances based on asset hex or asset label.
+#
+
+from decimal import Decimal
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.authproxy import JSONRPCException
+from test_framework.util import *
+
+class AssetdirTests(BitcoinTestFramework):
+    """
+    Test use of assetdir to specify asset labels.
+    Test listissuances returns a list of all issuances or specific issuances based on asset hex or asset label.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+
+    def run_test(self):
+        #Claim all anyone-can-spend 'bitcoin'
+        self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 21000000, "", "", True)
+        self.nodes[0].generate(101)
+
+        #Issue two assets that we will later label using the assetdir parameter
+        issuance1=self.nodes[0].issueasset(100, 1, False)
+        asset1hex=issuance1["asset"]
+
+        issuance2=self.nodes[0].issueasset(100, 1, False)
+        asset2hex=issuance2["asset"]
+
+        #Stop and restart the nodes, providing the assetdir parameter to locally label the assets
+        stop_nodes(self.nodes)
+        self.nodes=start_nodes(self.num_nodes, self.options.tmpdir, [["-assetdir=" + asset1hex + ":asset1", "-assetdir=" + asset2hex + ":asset2"]])
+
+        #Check that listissuances returns all 3 issuances
+        issuances=self.nodes[0].listissuances()
+        assert_equal(len(issuances), 3)
+        
+        #Check all 3 asset labels have been set: 'bitcoin', 'asset1', 'asset2'
+        #We can not be sure they will always be returned in the same order so will loop each one
+        label=""
+        for issue in issuances:
+            label+=issue["assetlabel"]
+        
+        assert_greater_than(label.find("bitcoin"), -1)
+        assert_greater_than(label.find("asset1"), -1)
+        assert_greater_than(label.find("asset2"), -1)
+
+        #Check we can get a list of isuances for a given label
+        issuances=self.nodes[0].listissuances("bitcoin")
+        assert_equal(len(issuances), 1)
+        assert_equal(issuances[0]["assetlabel"], "bitcoin")
+
+        issuances=self.nodes[0].listissuances("asset1")
+        assert_equal(len(issuances), 1)
+        assert_equal(issuances[0]["assetlabel"], "asset1")
+
+        #Check we can get a list of issuances for a given hex
+        issuances=self.nodes[0].listissuances(asset2hex)
+        assert_equal(len(issuances), 1)
+        assert_equal(issuances[0]["assetlabel"], "asset2")
+
+        #Check a non-existant label or hex raises an error
+        rpc_error=True
+        try:
+            self.nodes[0].listissuances("doesnotexist")
+            rpc_error=False
+        except Exception as e:
+            assert_equal(e.error["code"], -4)
+
+        try:
+            self.nodes[0].listissuances("0000000000000000000000000000000000000000000000000000000000000000")
+            rpc_error=False
+        except Exception as e:
+            assert_equal(e.error["code"], -4)
+
+        #Check that the code did error
+        assert_equal(rpc_error, True)
+
+if __name__ == '__main__':
+    AssetdirTests().main()
+

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3958,7 +3958,7 @@ UniValue listissuances(const JSONRPCRequest& request)
             "listissuances ( asset ) \n"
             "\nList all issuances known to the wallet for the given asset, or for all issued assets if none provided.\n"
             "\nArguments:\n"
-            "1. \"asset\"                 (string, optional) The asset whose issaunces you wish to list.\n"
+            "1. \"asset\"                 (string, optional) The asset whose issaunces you wish to list. Accepts either the asset hex or the locally assigned asset label.\n"
             "\nResult:\n"
             "[                     (json array of objects)\n"
             "  {\n"
@@ -3985,12 +3985,10 @@ UniValue listissuances(const JSONRPCRequest& request)
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
     std::string assetstr;
-    CAsset assetfilter;
+    CAsset asset_filter;
     if (request.params.size() > 0) {
         assetstr = request.params[0].get_str();
-        if (!IsHex(assetstr) || assetstr.size() != 64)
-            throw JSONRPCError(RPC_TYPE_ERROR, "Asset must be a hex string of length 64");
-        assetfilter.SetHex(assetstr);
+        asset_filter = GetAssetFromString(assetstr);
     }
 
     UniValue issuancelist(UniValue::VARR);
@@ -4031,7 +4029,7 @@ UniValue listissuances(const JSONRPCRequest& request)
             CAmount iaamount = pcoin->GetIssuanceAmount(vinIndex, false);
             item.push_back(Pair("assetamount", (iaamount == -1 ) ? -1 : ValueFromAmount(iaamount)));
             item.push_back(Pair("assetblinds", pcoin->GetIssuanceBlindingFactor(vinIndex, false).GetHex()));
-            if (!assetfilter.IsNull() && assetfilter != asset) {
+            if (!asset_filter.IsNull() && asset_filter != asset) {
                 continue;
             }
             issuancelist.push_back(item);


### PR DESCRIPTION
Addresses Issue #387 

This enables you to pass the label of an asset into listissuances. Previously you had to use a hex.

Added new test that covers assetdir in general and this PR.