### PR TITLE
Some more standard pegout testing

### DIFF
--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -33,7 +33,6 @@ public:
     std::string operator()(const PKHash& id) const
     {
         if (id.blinding_pubkey.IsFullyValid()) {
-            assert(!for_parent);
             std::vector<unsigned char> data = m_params.Base58Prefix(CChainParams::BLINDED_ADDRESS);
             // Blinded addresses have the actual address type prefix inside the payload.
             std::vector<unsigned char> prefix = m_params.Base58Prefix(CChainParams::PUBKEY_ADDRESS);
@@ -52,7 +51,6 @@ public:
     std::string operator()(const ScriptHash& id) const
     {
         if (id.blinding_pubkey.IsFullyValid()) {
-            assert(!for_parent);
             std::vector<unsigned char> data = m_params.Base58Prefix(CChainParams::BLINDED_ADDRESS);
             // Blinded addresses have the actual address type prefix inside the payload.
             std::vector<unsigned char> prefix = m_params.Base58Prefix(CChainParams::SCRIPT_ADDRESS);

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -56,6 +56,12 @@ static UniValue validateaddress(const JSONRPCRequest& request)
             "  \"witness_program\" : \"hex\"     (string, optional) The hex value of the witness program\n"
             "  \"confidential_key\" : \"hex\", (string) The hex value of the raw blinding public key for that address, if any. \"\" if none.\n"
             "  \"unconfidential\" : \"address\", (string) The address without confidentiality key.\n"
+            "   \"parent_address_info\":         (obj) If the address isvalid_parent, this object contains details about the parent address type.\n"
+            "   {\n"
+            "       \"address\" : \"address\",\n"
+            "       \"scriptPubKey\" : \"hex\",\n"
+            "       ...\n"
+            "   }\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("validateaddress", "\"1PSSGeFHDnKNxiEyFrD1wcEaHr9hrQDDWc\"")
@@ -81,6 +87,20 @@ static UniValue validateaddress(const JSONRPCRequest& request)
         ret.pushKVs(detail);
         UniValue blind_detail = DescribeBlindAddress(dest);
         ret.pushKVs(blind_detail);
+    }
+    if (is_valid_parent) {
+        UniValue parent_info(UniValue::VOBJ);
+        std::string currentAddress = EncodeParentDestination(parent_dest);
+        parent_info.pushKV("address", currentAddress);
+
+        CScript scriptPubKey = GetScriptForDestination(parent_dest);
+        parent_info.pushKV("scriptPubKey", HexStr(scriptPubKey.begin(), scriptPubKey.end()));
+
+        UniValue detail = DescribeAddress(parent_dest);
+        parent_info.pushKVs(detail);
+        UniValue blind_detail = DescribeBlindAddress(parent_dest);
+        parent_info.pushKVs(blind_detail);
+        ret.pushKV("parent_address_info", parent_info);
     }
     return ret;
 }

--- a/test/functional/feature_fedpeg.py
+++ b/test/functional/feature_fedpeg.py
@@ -15,8 +15,8 @@ from test_framework.util import (
 )
 from decimal import Decimal
 
-def get_new_unconfidential_address(node):
-    addr = node.getnewaddress()
+def get_new_unconfidential_address(node, addr_type="p2sh-segwit"):
+    addr = node.getnewaddress("", addr_type)
     val_addr = node.getaddressinfo(addr)
     if 'unconfidential' in val_addr:
         return val_addr['unconfidential']
@@ -148,6 +148,8 @@ class FedPegTest(BitcoinTestFramework):
                 pegout_tested = True
                 break
         assert pegout_tested
+        sidechain.generatetoaddress(1, sidechain.getnewaddress())
+        assert_equal(sidechain.gettransaction(pegout_txid)["confirmations"], 1)
 
     def run_test(self):
         parent = self.nodes[0]
@@ -289,8 +291,10 @@ class FedPegTest(BitcoinTestFramework):
             if "confirmations" not in tx or tx["confirmations"] == 0:
                 raise Exception("Peg-in confirmation has failed.")
 
-        print("Test pegout")
-        self.test_pegout(get_new_unconfidential_address(parent), sidechain)
+        print("Test pegouts")
+        self.test_pegout(get_new_unconfidential_address(parent, "legacy"), sidechain)
+        self.test_pegout(get_new_unconfidential_address(parent, "p2sh-segwit"), sidechain)
+        self.test_pegout(get_new_unconfidential_address(parent, "bech32"), sidechain)
 
         print("Test pegout P2SH")
         parent_chain_addr = get_new_unconfidential_address(parent)


### PR DESCRIPTION
Added more utility to `validateaddress` for parent addresses by returning an additional object `parent_address_info`, then used it to enhance various tests.