### PR TITLE
Adapt Elements default adress prefix bytes to elements-0.14 style

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -481,11 +481,17 @@ class CCustomParams : public CRegTestParams {
         fMineBlocksOnDemand = args.GetBoolArg("-fmineblocksondemand", fMineBlocksOnDemand);
         m_fallback_fee_enabled = args.GetBoolArg("-fallback_fee_enabled", m_fallback_fee_enabled);
 
-        bech32_hrp = args.GetArg("-bech32_hrp", bech32_hrp);
+        bech32_hrp = args.GetArg("-bech32_hrp", "ert");
         blech32_hrp = args.GetArg("-blech32_hrp", "el");
-        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, args.GetArg("-pubkeyprefix", 111));
-        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, args.GetArg("-scriptprefix", 196));
+        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, args.GetArg("-pubkeyprefix", 235));
+        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, args.GetArg("-scriptprefix", 75));
+        base58Prefixes[BLINDED_ADDRESS] = std::vector<unsigned char>(1, args.GetArg("-blindedprefix", 4));
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1, args.GetArg("-secretprefix", 239));
+        base58Prefixes[PARENT_PUBKEY_ADDRESS] = std::vector<unsigned char>(1, args.GetArg("-parentpubkeyprefix", 111));
+        base58Prefixes[PARENT_SCRIPT_ADDRESS] = std::vector<unsigned char>(1, args.GetArg("-parentscriptprefix", 196));
+        parent_bech32_hrp = args.GetArg("-parent_bech32_hrp", "bcrt");
+        parent_blech32_hrp = args.GetArg("-parent_blech32_hrp", "bcrt");
+
 
         std::string extpubprefix = args.GetArg("-extpubkeyprefix", "043587CF");
         assert(IsHex(extpubprefix) && extpubprefix.size() == 8 && "-extpubkeyprefix must be hex string of length 8");
@@ -558,13 +564,6 @@ class CCustomParams : public CRegTestParams {
 
         const CScript default_script(CScript() << OP_TRUE);
         consensus.fedpegScript = StrHexToScriptWithDefault(args.GetArg("-fedpegscript", ""), default_script);
-
-        base58Prefixes[PARENT_PUBKEY_ADDRESS] = std::vector<unsigned char>(1, args.GetArg("-parentpubkeyprefix", 111));
-        base58Prefixes[PARENT_SCRIPT_ADDRESS] = std::vector<unsigned char>(1, args.GetArg("-parentscriptprefix", 196));
-        parent_bech32_hrp = args.GetArg("-parent_bech32_hrp", "bcrt");
-        parent_blech32_hrp = args.GetArg("-parent_blech32_hrp", "bcrt");
-
-        base58Prefixes[BLINDED_ADDRESS] = std::vector<unsigned char>(1, args.GetArg("-blindedprefix", 4));
 
         // Calculate pegged Bitcoin asset
         std::vector<unsigned char> commit = CommitToArguments(consensus, strNetworkID);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4744,7 +4744,7 @@ UniValue sendtomainchain_base(const JSONRPCRequest& request)
 
     EnsureWalletIsUnlocked(pwallet);
 
-    CTxDestination parent_address = DecodeDestination(request.params[0].get_str());
+    CTxDestination parent_address = DecodeParentDestination(request.params[0].get_str());
     if (!IsValidDestination(parent_address))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
 

--- a/test/bitcoin_functional/functional/test_framework/util.py
+++ b/test/bitcoin_functional/functional/test_framework/util.py
@@ -319,6 +319,9 @@ def initialize_datadir(dirname, n, chain):
         f.write("con_genesis_style=bitcoin\n")
         f.write("con_csv_deploy_start=0\n") # Default is -1 (always active)
         f.write("blindedaddresses=0\n")
+        f.write("pubkeyprefix=111\n")
+        f.write("scriptprefix=196\n")
+        f.write("bech32_hrp=bcrt\n")
         os.makedirs(os.path.join(datadir, 'stderr'), exist_ok=True)
         os.makedirs(os.path.join(datadir, 'stdout'), exist_ok=True)
     return datadir

--- a/test/functional/feature_fedpeg.py
+++ b/test/functional/feature_fedpeg.py
@@ -68,6 +68,8 @@ class FedPegTest(BitcoinTestFramework):
                     "-anyonecanspendaremine",
                     "-signblockscript=51", # OP_TRUE
                     '-con_blocksubsidy=5000000000',
+                    "-pubkeyprefix=111",
+                    "-scriptprefix=196",
                 ])
 
             self.add_nodes(1, [extra_args], chain=[parent_chain], binary=parent_binary, chain_in_args=[not self.options.parent_bitcoin])

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -330,6 +330,9 @@ def initialize_datadir(dirname, n, chain):
         f.write("con_bip66height=1251\n")
         f.write("con_csv_deploy_start=0\n") # Enhance tests if removing this line
         f.write("blindedaddresses=0\n") # Set to minimize broken tests in favor of custom
+        f.write("pubkeyprefix=111\n")
+        f.write("scriptprefix=196\n")
+        f.write("bech32_hrp=bcrt\n")
         os.makedirs(os.path.join(datadir, 'stderr'), exist_ok=True)
         os.makedirs(os.path.join(datadir, 'stdout'), exist_ok=True)
     return datadir


### PR DESCRIPTION
Also chose `ert` as bech32 hrp, just to make it distinct.

Clustered the various address parameters for ease of the reader.

resolves https://github.com/ElementsProject/elements/issues/567