### PR TITLE
Blockindex compatibility fix, startup speedup

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -210,7 +210,6 @@ public:
     int32_t nVersion;
     uint256 hashMerkleRoot;
     uint32_t nTime;
-    uint32_t block_height;
     uint32_t nBits;
     uint32_t nNonce;
     CProof proof;
@@ -240,7 +239,6 @@ public:
         nVersion       = 0;
         hashMerkleRoot = uint256();
         nTime          = 0;
-        block_height   = 0;
         nBits          = 0;
         nNonce         = 0;
         proof.SetNull();
@@ -258,7 +256,6 @@ public:
         nVersion       = block.nVersion;
         hashMerkleRoot = block.hashMerkleRoot;
         nTime          = block.nTime;
-        block_height   = block.block_height;
         nBits          = block.nBits;
         nNonce         = block.nNonce;
         proof          = block.proof;
@@ -290,7 +287,9 @@ public:
             block.hashPrevBlock = pprev->GetBlockHash();
         block.hashMerkleRoot = hashMerkleRoot;
         block.nTime          = nTime;
-        block.block_height   = block_height;
+        if (g_con_blockheightinheader) {
+            block.block_height = nHeight;
+        }
         block.nBits          = nBits;
         block.nNonce         = nNonce;
         block.proof          = proof;
@@ -411,7 +410,6 @@ public:
         READWRITE(hashPrev);
         READWRITE(hashMerkleRoot);
         READWRITE(nTime);
-        READWRITE(block_height);
         // For compatibility with elements 0.14 based chains
         if (g_signed_blocks) {
             READWRITE(proof);
@@ -428,7 +426,9 @@ public:
         block.hashPrevBlock   = hashPrev;
         block.hashMerkleRoot  = hashMerkleRoot;
         block.nTime           = nTime;
-        block.block_height    = block_height;
+        if (g_con_blockheightinheader) {
+            block.block_height = nHeight;
+        }
         block.nBits           = nBits;
         block.nNonce          = nNonce;
         block.proof           = proof;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -320,7 +320,9 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
                 pindexNew->nTx            = diskindex.nTx;
 
                 const uint256 block_hash = pindexNew->GetBlockHash();
-                if (!CheckProof(pindexNew->GetBlockHeader(), consensusParams) &&
+                // Only validate one of every 1000 block header for sanity check
+                if (pindexNew->nHeight % 1000 == 0 &&
+                        !CheckProof(pindexNew->GetBlockHeader(), consensusParams) &&
                     block_hash != consensusParams.hashGenesisBlock) {
                     return error("%s: CheckProof: %s, %s", __func__, block_hash.ToString(), pindexNew->ToString());
                 }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -307,7 +307,6 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
                 CBlockIndex* pindexNew = insertBlockIndex(diskindex.GetBlockHash());
                 pindexNew->pprev          = insertBlockIndex(diskindex.hashPrev);
                 pindexNew->nHeight        = diskindex.nHeight;
-                pindexNew->block_height   = diskindex.block_height;
                 pindexNew->nFile          = diskindex.nFile;
                 pindexNew->nDataPos       = diskindex.nDataPos;
                 pindexNew->nUndoPos       = diskindex.nUndoPos;


### PR DESCRIPTION
We diverged from the 0.14 codebase, fix included here as well as performance speedup on initial load.

In 0.14 we did no signature checking at all, but the signature checks were what alerted me to the incompatibility, so I opted to preserve some of that as sanity check.