### PR TITLE
[0.17] Full RBF support

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1153,8 +1153,16 @@ bool AppInitParameterInteraction()
         // Minimal effort at forwards compatibility
         std::string strReplacementModeList = gArgs.GetArg("-mempoolreplacement", "");  // default is impossible
         std::vector<std::string> vstrReplacementModes;
-        boost::split(vstrReplacementModes, strReplacementModeList, boost::is_any_of(","));
+        boost::split(vstrReplacementModes, strReplacementModeList, boost::is_any_of(",+"));
         fEnableReplacement = (std::find(vstrReplacementModes.begin(), vstrReplacementModes.end(), "fee") != vstrReplacementModes.end());
+        if (fEnableReplacement) {
+            fReplacementHonourOptOut = (std::find(vstrReplacementModes.begin(), vstrReplacementModes.end(), "-optin") == vstrReplacementModes.end());
+            if (!fReplacementHonourOptOut) {
+                nLocalServices = ServiceFlags(nLocalServices | NODE_REPLACE_BY_FEE);
+            }
+        } else {
+            fReplacementHonourOptOut = true;
+        }
     }
 
     return true;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -276,6 +276,8 @@ enum ServiceFlags : uint64_t {
     // collisions and other cases where nodes may be advertising a service they
     // do not actually support. Other service bits should be allocated via the
     // BIP process.
+
+    NODE_REPLACE_BY_FEE = (1 << 26),
 };
 
 /**

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -835,6 +835,9 @@ QString formatServicesStr(quint64 mask)
             case NODE_XTHIN:
                 strList.append("XTHIN");
                 break;
+            case NODE_REPLACE_BY_FEE:
+                strList.append("REPLACE_BY_FEE?");
+                break;
             default:
                 strList.append(QString("%1[%2]").arg("UNKNOWN").arg(check));
             }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -233,6 +233,7 @@ size_t nCoinCacheUsage = 5000 * 300;
 uint64_t nPruneTarget = 0;
 int64_t nMaxTipAge = DEFAULT_MAX_TIP_AGE;
 bool fEnableReplacement = DEFAULT_ENABLE_REPLACEMENT;
+bool fReplacementHonourOptOut = DEFAULT_REPLACEMENT_HONOUR_OPTOUT;
 
 uint256 hashAssumeValid;
 arith_uint256 nMinimumChainWork;
@@ -623,6 +624,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
                 bool fReplacementOptOut = true;
                 if (fEnableReplacement)
                 {
+                  if (fReplacementHonourOptOut) {
                     for (const CTxIn &_txin : ptxConflicting->vin)
                     {
                         if (_txin.nSequence <= MAX_BIP125_RBF_SEQUENCE)
@@ -631,6 +633,9 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
                             break;
                         }
                     }
+                  } else {
+                        fReplacementOptOut = false;
+                  }
                 }
                 if (fReplacementOptOut) {
                     return state.Invalid(false, REJECT_DUPLICATE, "txn-mempool-conflict");

--- a/src/validation.h
+++ b/src/validation.h
@@ -122,6 +122,7 @@ static const unsigned int DEFAULT_BANSCORE_THRESHOLD = 100;
 static const bool DEFAULT_PERSIST_MEMPOOL = true;
 /** Default for -mempoolreplacement */
 static const bool DEFAULT_ENABLE_REPLACEMENT = true;
+static const bool DEFAULT_REPLACEMENT_HONOUR_OPTOUT = true;
 /** Default for using fee filter */
 static const bool DEFAULT_FEEFILTER = true;
 
@@ -169,6 +170,7 @@ extern CAmount maxTxFee;
 /** If the tip is older than this (in seconds), the node is considered to be in initial block download. */
 extern int64_t nMaxTipAge;
 extern bool fEnableReplacement;
+extern bool fReplacementHonourOptOut;
 
 /** Block hash whose ancestors we will assume to have valid scripts without checking them. */
 extern uint256 hashAssumeValid;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -60,7 +60,7 @@ static const bool DEFAULT_AVOIDPARTIALSPENDS = false;
 //! -txconfirmtarget default
 static const unsigned int DEFAULT_TX_CONFIRM_TARGET = 6;
 //! -walletrbf default
-static const bool DEFAULT_WALLET_RBF = false;
+static const bool DEFAULT_WALLET_RBF = true;
 static const bool DEFAULT_WALLETBROADCAST = true;
 static const bool DEFAULT_DISABLE_WALLET = false;
 

--- a/test/bitcoin_functional/functional/test_framework/util.py
+++ b/test/bitcoin_functional/functional/test_framework/util.py
@@ -305,10 +305,12 @@ def initialize_datadir(dirname, n, chain):
         f.write("discover=0\n")
         f.write("listenonion=0\n")
         f.write("printtoconsole=0\n")
+        # Elements:
         f.write("con_blocksubsidy=5000000000\n")
         f.write("con_connect_coinbase=0\n")
         f.write("anyonecanspendaremine=0\n")
         f.write("con_blockheightinheader=0\n")
+        f.write("walletrbf=0\n") # Default is 1 in Elements
         f.write("con_bip34height=100000000\n")
         f.write("con_bip65height=1351\n")
         f.write("con_bip66height=1251\n")

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -305,9 +305,11 @@ def initialize_datadir(dirname, n, chain):
         f.write("discover=0\n")
         f.write("listenonion=0\n")
         f.write("printtoconsole=0\n")
+        # Elements:
         f.write("con_blocksubsidy=5000000000\n")
         f.write("con_connect_coinbase=0\n")
         f.write("anyonecanspendaremine=0\n")
+        f.write("walletrbf=0\n") # Default is 1 in Elements
         f.write("con_bip34height=100000000\n")
         f.write("con_bip65height=1351\n")
         f.write("con_bip66height=1251\n")


### PR DESCRIPTION
Setting `-mempoolreplacement=fee,-optin` will cause the node to honor any RBF replacements even if they had the opt-out flags set.

This also sets the default for the wallet to create bip125-signaling transactions.