### PR TITLE
pin flake8 version to avoid breaking compatibilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -158,7 +158,7 @@ jobs:
       language: python
       python: '3.6'
       install:
-        - travis_retry pip install flake8
+        - travis_retry pip install flake8==3.5.0
       before_script:
         - git fetch --unshallow
       script:


### PR DESCRIPTION
This happened upstream too.