### PR TITLE
Set policyAsset for core unit tests

### DIFF
--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -10,6 +10,7 @@
 #include "consensus/consensus.h"
 #include "consensus/validation.h"
 #include "consensus/merkle.h"
+#include "policy/policy.h"
 #include "key.h"
 #include "validation.h"
 #include "miner.h"
@@ -54,6 +55,8 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::st
         // MAX_MONEY
         SoftSetArg("-initialfreecoins", "2100000000000000");
         SelectParams(chainName);
+        // Set policy asset for correct fee output generation
+        policyAsset = CAsset(uint256S(Params().GetConsensus().pegged_asset.GetHex()));
         noui_connect();
 }
 

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -45,10 +45,10 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup)
         spends[i].vin[0].prevout.hash = coinbaseTxns[0].GetHash();
         spends[i].vin[0].prevout.n = 0;
         spends[i].vout.resize(2);
-        spends[i].vout[0].nValue = 11*CENT;
+        spends[i].vout[0].nValue = MAX_MONEY-11*CENT;
         spends[i].vout[0].scriptPubKey = scriptPubKey;
         spends[i].vout[0].nAsset = Params().GetConsensus().pegged_asset;
-        spends[i].vout[1].nValue = MAX_MONEY-11*CENT;
+        spends[i].vout[1].nValue = 11*CENT;
         spends[i].vout[1].nAsset = Params().GetConsensus().pegged_asset;
         spends[i].vout[1].scriptPubKey = CScript();
 


### PR DESCRIPTION
Set policyAsset for all core c++ unit tests #408 

src/test/txvalidationcache_tests.cpp was failing with memory access violation somewhere in block creation. I believe it's because now that mempool entry fee is correctly set, the fact that the fee output was larger than the non-fee one was causing an issue. I haven't been able to track this down exactly though. Please let me know if you have some idea about this and if the change makes sense.