### PR TITLE
Remove use of 'bitcoin' as hard coded default asset for sendtoaddress…

### DIFF
--- a/qa/rpc-tests/default_asset_name.py
+++ b/qa/rpc-tests/default_asset_name.py
@@ -33,8 +33,8 @@ class NamedDefaultAssetTest(BitcoinTestFramework):
         self.sync_all()
 
     def run_test(self):
-        #Claim all anyone-can-spend 'bitcoin'
-        self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 21000000, "", "", True, "testasset")
+        #Claim all anyone-can-spend coins and test that calling sendtoaddress without providing the assetlabel parameter results in the specified default pegged asset being sent.
+        self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 21000000, "", "", True)
         self.nodes[0].generate(101)
         self.sync_all()
 
@@ -43,7 +43,7 @@ class NamedDefaultAssetTest(BitcoinTestFramework):
         assert_equal(walletinfo1["balance"]["testasset"], 21000000)
 
         #Send some of the default asset to the second node
-        self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1, "", "", False, "testasset")
+        self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1, "", "", False) 
         self.nodes[0].generate(101)
         self.sync_all()
 
@@ -53,6 +53,19 @@ class NamedDefaultAssetTest(BitcoinTestFramework):
 
         walletinfo2 = self.nodes[1].getwalletinfo()
         assert_equal(walletinfo2["balance"]["testasset"], 1)
+
+        #Check we send the default 'testasset' when calling 'sendmany' without needing to provide the relevant asset label
+        outputs = {self.nodes[1].getnewaddress():1.0,self.nodes[1].getnewaddress():3.0}
+        self.nodes[0].sendmany("", outputs)
+        self.nodes[0].generate(101)
+        self.sync_all()
+
+        #Check balances are correct and asset is named correctly
+        walletinfo1 = self.nodes[0].getwalletinfo()
+        assert_equal(walletinfo1["balance"]["testasset"], 20999995)
+
+        walletinfo2 = self.nodes[1].getwalletinfo()
+        assert_equal(walletinfo2["balance"]["testasset"], 5)
 
 if __name__ == '__main__':
     NamedDefaultAssetTest().main()

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -553,7 +553,7 @@ UniValue sendtoaddress(const JSONRPCRequest& request)
     if (request.params.size() > 4)
         fSubtractFeeFromAmount = request.params[4].get_bool();
 
-    std::string strasset = "bitcoin";
+    std::string strasset = Params().GetConsensus().pegged_asset.GetHex();
     if (request.params.size() > 5 && request.params[5].isStr()) {
         strasset = request.params[5].get_str();
     }
@@ -1158,7 +1158,7 @@ UniValue sendmany(const JSONRPCRequest& request)
     {
         CBitcoinAddress address(name_);
 
-        std::string strasset = "bitcoin";
+        std::string strasset = Params().GetConsensus().pegged_asset.GetHex(); 
         if (!assets.isNull() && assets[name_].isStr()) {
             strasset = assets[name_].get_str();
         }


### PR DESCRIPTION
… and sendmany.

Addresses issue #395 