### PR TITLE
Fix UnblindConfidentialPair: use IsFullyValid() for ephemeral_key

### DIFF
--- a/src/blind.cpp
+++ b/src/blind.cpp
@@ -41,7 +41,7 @@ bool UnblindConfidentialPair(const CKey &key, const CConfidentialValue& confValu
         return false;
     }
     CPubKey ephemeral_key(nNonce.vchCommitment);
-    if (nNonce.vchCommitment.size() > 0 && !ephemeral_key.IsValid()) {
+    if (nNonce.vchCommitment.size() > 0 && !ephemeral_key.IsFullyValid()) {
         return false;
     }
 

--- a/src/test/blind_tests.cpp
+++ b/src/test/blind_tests.cpp
@@ -302,6 +302,20 @@ BOOST_AUTO_TEST_CASE(naive_blinding_test)
         BOOST_CHECK(asset_out == unblinded_id);
         BOOST_CHECK(unblinded_amount == 50);
 
+        // Make invalid public keys in nonce commitment, first of right size
+        tx4.vout[2].nNonce.vchCommitment = std::vector<unsigned char>(33, 0);
+        tx4.vout[2].nNonce.vchCommitment[0] = 0x03;
+        BOOST_CHECK(UnblindConfidentialPair(key2, tx4.vout[2].nValue, tx4.vout[2].nAsset, tx4.vout[2].nNonce, scriptCommit, tx4.wit.vtxoutwit[2].vchRangeproof, unblinded_amount, blind4, asset_out, asset_blinder_out) == 0);
+
+        // Next, leading byte claiming to be 33 bytes in size
+        tx4.vout[2].nNonce.vchCommitment.resize(1);
+        BOOST_CHECK(UnblindConfidentialPair(key2, tx4.vout[2].nValue, tx4.vout[2].nAsset, tx4.vout[2].nNonce, scriptCommit, tx4.wit.vtxoutwit[2].vchRangeproof, unblinded_amount, blind4, asset_out, asset_blinder_out) == 0);
+
+        // Last, blank
+        tx4.vout[2].nNonce.vchCommitment.clear();
+        BOOST_CHECK(UnblindConfidentialPair(key2, tx4.vout[2].nValue, tx4.vout[2].nAsset, tx4.vout[2].nNonce, scriptCommit, tx4.wit.vtxoutwit[2].vchRangeproof, unblinded_amount, blind4, asset_out, asset_blinder_out) == 0);
+
+
         CCoinsModifier in4 = cache.ModifyCoins(ArithToUint256(4));
         in4->vout.resize(4);
         in4->vout[0] = tx4.vout[0];


### PR DESCRIPTION
if nNonce.vchCommitment contains invalid key of correct length,
IsValid() check will pass, but then assertion will be hit
when secp256k1_ec_pubkey_parse() is called on it inside CKey::ECDH().
Therefore, the check should be done with IsFullyValid()

reported in #488