### PR TITLE
Add comment on witness-null issuance transactions' invalidity

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -862,6 +862,9 @@ bool VerifyAmounts(const CCoinsViewCache& cache, const CTransaction& tx, std::ve
             return false;
         }
         if (!issuance.nAmount.IsNull()) {
+            // Note: This check disallows issuances in transactions with *no* witness data.
+            // This can be relaxed in a future update as a HF by passing in an empty rangeproof
+            // to `VerifyIssuanceAmount` instead.
             if (i >= tx.wit.vtxinwit.size()) {
                 return false;
             }
@@ -889,6 +892,9 @@ bool VerifyAmounts(const CCoinsViewCache& cache, const CTransaction& tx, std::ve
                 return false;
             }
 
+            // Note: This check disallows issuances in transactions with *no* witness data.
+            // This can be relaxed in a future update as a HF by passing in an empty rangeproof
+            // to `VerifyIssuanceAmount` instead.
             if (i >= tx.wit.vtxinwit.size()) {
                 return false;
             }


### PR DESCRIPTION
Transaction serialization requires that witness-empty transactions have empty witness vectors for inputs and outputs. While fixing the OOB access in `VerifyAmounts` we accidentally softforked out the ability to have issuances in transactions with no other witness data. In real-life usage this is fairly unlikely, since any blinding, any segwit signatures, and any peg-in data make this not true.