### PR TITLE
[backport] Fix crash bug with duplicate inputs within a transaction

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3859,7 +3859,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
 
     // Check transactions
     for (const auto& tx : block.vtx)
-        if (!CheckTransaction(*tx, state, false))
+        if (!CheckTransaction(*tx, state, true))
             return state.Invalid(false, state.GetRejectCode(), state.GetRejectReason(),
                                  strprintf("Transaction check failed (tx hash %s) %s", tx->GetHash().ToString(), state.GetDebugMessage()));
 


### PR DESCRIPTION
Introduced by #9049