### PR TITLE
Changed tutorial bitcoin config file to work with new core v0.17 format

### DIFF
--- a/contrib/assets_tutorial/bitcoin.conf
+++ b/contrib/assets_tutorial/bitcoin.conf
@@ -2,8 +2,6 @@ regtest=1
 daemon=1
 txindex=1
 
-regtest.rpcuser=user3
-regtest.rpcpassword=password3
 regtest.rpcport=18888
 regtest.port=18889
 

--- a/contrib/assets_tutorial/bitcoin.conf
+++ b/contrib/assets_tutorial/bitcoin.conf
@@ -1,9 +1,14 @@
+regtest=1
+daemon=1
+txindex=1
+
+regtest.rpcuser=user3
+regtest.rpcpassword=password3
+regtest.rpcport=18888
+regtest.port=18889
+
 rpcuser=user3
 rpcpassword=password3
 rpcport=18888
 port=18889
 
-regtest=1
-testnet=0
-daemon=1
-txindex=1


### PR DESCRIPTION
Core v0.17 now handles config file settings differently and loads the existing config settings as mainnet and not regtest. This means our e1 and e2 nodes in the tutorial can't connect. 

This PR makes the bitcoin.conf file compatible with both formats. Without this change the tutorial code fails if you are using bitcoind v0.17.0.0.

REF: https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-0.17.0.md

If the following options are not in a section, they will only apply to mainnet:
`addnode=`, `connect=`, `port=`, `bind=`, `rpcport=`, `rpcbind=` and `wallet=`.
The options to choose a network (`regtest=` and `testnet=`) must be specified
outside of sections.

Tested with bitcoind v0.16.2.0 and v0.17.0.0