### PR TITLE
[0.17] add block subsidy argument to allow different/non-inflation chains

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -104,6 +104,8 @@ public:
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S("0x0000000000000000002e63058c023a9a1de233554f28c7b21380b6c9003f36a8"); //534292
 
+        consensus.genesis_subsidy = 50*COIN;
+
         /**
          * The message start string is designed to be unlikely to occur in normal data.
          * The characters are rarely used upper ASCII, not valid as UTF-8, and produce
@@ -218,6 +220,8 @@ public:
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S("0x0000000000000037a8cd3e06cd5edbfe9dd1dbcc5dacab279376ef7cfc2b4c75"); //1354312
 
+        consensus.genesis_subsidy = 50*COIN;
+
         pchMessageStart[0] = 0x0b;
         pchMessageStart[1] = 0x11;
         pchMessageStart[2] = 0x09;
@@ -306,6 +310,8 @@ public:
 
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S("0x00");
+
+        consensus.genesis_subsidy = 50*COIN;
 
         pchMessageStart[0] = 0xfa;
         pchMessageStart[1] = 0xbf;
@@ -419,6 +425,9 @@ class CCustomParams : public CRegTestParams {
 
         consensus.nMinimumChainWork = uint256S(args.GetArg("-con_nminimumchainwork", "0x0"));
         consensus.defaultAssumeValid = uint256S(args.GetArg("-con_defaultassumevalid", "0x00"));
+
+        // No subsidy for custom chains by default
+        consensus.genesis_subsidy = args.GetArg("-con_blocksubsidy", 0);
 
         // All non-zero coinbase outputs must go to this scriptPubKey
         std::vector<unsigned char> man_bytes = ParseHex(gArgs.GetArg("-con_mandatorycoinbase", ""));

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -24,6 +24,7 @@ void SetupChainParamsBaseOptions()
     gArgs.AddArg("-vbparams=deployment:start:end", "Use given start/end times for specified version bits deployment (regtest or custom only)", true, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-con_mandatorycoinbase", "All non-zero valued coinbase outputs must go to this scriptPubKey, if set.", false, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-seednode=<ip>", "Use specified node as seed node. This option can be specified multiple times to connect to multiple nodes. (custom only)", true, OptionsCategory::CHAINPARAMS);
+    gArgs.AddArg("-con_blocksubsidy", "Defines the amount of block subsidy to start with, at genesis block.", false, OptionsCategory::CHAINPARAMS);
 }
 
 static std::unique_ptr<CBaseChainParams> globalChainBaseParams;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -12,6 +12,7 @@
 #include <string>
 
 #include <script/script.h> // mandatory_coinbase_destination
+#include <amount.h> // genesis_subsidy
 
 namespace Consensus {
 
@@ -80,6 +81,7 @@ struct Params {
 
     // Elements-specific chainparams
     CScript mandatory_coinbase_destination;
+    CAmount genesis_subsidy;
 };
 } // namespace Consensus
 

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -34,6 +34,7 @@ static void TestBlockSubsidyHalvings(int nSubsidyHalvingInterval)
 {
     Consensus::Params consensusParams;
     consensusParams.nSubsidyHalvingInterval = nSubsidyHalvingInterval;
+    consensusParams.genesis_subsidy = 50*COIN;
     TestBlockSubsidyHalvings(consensusParams);
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1169,7 +1169,7 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
     if (halvings >= 64)
         return 0;
 
-    CAmount nSubsidy = 50 * COIN;
+    CAmount nSubsidy = consensusParams.genesis_subsidy;
     // Subsidy is cut in half every 210,000 blocks which will occur approximately every 4 years.
     nSubsidy >>= halvings;
     return nSubsidy;

--- a/test/functional/feature_block_subsidy.py
+++ b/test/functional/feature_block_subsidy.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test parameterized block subsidy"""
+
+from binascii import b2a_hex
+from decimal import Decimal
+
+from test_framework.blocktools import create_coinbase
+from test_framework.messages import CBlock
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+def b2x(b):
+    return b2a_hex(b).decode('ascii')
+
+def assert_template(node, block, expect, rehash=True):
+    if rehash:
+        block.hashMerkleRoot = block.calc_merkle_root()
+        block.calc_sha256()
+    rsp = node.getblocktemplate({'data': b2x(block.serialize()), 'mode': 'proposal'})
+    assert_equal(rsp, expect)
+
+class BlockSubsidyTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+        # 10 satoshi block subsidy at start for one node, none for other
+        self.extra_args = [["-con_blocksubsidy=10"], ["-con_blocksubsidy=0"]]
+
+    def run_test(self):
+
+        # Block will have 10 satoshi output, node 1 will ban
+        addr = self.nodes[0].getnewaddress()
+        sub_block = self.nodes[0].generatetoaddress(1, addr)
+
+        raw_coinbase = self.nodes[0].getrawtransaction(self.nodes[0].getblock(sub_block[0])["tx"][0])
+        decoded_coinbase = self.nodes[0].decoderawtransaction(raw_coinbase)
+
+        found_ten = False
+        for vout in decoded_coinbase["vout"]:
+            if vout["value"] == Decimal('0.00000010') and found_ten == False:
+                found_ten = True
+            elif vout["value"] == 0:
+                continue
+            else:
+                raise Exception("Invalid output amount in coinbase")
+
+        assert(found_ten)
+
+        # Block will have 0 satoshis outputs only at height 1
+        no_sub_block = self.nodes[1].generatetoaddress(1, addr)
+        raw_coinbase = self.nodes[1].getrawtransaction(self.nodes[1].getblock(no_sub_block[0])["tx"][0])
+        decoded_coinbase = self.nodes[1].decoderawtransaction(raw_coinbase)
+        for vout in decoded_coinbase["vout"]:
+            if vout["value"] != 0:
+                raise Exception("Invalid output amount in coinbase")
+
+        tmpl = self.nodes[0].getblocktemplate()
+
+        # Template with invalid amount(50*COIN) will be invalid in both
+        coinbase_tx = create_coinbase(height=int(tmpl["height"]) + 1)
+
+        block = CBlock()
+        block.nVersion = tmpl["version"]
+        block.hashPrevBlock = int(tmpl["previousblockhash"], 16)
+        block.nTime = tmpl["curtime"]
+        block.nBits = int(tmpl["bits"], 16)
+        block.nNonce = 0
+        block.vtx = [coinbase_tx]
+
+        assert_template(self.nodes[0], block, "bad-cb-amount")
+
+        # Set to proper value, resubmit
+        block.vtx[0].vout[0].nValue = 10
+        block.vtx[0].sha256 = None
+        assert_template(self.nodes[0], block, None)
+
+        # No subsidy also allowed
+        block.vtx[0].vout[0].nValue = 0
+        block.vtx[0].sha256 = None
+        assert_template(self.nodes[0], block, None)
+
+        # Change previous blockhash to other nodes' genesis block and reward to 1, test again
+        block.hashPrevBlock = int(self.nodes[1].getblockhash(self.nodes[1].getblockcount()), 16)
+        block.vtx[0].vout[0].nValue = 1
+        block.vtx[0].sha256 = None
+        assert_template(self.nodes[1], block, "bad-cb-amount")
+
+        block.vtx[0].vout[0].nValue = 0
+        block.vtx[0].sha256 = None
+        assert_template(self.nodes[1], block, None)
+
+if __name__ == '__main__':
+    BlockSubsidyTest().main()

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -305,6 +305,7 @@ def initialize_datadir(dirname, n, chain):
         f.write("discover=0\n")
         f.write("listenonion=0\n")
         f.write("printtoconsole=0\n")
+        f.write("con_blocksubsidy=5000000000\n")
         os.makedirs(os.path.join(datadir, 'stderr'), exist_ok=True)
         os.makedirs(os.path.join(datadir, 'stdout'), exist_ok=True)
     return datadir

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -154,6 +154,7 @@ BASE_SCRIPTS = [
     'feature_config_args.py',
     'feature_help.py',
     'feature_mandatory_coinbase.py',
+    'feature_block_subsidy.py'
     # Don't append tests at the end to avoid merge conflicts
     # Put them in a random line within the section that fits their approximate run-time
 ]


### PR DESCRIPTION
Previously we just set this to 0 and continued, this allows tests to otherwise pass up until this point.