### PR TITLE
remove unnecessary confValue reassignment

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -727,7 +727,6 @@ void FillBlinds(CMutableTransaction& tx, bool fUseWallet, std::vector<uint256>& 
                 if (fUseWallet && UnblindConfidentialPair(pwalletMain->GetBlindingKey(&blindingScript), confValue, CConfidentialAsset(asset), CConfidentialNonce(), CScript(), vchRangeproof, amount, blinding_factor, asset, asset_blinding_factor) != 0) {
                     // Wipe out confidential info from issuance
                     vchRangeproof.clear();
-                    confValue = CConfidentialValue(amount);
                     // One key both blinded values, single key needed for issuance reveal
                     asset_keys.push_back(pwalletMain->GetBlindingKey(&blindingScript));
                     token_keys.push_back(pwalletMain->GetBlindingKey(&blindingScript));


### PR DESCRIPTION
A minor nitpick, but removing redundant code improves readability.

I was reading the code for FillBlinds() and noticed that there is unnecessary assignment of confValue, because the value is not used after that - its scope is within the loop, and it is set anew at the start of the loop.

"//Wipe out confidential info from issuance" comment is applicable to vchRangeproof.clear(), but not to confValue reassignment - becasue this variable is just a reference.

NOTE: I did not compile or tested the code.  I just wanted to report this minor thing.  I am not sure that creating a PR is a correct channel to notify about this sort of nitpicks, maybe I should have created an issue instead of PR ?