### PR TITLE
Let's try to have more builds complete within allotted time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ jobs:
         BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++"
         CONFIG_SHELL="/bin/dash"
         RUN_UNIT_TESTS=false # secp-zkp times out Travis, get 32-bit build in upstream?
-# x86_64 Linux (uses qt5 dev package instead of depends Qt to speed up build and avoid timeout)
+# x86_64 Linux (uses qt5 dev package instead of depends Qt to speed up build and avoid timeout), no functional tests
     - stage: test
       env: >-
         HOST=x86_64-unknown-linux-gnu
@@ -101,6 +101,16 @@ jobs:
         DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1 ALLOW_HOST_PACKAGES=1"
         GOAL="install"
         BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports --enable-debug CXXFLAGS=\"-g0 -O2\""
+        RUN_FUNCTIONAL_TESTS=false
+# x86_64 Linux (uses qt5 dev package instead of depends Qt to speed up build and avoid timeout), no unit tests
+    - stage: test
+      env: >-
+        HOST=x86_64-unknown-linux-gnu
+        PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools protobuf-compiler libdbus-1-dev libharfbuzz-dev libprotobuf-dev"
+        DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1 ALLOW_HOST_PACKAGES=1"
+        GOAL="install"
+        BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports --enable-debug CXXFLAGS=\"-g0 -O2\""
+        RUN_UNIT_TESTS=false
 # x86_64 Linux (no depends, only system libs)
     - stage: test
       env: >-

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ jobs:
         PACKAGES="python3 nsis g++-mingw-w64-i686 wine-binfmt wine32"
         GOAL="install"
         BITCOIN_CONFIG="--enable-reduce-exports"
+        RUN_UNIT_TESTS=false # secp-zkp times out Travis, get 32-bit build in upstream?
 # Win64
     - stage: test
       env: >-
@@ -91,6 +92,7 @@ jobs:
         GOAL="install"
         BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++"
         CONFIG_SHELL="/bin/dash"
+        RUN_UNIT_TESTS=false # secp-zkp times out Travis, get 32-bit build in upstream?
 # x86_64 Linux (uses qt5 dev package instead of depends Qt to speed up build and avoid timeout)
     - stage: test
       env: >-


### PR DESCRIPTION
secp-zkp unit tests takes over 10 minutes, which triggers a Travis timeout.

Until we fix it upstream it's probably better to know it compiles and maybe passes functional tests.

DEBUG=1 builds are also timing out, so split up concerns into two different runs.