### PR TITLE
Chang claimpegin depth to 102 in api docs

### DIFF
--- a/doc/elements-api.md
+++ b/doc/elements-api.md
@@ -237,7 +237,7 @@ elements-cli blindrawtransaction $raw_tx
 
 The `claimpegin` RPC claims bitcoins that you deposited to a pegin
 address on the main chain.  The mainchain deposit transaction must have
-at least 10 confirmations before the claim is valid. On some
+at least 102 confirmations before the claim is valid. On some
 sidechains you may need to use a special method not described here to
 submit the claim to a functionary in order for it to be mined.
 


### PR DESCRIPTION
Previously stated deposit tx depth must be 10 but I think it's 102

ref issue #506 