### PR TITLE
add standard license header to src/blind.cpp

### DIFF
--- a/src/blind.cpp
+++ b/src/blind.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2017-2018 The Elements Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "blind.h"
 
 #include "hash.h"


### PR DESCRIPTION
As discussed in #485, src/blind.cpp should have a standard license header.