### PR TITLE
issueasset contract_hash arg, default of generated key in wallet

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -5713,7 +5713,7 @@ UniValue issueasset(const JSONRPCRequest& request)
         return NullUniValue;
     }
 
-    if (request.fHelp || request.params.size() < 2 || request.params.size() > 3)
+    if (request.fHelp || request.params.size() < 2 || request.params.size() > 4)
         throw std::runtime_error(
             "issueasset assetamount tokenamount ( blind )\n"
             "\nCreate an asset. Must have funds in wallet to do so. Returns asset hex id.\n"
@@ -5721,6 +5721,7 @@ UniValue issueasset(const JSONRPCRequest& request)
             "1. \"assetamount\"           (numeric or string, required) Amount of asset to generate.\n"
             "2. \"tokenamount\"           (numeric or string, required) Amount of reissuance tokens to generate. These will allow you to reissue the asset if in wallet using `reissueasset`. These tokens are not consumed during reissuance.\n"
             "3. \"blind\"                 (bool, optional, default=true) Whether to blind the issuances.\n"
+            "4. \"contract_hash\"         (string, optional) 32-byte string to have asset id commit to.\n"
             "\nResult:\n"
             "{                        (json object)\n"
             "  \"txid\":\"<txid>\",   (string) Transaction id for issuance.\n"
@@ -5728,6 +5729,7 @@ UniValue issueasset(const JSONRPCRequest& request)
             "  \"entropy\":\"<entropy>\", (string) Entropy of the asset type.\n"
             "  \"asset\":\"<asset>\", (string) Asset type for issuance.\n"
             "  \"token\":\"<token>\", (string) Token type for issuance.\n"
+            "  \"contract_hash\":<hex> (string) If no `contract_hash` was given as an argument, this will be the SHA256 image of a newly generated public key from your wallet. Can be used to prove authorship of issuance after the fact.\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("issueasset", "10 0")
@@ -5771,9 +5773,18 @@ UniValue issueasset(const JSONRPCRequest& request)
         token_dest_blindpub = pwallet->GetBlindingPubKey(GetScriptForDestination(token_dest));
     }
 
-    uint256 dummyentropy;
-    CAsset dummyasset;
     IssuanceDetails issuance_details;
+
+    if (!request.params[3].isNull()) {
+        issuance_details.contract_hash = ParseHashV(request.params[3], "contract_hash");
+    } else {
+        // Finally get contract hash key
+        if (!pwallet->GetKeyFromPool(newKey)) {
+                throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Error: Keypool ran out, please call keypoolrefill first");
+        }
+        issuance_details.contract_hash = newKey.GetHash();
+    }
+
     issuance_details.blind_issuance = blind_issuances;
     CTransactionRef tx_ref = SendGenerationTransaction(GetScriptForDestination(asset_dest), asset_dest_blindpub, GetScriptForDestination(token_dest), token_dest_blindpub, nAmount, nTokens, &issuance_details, pwallet);
 
@@ -5781,7 +5792,7 @@ UniValue issueasset(const JSONRPCRequest& request)
     CAsset asset;
     CAsset token;
     assert(!tx_ref->vin.empty());
-    GenerateAssetEntropy(issuance_details.entropy, tx_ref->vin[0].prevout, uint256());
+    GenerateAssetEntropy(issuance_details.entropy, tx_ref->vin[0].prevout, issuance_details.contract_hash);
     CalculateAsset(asset, issuance_details.entropy);
     CalculateReissuanceToken(token, issuance_details.entropy, blind_issuances);
 
@@ -5791,6 +5802,7 @@ UniValue issueasset(const JSONRPCRequest& request)
     ret.pushKV("entropy", issuance_details.entropy.GetHex());
     ret.pushKV("asset", asset.GetHex());
     ret.pushKV("token", token.GetHex());
+    ret.pushKV("contract_hash", issuance_details.contract_hash.GetHex());
     return ret;
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3223,7 +3223,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
                         CAsset token;
                         //TODO take optional contract hash
                         // Initial issuance always uses vin[0]
-                        GenerateAssetEntropy(entropy, txNew.vin[0].prevout, uint256());
+                        GenerateAssetEntropy(entropy, txNew.vin[0].prevout, issuance_details->contract_hash);
                         CalculateAsset(asset, entropy);
                         CalculateReissuanceToken(token, entropy, issuance_details->blind_issuance);
                         CScript blindingScript(CScript() << OP_RETURN << std::vector<unsigned char>(txNew.vin[0].prevout.hash.begin(), txNew.vin[0].prevout.hash.end()) << txNew.vin[0].prevout.n);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -629,6 +629,7 @@ struct CoinSelectionParams
 
 struct IssuanceDetails {
     bool issuing = false;
+    uint256 contract_hash;
 
     bool blind_issuance = true;
     CAsset reissuance_asset;


### PR DESCRIPTION
Completely untested, needs tests.

Kind of annoying it's the sha2 of the public key, but I gotta figure out how to graft a hash160 into it instead as the alternative.

resolves https://github.com/ElementsProject/elements/issues/536