### PR TITLE
2WP: Verify number of transactions in SPV proof

### DIFF
--- a/qa/rpc-tests/pruning.py
+++ b/qa/rpc-tests/pruning.py
@@ -269,9 +269,16 @@ class PruneTest(BitcoinTestFramework):
         # should not prune because chain tip of node 3 (995) < PruneAfterHeight (1000)
         assert_raises_message(JSONRPCException, "Blockchain is too short for pruning", node.pruneblockchain, height(500))
 
+        # Save block transaction count before pruning, assert value
+        block1_details = node.getblock(node.getblockhash(1))
+        assert_equal(block1_details["nTx"], len(block1_details["tx"]))
+
         # mine 6 blocks so we are at height 1001 (i.e., above PruneAfterHeight)
         node.generate(6)
         assert_equal(node.getblockchaininfo()["blocks"], 1001)
+
+        # Pruned block should still know the number of transactions
+        assert_equal(node.getblockheader(node.getblockhash(1))["nTx"], block1_details["nTx"])
 
         # negative heights should raise an exception
         assert_raises_message(JSONRPCException, "Negative", node.pruneblockchain, -10)

--- a/src/callrpc.h
+++ b/src/callrpc.h
@@ -35,6 +35,11 @@ public:
 };
 
 UniValue CallRPC(const std::string& strMethod, const UniValue& params, bool connectToMainchain=false);
-bool IsConfirmedBitcoinBlock(const uint256& hash, int nMinConfirmationDepth);
+
+// Verify if the block with given hash has at least the specified minimum number
+// of confirmations.
+// For validating merkle blocks, you can provide the nbTxs parameter to verify if
+// it equals the number of transactions in the block.
+bool IsConfirmedBitcoinBlock(const uint256& hash, int nMinConfirmationDepth, int nbTxs);
 
 #endif // BITCOIN_CALLRPC_H

--- a/src/merkleblock.h
+++ b/src/merkleblock.h
@@ -115,6 +115,11 @@ public:
      * returns the merkle root, or 0 in case of failure
      */
     uint256 ExtractMatches(std::vector<uint256> &vMatch, std::vector<unsigned int> &vnIndex);
+
+    /** Get number of transactions the merkle proof is indicating for cross-reference with
+     * local blockchain knowledge.
+     */
+    unsigned int GetNumTransactions() const { return nTransactions; };
 };
 
 

--- a/src/primitives/bitcoin/merkleblock.h
+++ b/src/primitives/bitcoin/merkleblock.h
@@ -120,6 +120,11 @@ public:
      * returns the merkle root, or 0 in case of failure
      */
     uint256 ExtractMatches(std::vector<uint256> &vMatch, std::vector<unsigned int> &vnIndex);
+
+    /** Get number of transactions the merkle proof is indicating for cross-reference with
+     * local blockchain knowledge.
+     */
+    unsigned int GetNumTransactions() const { return nTransactions; };
 };
 
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -62,6 +62,7 @@ UniValue blockheaderToJSON(const CBlockIndex* blockindex)
     result.push_back(Pair("merkleroot", blockindex->hashMerkleRoot.GetHex()));
     result.push_back(Pair("time", (int64_t)blockindex->nTime));
     result.push_back(Pair("mediantime", (int64_t)blockindex->GetMedianTimePast()));
+    result.push_back(Pair("nTx", (uint64_t)blockindex->nTx));
     result.push_back(Pair("signblock_witness_asm", ScriptToAsmStr(blockindex->proof.solution)));
     result.push_back(Pair("signblock_witness_hex", HexStr(blockindex->proof.solution)));
 
@@ -104,6 +105,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     result.push_back(Pair("tx", txs));
     result.push_back(Pair("time", block.GetBlockTime()));
     result.push_back(Pair("mediantime", (int64_t)blockindex->GetMedianTimePast()));
+    result.push_back(Pair("nTx", (int64_t)blockindex->nTx));
     result.push_back(Pair("signblock_witness_asm", ScriptToAsmStr(blockindex->proof.solution)));
     result.push_back(Pair("signblock_witness_hex", HexStr(blockindex->proof.solution)));
 
@@ -605,8 +607,7 @@ UniValue getblockheader(const JSONRPCRequest& request)
             "  \"merkleroot\" : \"xxxx\", (string) The merkle root\n"
             "  \"time\" : ttt,          (numeric) The block time in seconds since epoch (Jan 1 1970 GMT)\n"
             "  \"mediantime\" : ttt,    (numeric) The median block time in seconds since epoch (Jan 1 1970 GMT)\n"
-            "  \"signblock_witness_asm\":\"asm\", (string) scriptSig for block signing (asm)'\n"
-            "  \"signblock_witness_hex\":\"hex\", (string) scriptSig for block signing (hex)'\n"
+            "  \"nTx\" : n,             (numeric) The number of transactions in the block.\n"
             "  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n"
             "  \"nextblockhash\" : \"hash\",      (string) The hash of the next block\n"
             "}\n"
@@ -691,8 +692,7 @@ static UniValue getblock(const JSONRPCRequest& request)
             "  ],\n"
             "  \"time\" : ttt,          (numeric) The block time in seconds since epoch (Jan 1 1970 GMT)\n"
             "  \"mediantime\" : ttt,    (numeric) The median block time in seconds since epoch (Jan 1 1970 GMT)\n"
-            "  \"signblock_witness_asm\":\"asm\", (string) scriptSig for block signing (asm)'\n"
-            "  \"signblock_witness_hex\":\"hex\", (string) scriptSig for block signing (hex)'\n"
+            "  \"nTx\" : n,             (numeric) The number of transactions in the block.\n"
             "  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n"
             "  \"nextblockhash\" : \"hash\"       (string) The hash of the next block\n"
             "}\n"

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2531,6 +2531,7 @@ bool IsValidPeginWitness(const CScriptWitness& pegin_witness, const COutPoint& p
 
     uint256 block_hash;
     uint256 tx_hash;
+    int num_txs;
     // Get txout proof
     if (Params().GetConsensus().ParentChainHasPow()) {
 
@@ -2546,6 +2547,8 @@ bool IsValidPeginWitness(const CScriptWitness& pegin_witness, const COutPoint& p
         if (!CheckPeginTx(stack[4], pegtx, prevout, value, claim_script)) {
             return false;
         }
+
+        num_txs = merkle_block_pow.txn.GetNumTransactions();
     } else {
 
         CMerkleBlock merkle_block;
@@ -2561,6 +2564,8 @@ bool IsValidPeginWitness(const CScriptWitness& pegin_witness, const COutPoint& p
         if (!CheckPeginTx(stack[4], pegtx, prevout, value, claim_script)) {
             return false;
         }
+
+        num_txs = merkle_block.txn.GetNumTransactions();
     }
 
     // Check that the merkle proof corresponds to the txid
@@ -2580,7 +2585,9 @@ bool IsValidPeginWitness(const CScriptWitness& pegin_witness, const COutPoint& p
 
     // Finally, validate peg-in via rpc call
     if (check_depth && GetBoolArg("-validatepegin", DEFAULT_VALIDATE_PEGIN)) {
-        return IsConfirmedBitcoinBlock(block_hash, Params().GetConsensus().pegin_min_depth);
+        if (!IsConfirmedBitcoinBlock(block_hash, Params().GetConsensus().pegin_min_depth, num_txs)) {
+            return false;
+        }
     }
     return true;
 }

--- a/src/validation.h
+++ b/src/validation.h
@@ -149,6 +149,10 @@ static const int MAX_UNCONNECTING_HEADERS = 10;
 
 static const bool DEFAULT_PEERBLOOMFILTERS = false;
 
+/** The minimum version for the parent chain node.
+ *  We need v0.16.2 to get the nTx field in getblockheader. */
+static const int MIN_PARENT_NODE_VERSION = 160200; // 0.16.2
+
 struct BlockHasher
 {
     size_t operator()(const uint256& hash) const { return hash.GetCheapHash(); }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3702,7 +3702,8 @@ static UniValue createrawpegin(const JSONRPCRequest& request, T_tx_ref& txBTCRef
 
     // Additional block lee-way to avoid bitcoin block races
     if (GetBoolArg("-validatepegin", DEFAULT_VALIDATE_PEGIN)) {
-        ret.push_back(Pair("mature", IsConfirmedBitcoinBlock(merkleBlock.header.GetHash(), Params().GetConsensus().pegin_min_depth+2)));
+        ret.push_back(Pair("mature", IsConfirmedBitcoinBlock(merkleBlock.header.GetHash(), 
+			Params().GetConsensus().pegin_min_depth+2, merkleBlock.txn.GetNumTransactions())));
     }
 
     return ret;


### PR DESCRIPTION
Use the getblockheader RPC from Bitcoin Core to verify if the number of
transactions mentioned in the SPV proof matches the number for the
block known by the Core daemon.

Inspired by https://github.com/bitcoin/bitcoin/commit/6b9dc8ceaed597d9c539ba6b09c171b258b66ca3

Partially fixes https://github.com/ElementsProject/elements/issues/369