### PR TITLE
Make new actually working master blinding calls, test

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -190,7 +190,6 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "sendmany", 8 , "output_assets" },
     { "sendmany", 9 , "ignoreblindfail" },
     { "sendtoaddress", 9 , "ignoreblindfail" },
-    { "importblindingkey", 2, "key_is_master"},
     { "createrawtransaction", 4, "output_assets" },
 
 };

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -6199,8 +6199,10 @@ UniValue getpegoutkeys(const JSONRPCRequest& request)
 UniValue abortrescan(const JSONRPCRequest& request); // in rpcdump.cpp
 UniValue dumpprivkey(const JSONRPCRequest& request); // in rpcdump.cpp
 UniValue importblindingkey(const JSONRPCRequest& request); // in rpcdump.cpp
+UniValue importmasterblindingkey(const JSONRPCRequest& request); // in rpcdump.cpp
 UniValue importissuanceblindingkey(const JSONRPCRequest& request); // in rpcdump.cpp
 UniValue dumpblindingkey(const JSONRPCRequest& request); // in rpcdump.cpp
+UniValue dumpmasterblindingkey(const JSONRPCRequest& request); // in rpcdump.cpp
 UniValue dumpissuanceblindingkey(const JSONRPCRequest& request); // in rpcdump.cpp
 UniValue importprivkey(const JSONRPCRequest& request);
 UniValue importaddress(const JSONRPCRequest& request);
@@ -6281,9 +6283,11 @@ static const CRPCCommand commands[] =
     { "wallet",             "sendtomainchain",                  &sendtomainchain,               {"address", "amount", "subtractfeefromamount"} },
     { "wallet",             "initpegoutwallet",                 &initpegoutwallet,              {"bitcoin_descriptor", "bip32_counter", "liquid_pak"} },
     { "wallet",             "getwalletpakinfo",                 &getwalletpakinfo,              {} },
-    { "wallet",             "importblindingkey",                &importblindingkey,             {"address", "hexkey", "key_is_master"}},
+    { "wallet",             "importblindingkey",                &importblindingkey,             {"address", "hexkey"}},
+    { "wallet",             "importmasterblindingkey",          &importmasterblindingkey,       {"hexkey"}},
     { "wallet",             "importissuanceblindingkey",        &importissuanceblindingkey,     {"txid", "vin", "blindingkey"}},
     { "wallet",             "dumpblindingkey",                  &dumpblindingkey,               {"address"}},
+    { "wallet",             "dumpmasterblindingkey",            &dumpmasterblindingkey,         {}},
     { "wallet",             "dumpissuanceblindingkey",          &dumpissuanceblindingkey,       {"txid", "vin"}},
     { "wallet",             "signblock",                        &signblock,                     {"blockhex"}},
     { "wallet",             "listissuances",                    &listissuances,                 {"asset"}},


### PR DESCRIPTION
resolves https://github.com/ElementsProject/elements/issues/547

Previous API was improperly overloading the specific blinding key calls, and incorrectly on top of that.

Instead implement `importmasterblindingkey` and `dumpmasterblindingkey` and check that `dumpwallet` details are enough to recover same blinded wallet addresses.