### PR TITLE
Tests: Explicitly destroy zmq object when exiting after not actually using it

### DIFF
--- a/qa/rpc-tests/zmq_test.py
+++ b/qa/rpc-tests/zmq_test.py
@@ -34,6 +34,9 @@ class ZMQTest (BitcoinTestFramework):
             ])
 
     def run_test(self):
+        # destroy() required for ubuntu docker hang workaround when
+        # exiting without actually messaging (remove with resolution of #TODO)
+        self.zmqContext.destroy(linger=0)
         return #TODO
         self.sync_all()
 


### PR DESCRIPTION
When run in a docker Ubuntu instance under Centos 7, the script `qa/rpc-tests/zmq_test.py` will typically hang indefinitely (even though it has reported a successful -- albeit mostly stubbed-out -- completion). Using gdb to debug the [core file manually generated from the] associated python instance reveals that the main thread is waiting for a call to zmq_ctx_term() to end -- a scenario similar to  that described in https://github.com/zeromq/libzmq/issues/2586

This change adds the workaround described in the issue (namely to explicitly call `self.zmqContext.destroy(linger=0)` after the process is finished with zmq).

Note: the workaround is otherwise innocuous for any environment not experiencing a hang.