### PR TITLE
mainchainrpc* description fixes

### DIFF
--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -16,7 +16,7 @@ const std::string CBaseChainParams::REGTEST = CHAINPARAMS_REGTEST;
 void AppendParamsHelpMessages(std::string& strUsage, bool debugHelp)
 {
     strUsage += HelpMessageGroup(_("Chain selection options:"));
-    strUsage += HelpMessageOpt("-chain=<chain>", strprintf(_("Use the chain <chain> (default: %s). Anything except main is allowed"), CHAINPARAMS_REGTEST));
+    strUsage += HelpMessageOpt("-chain=<chain>", strprintf(_("Use the chain <chain> (default: %s). Anything except main is allowed. Note that this affects where \"network specific\" files will be searched for, such as cookie files when using -cli."), CHAINPARAMS_REGTEST));
     if (debugHelp) {
         strUsage += HelpMessageOpt("-regtest", strprintf(_("Equivalent to -chain=%s"), CHAINPARAMS_REGTEST));
         strUsage += HelpMessageOpt("-pubkeyprefix", strprintf(_("The byte prefix, in decimal, of the chain's base58 pubkey address. (default: %d)"), 235));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -520,12 +520,12 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-parentscriptprefix", strprintf(_("The byte prefix, in decimal, of the parent chain's base58 script address. (default: %d)"), 196));
 
     }
-    strUsage += HelpMessageOpt("-validatepegin", strprintf(_("Validate pegin claims. All functionaries must run this. (default: %u)"), DEFAULT_VALIDATE_PEGIN));
-    strUsage += HelpMessageOpt("-mainchainrpchost=<addr>", strprintf("The address which the daemon will try to connect to validate peg-ins, if enabled. (default: cookie auth)"));
-    strUsage += HelpMessageOpt("-mainchainrpcport=<port>", strprintf("The port which the daemon will try to connect to validate peg-ins, if enabled. (default: cookie auth)"));
-    strUsage += HelpMessageOpt("-mainchainrpcuser=<username>", strprintf("The rpc username that the daemon will use to connect to validate peg-ins, if enabled. (default: cookie auth)"));
-    strUsage += HelpMessageOpt("-mainchainrpcpassword=<password>", strprintf("The rpc password which the daemon will use to connect to validate peg-ins, if enabled. (default: cookie auth)"));
-    strUsage += HelpMessageOpt("-mainchainrpccookiefile=<path>", strprintf("The bitcoind cookie auth path which the daemon will use to connect to validate peg-ins, if enabled. (default: default bitcoind datadir)"));
+    strUsage += HelpMessageOpt("-validatepegin", strprintf(_("Validate peg-in claims. An RPC connection will be attempted to the trusted bitcoind using the `mainchain*` settings below. All functionaries must run this enabled. (default: %u)"), DEFAULT_VALIDATE_PEGIN));
+    strUsage += HelpMessageOpt("-mainchainrpchost=<addr>", strprintf("The address which the daemon will try to connect to the trusted bitcoind to validate peg-ins, if enabled. (default: cookie auth)"));
+    strUsage += HelpMessageOpt("-mainchainrpcport=<port>", strprintf("The port which the daemon will try to connect to the trusted bitcoind to validate peg-ins, if enabled. (default: cookie auth)"));
+    strUsage += HelpMessageOpt("-mainchainrpcuser=<username>", strprintf("The rpc username that the daemon will use to connect to the trusted bitcoind to validate peg-ins, if enabled. (default: cookie auth)"));
+    strUsage += HelpMessageOpt("-mainchainrpcpassword=<password>", strprintf("The rpc password which the daemon will use to connect to the trusted bitcoind to validate peg-ins, if enabled. (default: cookie auth)"));
+    strUsage += HelpMessageOpt("-mainchainrpccookiefile=<path>", strprintf("The bitcoind cookie auth path which the daemon will use to connect to the trusted bitcoind to validate peg-ins. (default: `<datadir>/regtest/.cookie`)"));
 
 
     return strUsage;


### PR DESCRIPTION
Most important fix is being explicit that the cookie file is being searched for under "regtest" by default.