### PR TITLE
[0.17] Test: Fix example_test.py

### DIFF
--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -15,8 +15,10 @@ from collections import defaultdict
 
 # Avoid wildcard * imports if possible
 from test_framework.blocktools import (create_block, create_coinbase)
-from test_framework.mininode import (
+from test_framework.messages import (
     CInv,
+)
+from test_framework.mininode import (
     P2PInterface,
     mininode_lock,
     msg_block,


### PR DESCRIPTION
Fix this useful test in -extended.

IMO should be backported to bitcoin/0.17, but I'm not sure if it's wanted there.
