### PR TITLE
check amount against MAX_MONEY with unsigned comparison

### DIFF
--- a/src/blind.cpp
+++ b/src/blind.cpp
@@ -95,7 +95,7 @@ bool UnblindConfidentialPair(const CKey &key, const CConfidentialValue& confValu
     }
 
     // Value sidechannel must be a transaction-valid amount (should be belt-and-suspenders check)
-    if (!MoneyRange((CAmount)amount)) {
+    if (amount > (uint64_t)MAX_MONEY || !MoneyRange((CAmount)amount)) {
         return false;
     }
 


### PR DESCRIPTION
Because explicit conversion of arbitrarily large unsigned values
to signed values of the same bit width is implementation defined
until c++20, better check against MAX_MONEY with unsigned comparison.