### PR TITLE
Properly serialize surjection proof in caching checker

### DIFF
--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -202,9 +202,9 @@ bool CachingSurjectionProofChecker::VerifySurjectionProof(secp256k1_surjectionpr
 
     // Serialize proof
     std::vector<unsigned char> vchproof;
-    size_t proof_len = 0;
-    vchproof.resize(secp256k1_surjectionproof_serialized_size(secp256k1_ctx_verify_amounts, &proof));
-    secp256k1_surjectionproof_serialize(secp256k1_ctx_verify_amounts, &vchproof[0], &proof_len, &proof);
+    size_t proof_len = secp256k1_surjectionproof_serialized_size(secp256k1_ctx_verify_amounts, &proof);
+    vchproof.resize(proof_len);
+    assert(secp256k1_surjectionproof_serialize(secp256k1_ctx_verify_amounts, &vchproof[0], &proof_len, &proof) == 1);
 
     // wtxid commits to all data including surj targets
     // we need to specify the proof and output asset point to be unique


### PR DESCRIPTION
@dgpv 