### PR TITLE
configure option --enable-liquid for default liquidv1 chain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -172,3 +172,13 @@ jobs:
         RUN_FEDPEG_BITCOIND_TEST=true
         GOAL="install"
         BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --enable-glibc-back-compat --enable-reduce-exports --with-gui=no --disable-tests --disable-bench CPPFLAGS=-DDEBUG_LOCKORDER"
+# x86_64 Linux (uses qt5 dev package instead of depends Qt to speed up build and avoid timeout), no functional tests, LIQUID BUILD
+    - stage: test
+      env: >-
+        HOST=x86_64-unknown-linux-gnu
+        PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools protobuf-compiler libdbus-1-dev libharfbuzz-dev libprotobuf-dev"
+        DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1 ALLOW_HOST_PACKAGES=1"
+        GOAL="install"
+        BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports --enable-debug --enable-liquid CXXFLAGS=\"-g0 -O2\""
+        RUN_FUNCTIONAL_TESTS=false
+

--- a/configure.ac
+++ b/configure.ac
@@ -194,8 +194,18 @@ AC_ARG_ENABLE([asm],
   [use_asm=$enableval],
   [use_asm=yes])
 
+AC_ARG_ENABLE([liquid],
+  [AS_HELP_STRING([--enable-liquid],
+  [Enable build that defaults to -chain=liquidv1])],
+  [liquid_build=yes],
+  [liquid_build=no])
+
 if test "x$use_asm" = xyes; then
   AC_DEFINE(USE_ASM, 1, [Define this symbol to build in assembly routines])
+fi
+
+if test "x$liquid_build" = xyes; then
+  AC_DEFINE(LIQUID, 1, [Define this symbol for Liquid builds])
 fi
 
 AC_ARG_WITH([system-univalue],
@@ -1378,6 +1388,7 @@ AM_CONDITIONAL([ENABLE_SSE41],[test x$enable_sse41 = xyes])
 AM_CONDITIONAL([ENABLE_AVX2],[test x$enable_avx2 = xyes])
 AM_CONDITIONAL([ENABLE_SHANI],[test x$enable_shani = xyes])
 AM_CONDITIONAL([USE_ASM],[test x$use_asm = xyes])
+AM_CONDITIONAL([LIQUID],[test x$liquid_build = xyes])
 
 AC_DEFINE(CLIENT_VERSION_MAJOR, _CLIENT_VERSION_MAJOR, [Major version])
 AC_DEFINE(CLIENT_VERSION_MINOR, _CLIENT_VERSION_MINOR, [Minor version])
@@ -1510,6 +1521,7 @@ echo "  with test     = $use_tests"
 echo "  with bench    = $use_bench"
 echo "  with upnp     = $use_upnp"
 echo "  use asm       = $use_asm"
+echo "  liquid_build  = $liquid_build"
 echo "  sanitizers    = $use_sanitizers"
 echo "  debug enabled = $enable_debug"
 echo "  gprof enabled = $enable_gprof"

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -42,7 +42,7 @@ script: |
 
   WRAP_DIR=$HOME/wrapped
   HOSTS="i686-pc-linux-gnu x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu"
-  CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --disable-gui-tests"
+  CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --disable-gui-tests --enable-liquid"
   FAKETIME_HOST_PROGS="gcc g++"
   FAKETIME_PROGS="date ar ranlib nm"
   HOST_CFLAGS="-O2 -g"

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -186,6 +186,10 @@ script: |
     find . -name "lib*.la" -delete
     find . -name "lib*.a" -delete
     rm -rf ${DISTNAME}/lib/pkgconfig
+    mv ${DISTNAME}/bin/elements-qt ${DISTNAME}/bin/liquid-qt
+    mv ${DISTNAME}/bin/elements-cli ${DISTNAME}/bin/liquid-cli
+    mv ${DISTNAME}/bin/elementsd ${DISTNAME}/bin/liquidd
+    mv ${DISTNAME}/bin/elements-tx ${DISTNAME}/bin/liquid-tx
     find ${DISTNAME}/bin -type f -executable -exec ../contrib/devtools/split-debug.sh {} {} {}.dbg \;
     find ${DISTNAME}/lib -type f -exec ../contrib/devtools/split-debug.sh {} {} {}.dbg \;
     cp ../doc/README.md ${DISTNAME}/

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -42,7 +42,9 @@ script: |
 
   WRAP_DIR=$HOME/wrapped
   HOSTS="i686-pc-linux-gnu x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu"
-  CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --disable-gui-tests --enable-liquid"
+  #LIQUID BUILDS: Replace next line with following
+  CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --disable-gui-tests"
+  #CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --disable-gui-tests --enable-liquid"
   FAKETIME_HOST_PROGS="gcc g++"
   FAKETIME_PROGS="date ar ranlib nm"
   HOST_CFLAGS="-O2 -g"
@@ -186,10 +188,13 @@ script: |
     find . -name "lib*.la" -delete
     find . -name "lib*.a" -delete
     rm -rf ${DISTNAME}/lib/pkgconfig
-    mv ${DISTNAME}/bin/elements-qt ${DISTNAME}/bin/liquid-qt
-    mv ${DISTNAME}/bin/elements-cli ${DISTNAME}/bin/liquid-cli
-    mv ${DISTNAME}/bin/elementsd ${DISTNAME}/bin/liquidd
-    mv ${DISTNAME}/bin/elements-tx ${DISTNAME}/bin/liquid-tx
+
+    # LIQUID: Uncomment next few lines
+    #mv ${DISTNAME}/bin/elements-qt ${DISTNAME}/bin/liquid-qt
+    #mv ${DISTNAME}/bin/elements-cli ${DISTNAME}/bin/liquid-cli
+    #mv ${DISTNAME}/bin/elementsd ${DISTNAME}/bin/liquidd
+    #mv ${DISTNAME}/bin/elements-tx ${DISTNAME}/bin/liquid-tx
+
     find ${DISTNAME}/bin -type f -executable -exec ../contrib/devtools/split-debug.sh {} {} {}.dbg \;
     find ${DISTNAME}/lib -type f -exec ../contrib/devtools/split-debug.sh {} {} {}.dbg \;
     cp ../doc/README.md ${DISTNAME}/

--- a/contrib/gitian-descriptors/gitian-liquid-linux.yml
+++ b/contrib/gitian-descriptors/gitian-liquid-linux.yml
@@ -42,7 +42,7 @@ script: |
 
   WRAP_DIR=$HOME/wrapped
   HOSTS="i686-pc-linux-gnu x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu"
-  CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --disable-gui-tests"
+  CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --disable-gui-tests --enable-liquid"
   FAKETIME_HOST_PROGS="gcc g++"
   FAKETIME_PROGS="date ar ranlib nm"
   HOST_CFLAGS="-O2 -g"
@@ -186,6 +186,11 @@ script: |
     find . -name "lib*.la" -delete
     find . -name "lib*.a" -delete
     rm -rf ${DISTNAME}/lib/pkgconfig
+
+    mv ${DISTNAME}/bin/elements-qt ${DISTNAME}/bin/liquid-qt
+    mv ${DISTNAME}/bin/elements-cli ${DISTNAME}/bin/liquid-cli
+    mv ${DISTNAME}/bin/elementsd ${DISTNAME}/bin/liquidd
+    mv ${DISTNAME}/bin/elements-tx ${DISTNAME}/bin/liquid-tx
 
     find ${DISTNAME}/bin -type f -executable -exec ../contrib/devtools/split-debug.sh {} {} {}.dbg \;
     find ${DISTNAME}/lib -type f -exec ../contrib/devtools/split-debug.sh {} {} {}.dbg \;

--- a/contrib/gitian-descriptors/gitian-liquid-osx.yml
+++ b/contrib/gitian-descriptors/gitian-liquid-osx.yml
@@ -36,7 +36,7 @@ files:
 script: |
   WRAP_DIR=$HOME/wrapped
   HOSTS="x86_64-apple-darwin14"
-  CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests GENISOIMAGE=$WRAP_DIR/genisoimage"
+  CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests --enable-liquid GENISOIMAGE=$WRAP_DIR/genisoimage"
   FAKETIME_HOST_PROGS=""
   FAKETIME_PROGS="ar ranlib date dmg genisoimage"
 
@@ -161,6 +161,11 @@ script: |
     ${WRAP_DIR}/dmg dmg "${OSX_VOLNAME}.dmg" ${OUTDIR}/${DISTNAME}-osx-unsigned.dmg
 
     cd installed
+
+    mv ${DISTNAME}/bin/elements-qt ${DISTNAME}/bin/liquid-qt
+    mv ${DISTNAME}/bin/elements-cli ${DISTNAME}/bin/liquid-cli
+    mv ${DISTNAME}/bin/elementsd ${DISTNAME}/bin/liquidd
+    mv ${DISTNAME}/bin/elements-tx ${DISTNAME}/bin/liquid-tx
 
     find ${DISTNAME} | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}.tar.gz
     cd ../../

--- a/contrib/gitian-descriptors/gitian-liquid-win.yml
+++ b/contrib/gitian-descriptors/gitian-liquid-win.yml
@@ -1,44 +1,42 @@
 ---
-name: "elements-osx-0.18"
+name: "elements-win-0.18"
 enable_cache: true
 suites:
 - "bionic"
 architectures:
 - "amd64"
 packages:
-- "ca-certificates"
 - "curl"
 - "g++"
 - "git"
 - "icnsutils"
+- "imagemagick"
+- "librsvg2-bin"
 - "pkg-config"
 - "autoconf"
-- "librsvg2-bin"
-- "libtiff-tools"
 - "libtool"
 - "automake"
 - "faketime"
 - "bsdmainutils"
-- "cmake"
-- "imagemagick"
-- "libcap-dev"
-- "libz-dev"
-- "libbz2-dev"
+- "mingw-w64"
+- "g++-mingw-w64"
+- "nsis"
+- "zip"
+- "ca-certificates"
 - "python"
-- "python-dev"
-- "python-setuptools"
-- "fonts-tuffy"
+- "rename"
 remotes:
 - "url": "https://github.com/ElementsProject/elements.git"
   "dir": "elements"
-files:
-- "MacOSX10.11.sdk.tar.gz"
+files: []
 script: |
   WRAP_DIR=$HOME/wrapped
-  HOSTS="x86_64-apple-darwin14"
-  CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests GENISOIMAGE=$WRAP_DIR/genisoimage"
-  FAKETIME_HOST_PROGS=""
-  FAKETIME_PROGS="ar ranlib date dmg genisoimage"
+  HOSTS="i686-w64-mingw32 x86_64-w64-mingw32"
+  CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests --enable-liquid"
+  FAKETIME_HOST_PROGS="ar ranlib nm windres strip objcopy"
+  FAKETIME_PROGS="date makensis zip"
+  HOST_CFLAGS="-O2 -g"
+  HOST_CXXFLAGS="-O2 -g"
 
   export QT_RCC_TEST=1
   export QT_RCC_SOURCE_DATE_OVERRIDE=1
@@ -52,8 +50,6 @@ script: |
     export BASE_CACHE=${GBUILD_PACKAGE_CACHE}
     mkdir -p ${BASE_CACHE} ${SOURCES_PATH}
   fi
-
-  export ZERO_AR_DATE=1
 
   ls librsvg*.deb || wget http://mirrors.kernel.org/ubuntu/pool/main/libr/librsvg/librsvg2-2_2.40.13-3_amd64.deb
   dpkg -x librsvg*.deb new-rsvg
@@ -83,18 +79,39 @@ script: |
   done
   }
 
+  function create_per-host_linker_wrapper {
+  # This is only needed for trusty, as the mingw linker leaks a few bytes of
+  # heap, causing non-determinism. See discussion in https://github.com/bitcoin/bitcoin/pull/6900
+  for i in $HOSTS; do
+    mkdir -p ${WRAP_DIR}/${i}
+    for prog in collect2; do
+        echo '#!/usr/bin/env bash' > ${WRAP_DIR}/${i}/${prog}
+        REAL=$(${i}-gcc -print-prog-name=${prog})
+        echo "export MALLOC_PERTURB_=255" >> ${WRAP_DIR}/${i}/${prog}
+        echo "${REAL} \$@" >> $WRAP_DIR/${i}/${prog}
+        chmod +x ${WRAP_DIR}/${i}/${prog}
+    done
+    for prog in gcc g++; do
+        echo '#!/usr/bin/env bash' > ${WRAP_DIR}/${i}-${prog}
+        echo "REAL=\`which -a ${i}-${prog}-posix | grep -v ${WRAP_DIR}/${i}-${prog} | head -1\`" >> ${WRAP_DIR}/${i}-${prog}
+        echo 'export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/faketime/libfaketime.so.1' >> ${WRAP_DIR}/${i}-${prog}
+        echo "export FAKETIME=\"$1\"" >> ${WRAP_DIR}/${i}-${prog}
+        echo "export COMPILER_PATH=${WRAP_DIR}/${i}" >> ${WRAP_DIR}/${i}-${prog}
+        echo "\$REAL \$@" >> $WRAP_DIR/${i}-${prog}
+        chmod +x ${WRAP_DIR}/${i}-${prog}
+    done
+  done
+  }
+
   # Faketime for depends so intermediate results are comparable
   export PATH_orig=${PATH}
   create_global_faketime_wrappers "2000-01-01 12:00:00"
   create_per-host_faketime_wrappers "2000-01-01 12:00:00"
+  create_per-host_linker_wrapper "2000-01-01 12:00:00"
   export PATH=${WRAP_DIR}:${PATH}
 
   cd elements
   BASEPREFIX=`pwd`/depends
-
-  mkdir -p ${BASEPREFIX}/SDKs
-  tar -C ${BASEPREFIX}/SDKs -xf ${BUILD_DIR}/MacOSX10.11.sdk.tar.gz
-
   # Build dependencies for each host
   for i in $HOSTS; do
     make ${MAKEOPTS} -C ${BASEPREFIX} HOST="${i}"
@@ -104,6 +121,7 @@ script: |
   export PATH=${PATH_orig}
   create_global_faketime_wrappers "${REFERENCE_DATETIME}"
   create_per-host_faketime_wrappers "${REFERENCE_DATETIME}"
+  create_per-host_linker_wrapper "${REFERENCE_DATETIME}"
   export PATH=${WRAP_DIR}:${PATH}
 
   # Create the release tarball using (arbitrarily) the first host
@@ -118,6 +136,8 @@ script: |
   pushd temp
   tar xf ../$SOURCEDIST
   find elements-* | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ../$SOURCEDIST
+  mkdir -p $OUTDIR/src
+  cp ../$SOURCEDIST $OUTDIR/src
   popd
 
   # Workaround for tarball not building with the bare tag version (prep)
@@ -138,33 +158,32 @@ script: |
     mkdir src/obj
     cp ../src/obj/build.h src/obj/
 
-    CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS}
+    CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS} CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}"
     make ${MAKEOPTS}
-    make install-strip DESTDIR=${INSTALLPATH}
-
-    make osx_volname
-    make deploydir
-    OSX_VOLNAME="$(cat osx_volname)"
-    mkdir -p unsigned-app-${i}
-    cp osx_volname unsigned-app-${i}/
-    cp contrib/macdeploy/detached-sig-apply.sh unsigned-app-${i}
-    cp contrib/macdeploy/detached-sig-create.sh unsigned-app-${i}
-    cp ${BASEPREFIX}/${i}/native/bin/dmg ${BASEPREFIX}/${i}/native/bin/genisoimage unsigned-app-${i}
-    cp ${BASEPREFIX}/${i}/native/bin/${i}-codesign_allocate unsigned-app-${i}/codesign_allocate
-    cp ${BASEPREFIX}/${i}/native/bin/${i}-pagestuff unsigned-app-${i}/pagestuff
-    mv dist unsigned-app-${i}
-    pushd unsigned-app-${i}
-    find . | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-osx-unsigned.tar.gz
-    popd
-
+    make ${MAKEOPTS} -C src check-security
     make deploy
-    ${WRAP_DIR}/dmg dmg "${OSX_VOLNAME}.dmg" ${OUTDIR}/${DISTNAME}-osx-unsigned.dmg
-
+    make install DESTDIR=${INSTALLPATH}
+    rename 's/-setup\.exe$/-setup-unsigned.exe/' *-setup.exe
+    cp -f elements-*setup*.exe $OUTDIR/
     cd installed
 
-    find ${DISTNAME} | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}.tar.gz
+    mv ${DISTNAME}/bin/elements-qt.exe ${DISTNAME}/bin/liquid-qt.exe
+    mv ${DISTNAME}/bin/elements-cli.exe ${DISTNAME}/bin/liquid-cli.exe
+    mv ${DISTNAME}/bin/elementsd.exe ${DISTNAME}/bin/liquidd.exe
+    mv ${DISTNAME}/bin/elements-tx.exe ${DISTNAME}/bin/liquid-tx.exe
+
+    find ${DISTNAME}/bin -type f -executable -exec ${i}-objcopy --only-keep-debug {} {}.dbg \; -exec ${i}-strip -s {} \; -exec ${i}-objcopy --add-gnu-debuglink={}.dbg {} \;
+    find ${DISTNAME} -not -name "*.dbg"  -type f | sort | zip -X@ ${OUTDIR}/${DISTNAME}-${i}.zip
+    find ${DISTNAME} -name "*.dbg"  -type f | sort | zip -X@ ${OUTDIR}/${DISTNAME}-${i}-debug.zip
     cd ../../
+    rm -rf distsrc-${i}
   done
-  mkdir -p $OUTDIR/src
-  mv $SOURCEDIST $OUTDIR/src
-  mv ${OUTDIR}/${DISTNAME}-x86_64-*.tar.gz ${OUTDIR}/${DISTNAME}-osx64.tar.gz
+  cp -rf contrib/windeploy $BUILD_DIR
+  cd $BUILD_DIR/windeploy
+  mkdir unsigned
+  cp $OUTDIR/elements-*setup-unsigned.exe unsigned/
+  find . | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-win-unsigned.tar.gz
+  mv ${OUTDIR}/${DISTNAME}-x86_64-*-debug.zip ${OUTDIR}/${DISTNAME}-win64-debug.zip
+  mv ${OUTDIR}/${DISTNAME}-i686-*-debug.zip ${OUTDIR}/${DISTNAME}-win32-debug.zip
+  mv ${OUTDIR}/${DISTNAME}-x86_64-*.zip ${OUTDIR}/${DISTNAME}-win64.zip
+  mv ${OUTDIR}/${DISTNAME}-i686-*.zip ${OUTDIR}/${DISTNAME}-win32.zip

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -36,7 +36,9 @@ files:
 script: |
   WRAP_DIR=$HOME/wrapped
   HOSTS="x86_64-apple-darwin14"
-  CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests --enable-liquid GENISOIMAGE=$WRAP_DIR/genisoimage"
+  #LIQUID BUILDS: Replace next line with following
+  CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests GENISOIMAGE=$WRAP_DIR/genisoimage"
+  #CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests --enable-liquid GENISOIMAGE=$WRAP_DIR/genisoimage"
   FAKETIME_HOST_PROGS=""
   FAKETIME_PROGS="ar ranlib date dmg genisoimage"
 
@@ -161,10 +163,12 @@ script: |
     ${WRAP_DIR}/dmg dmg "${OSX_VOLNAME}.dmg" ${OUTDIR}/${DISTNAME}-osx-unsigned.dmg
 
     cd installed
-    mv ${DISTNAME}/bin/elements-qt ${DISTNAME}/bin/liquid-qt
-    mv ${DISTNAME}/bin/elements-cli ${DISTNAME}/bin/liquid-cli
-    mv ${DISTNAME}/bin/elementsd ${DISTNAME}/bin/liquidd
-    mv ${DISTNAME}/bin/elements-tx ${DISTNAME}/bin/liquid-tx
+
+    # LIQUID: Uncomment next few lines
+    #mv ${DISTNAME}/bin/elements-qt ${DISTNAME}/bin/liquid-qt
+    #mv ${DISTNAME}/bin/elements-cli ${DISTNAME}/bin/liquid-cli
+    #mv ${DISTNAME}/bin/elementsd ${DISTNAME}/bin/liquidd
+    #mv ${DISTNAME}/bin/elements-tx ${DISTNAME}/bin/liquid-tx
 
     find ${DISTNAME} | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}.tar.gz
     cd ../../

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -36,7 +36,7 @@ files:
 script: |
   WRAP_DIR=$HOME/wrapped
   HOSTS="x86_64-apple-darwin14"
-  CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests GENISOIMAGE=$WRAP_DIR/genisoimage"
+  CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests --enable-liquid GENISOIMAGE=$WRAP_DIR/genisoimage"
   FAKETIME_HOST_PROGS=""
   FAKETIME_PROGS="ar ranlib date dmg genisoimage"
 

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -161,6 +161,11 @@ script: |
     ${WRAP_DIR}/dmg dmg "${OSX_VOLNAME}.dmg" ${OUTDIR}/${DISTNAME}-osx-unsigned.dmg
 
     cd installed
+    mv ${DISTNAME}/bin/elements-qt ${DISTNAME}/bin/liquid-qt
+    mv ${DISTNAME}/bin/elements-cli ${DISTNAME}/bin/liquid-cli
+    mv ${DISTNAME}/bin/elementsd ${DISTNAME}/bin/liquidd
+    mv ${DISTNAME}/bin/elements-tx ${DISTNAME}/bin/liquid-tx
+
     find ${DISTNAME} | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}.tar.gz
     cd ../../
   done

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -166,6 +166,10 @@ script: |
     rename 's/-setup\.exe$/-setup-unsigned.exe/' *-setup.exe
     cp -f elements-*setup*.exe $OUTDIR/
     cd installed
+    mv ${DISTNAME}/bin/elements-qt.exe ${DISTNAME}/bin/liquid-qt.exe
+    mv ${DISTNAME}/bin/elements-cli.exe ${DISTNAME}/bin/liquid-cli.exe
+    mv ${DISTNAME}/bin/elementsd.exe ${DISTNAME}/bin/liquidd.exe
+    mv ${DISTNAME}/bin/elements-tx.exe ${DISTNAME}/bin/liquid-tx.exe
     find ${DISTNAME}/bin -type f -executable -exec ${i}-objcopy --only-keep-debug {} {}.dbg \; -exec ${i}-strip -s {} \; -exec ${i}-objcopy --add-gnu-debuglink={}.dbg {} \;
     find ${DISTNAME} -not -name "*.dbg"  -type f | sort | zip -X@ ${OUTDIR}/${DISTNAME}-${i}.zip
     find ${DISTNAME} -name "*.dbg"  -type f | sort | zip -X@ ${OUTDIR}/${DISTNAME}-${i}-debug.zip

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -32,9 +32,7 @@ files: []
 script: |
   WRAP_DIR=$HOME/wrapped
   HOSTS="i686-w64-mingw32 x86_64-w64-mingw32"
-  #LIQUID BUILDS: Replace next line with following
   CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests"
-  #CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests --enable-liquid"
   FAKETIME_HOST_PROGS="ar ranlib nm windres strip objcopy"
   FAKETIME_PROGS="date makensis zip"
   HOST_CFLAGS="-O2 -g"
@@ -168,12 +166,6 @@ script: |
     rename 's/-setup\.exe$/-setup-unsigned.exe/' *-setup.exe
     cp -f elements-*setup*.exe $OUTDIR/
     cd installed
-
-    # LIQUID: Uncomment next few lines
-    #mv ${DISTNAME}/bin/elements-qt.exe ${DISTNAME}/bin/liquid-qt.exe
-    #mv ${DISTNAME}/bin/elements-cli.exe ${DISTNAME}/bin/liquid-cli.exe
-    #mv ${DISTNAME}/bin/elementsd.exe ${DISTNAME}/bin/liquidd.exe
-    #mv ${DISTNAME}/bin/elements-tx.exe ${DISTNAME}/bin/liquid-tx.exe
 
     find ${DISTNAME}/bin -type f -executable -exec ${i}-objcopy --only-keep-debug {} {}.dbg \; -exec ${i}-strip -s {} \; -exec ${i}-objcopy --add-gnu-debuglink={}.dbg {} \;
     find ${DISTNAME} -not -name "*.dbg"  -type f | sort | zip -X@ ${OUTDIR}/${DISTNAME}-${i}.zip

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -32,7 +32,7 @@ files: []
 script: |
   WRAP_DIR=$HOME/wrapped
   HOSTS="i686-w64-mingw32 x86_64-w64-mingw32"
-  CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests"
+  CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests --enable-liquid"
   FAKETIME_HOST_PROGS="ar ranlib nm windres strip objcopy"
   FAKETIME_PROGS="date makensis zip"
   HOST_CFLAGS="-O2 -g"

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -32,7 +32,9 @@ files: []
 script: |
   WRAP_DIR=$HOME/wrapped
   HOSTS="i686-w64-mingw32 x86_64-w64-mingw32"
-  CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests --enable-liquid"
+  #LIQUID BUILDS: Replace next line with following
+  CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests"
+  #CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests --enable-liquid"
   FAKETIME_HOST_PROGS="ar ranlib nm windres strip objcopy"
   FAKETIME_PROGS="date makensis zip"
   HOST_CFLAGS="-O2 -g"
@@ -166,10 +168,13 @@ script: |
     rename 's/-setup\.exe$/-setup-unsigned.exe/' *-setup.exe
     cp -f elements-*setup*.exe $OUTDIR/
     cd installed
-    mv ${DISTNAME}/bin/elements-qt.exe ${DISTNAME}/bin/liquid-qt.exe
-    mv ${DISTNAME}/bin/elements-cli.exe ${DISTNAME}/bin/liquid-cli.exe
-    mv ${DISTNAME}/bin/elementsd.exe ${DISTNAME}/bin/liquidd.exe
-    mv ${DISTNAME}/bin/elements-tx.exe ${DISTNAME}/bin/liquid-tx.exe
+
+    # LIQUID: Uncomment next few lines
+    #mv ${DISTNAME}/bin/elements-qt.exe ${DISTNAME}/bin/liquid-qt.exe
+    #mv ${DISTNAME}/bin/elements-cli.exe ${DISTNAME}/bin/liquid-cli.exe
+    #mv ${DISTNAME}/bin/elementsd.exe ${DISTNAME}/bin/liquidd.exe
+    #mv ${DISTNAME}/bin/elements-tx.exe ${DISTNAME}/bin/liquid-tx.exe
+
     find ${DISTNAME}/bin -type f -executable -exec ${i}-objcopy --only-keep-debug {} {}.dbg \; -exec ${i}-strip -s {} \; -exec ${i}-objcopy --add-gnu-debuglink={}.dbg {} \;
     find ${DISTNAME} -not -name "*.dbg"  -type f | sort | zip -X@ ${OUTDIR}/${DISTNAME}-${i}.zip
     find ${DISTNAME} -name "*.dbg"  -type f | sort | zip -X@ ${OUTDIR}/${DISTNAME}-${i}-debug.zip

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -48,7 +48,16 @@ static const int MAX_URI_LENGTH = 255;
 
 #define QAPP_ORG_NAME "Bitcoin"
 #define QAPP_ORG_DOMAIN "bitcoin.org"
+#if LIQUID
+#define QAPP_APP_NAME_DEFAULT "Liquid-Qt"
+#else
 #define QAPP_APP_NAME_DEFAULT "Elements-Qt"
+#endif
+
+#if LIQUID
+#define QAPP_APP_NAME_TESTNET "Liquid-Qt-testnet"
+#else
 #define QAPP_APP_NAME_TESTNET "Elements-Qt-testnet"
+#endif
 
 #endif // BITCOIN_QT_GUICONSTANTS_H

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -87,16 +87,15 @@ QFont fixedPitchFont()
 #endif
 }
 
-// Just some dummy data to generate a convincing random-looking (but consistent) address
-static const uint8_t dummydata[33] = {3};
-
 // Generate a dummy address with invalid CRC, starting with the network prefix.
 static std::string DummyAddress(const CChainParams &params)
 {
+    std::vector<unsigned char> dummydata = ParseHex("02217226f8114ad5807e90402a534ff3311a44f498ce5c0f1f56ccd9e60383d01e");
     std::vector<unsigned char> sourcedata;
-    CPubKey dummy_key(&dummydata[0], &dummydata[33]);
+    CPubKey dummy_key(dummydata);
     ScriptHash script_dest(uint160(), dummy_key);
-    DecodeBase58(EncodeDestination(script_dest), sourcedata);
+    std::string dest_str = EncodeDestination(script_dest);
+    DecodeBase58(dest_str, sourcedata);
     for(int i=0; i<256; ++i) { // Try every trailing byte
         std::string s = EncodeBase58(sourcedata.data(), sourcedata.data() + sourcedata.size());
         if (!IsValidDestinationString(s)) {

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -172,8 +172,9 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
             // Debit
             //
             auto mine = wtx.txout_is_mine.begin();
-            for (const CTxOut& txout : wtx.tx->vout)
+            for (unsigned int i = 0; i < wtx.tx->vout.size(); ++i)
             {
+                const CTxOut& txout = wtx.tx->vout[i];
                 // Ignore change
                 isminetype toSelf = *(mine++);
                 if ((toSelf == ISMINE_SPENDABLE) && (fAllFromMe == ISMINE_SPENDABLE))
@@ -199,9 +200,9 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
                     }
                 }
 
-                strHTML += "<b>" + tr("Debit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -txout.nValue.GetAmount()) + "<br>";
+                strHTML += "<b>" + tr("Debit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -wtx.txout_amounts[i]) + "<br>";
                 if(toSelf)
-                    strHTML += "<b>" + tr("Credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, txout.nValue.GetAmount()) + "<br>";
+                    strHTML += "<b>" + tr("Credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, wtx.txout_amounts[i]) + "<br>";
             }
 
             if (fAllToMe)
@@ -281,7 +282,7 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     //
     // Debug view
     //
-    if (node.getLogCategories() != BCLog::NONE)
+    if (node.getLogCategories() != BCLog::NONE && !g_con_elementsmode)
     {
         strHTML += "<hr><br>" + tr("Debug information") + "<br><br>";
         for (const CTxIn& txin : wtx.tx->vin)

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -51,7 +51,7 @@ WalletModel::WalletModel(std::unique_ptr<interfaces::Wallet> wallet, interfaces:
     cachedNumBlocks(0)
 {
     fHaveWatchOnly = m_wallet->haveWatchOnly();
-    fForceCheckBalanceChanged = false;
+    fForceCheckBalanceChanged = true;
 
     addressTableModel = new AddressTableModel(this);
     transactionTableModel = new TransactionTableModel(platformStyle, this);

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -236,9 +236,10 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
         std::vector<CAmount> out_amounts;
         newTx = m_wallet->createTransaction(vecSend, coinControl, true /* sign */, nChangePosRet, nFeeRequired, out_amounts, strFailReason);
         transaction.setTransactionFee(nFeeRequired);
-        if (fSubtractFeeFromAmount && newTx)
+        if (fSubtractFeeFromAmount && newTx) {
             assert(out_amounts.size() == newTx->get().vout.size());
             transaction.reassignAmounts(out_amounts, nChangePosRet);
+        }
 
         if(!newTx)
         {

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -558,7 +558,11 @@ BOOST_AUTO_TEST_CASE(util_GetChainName)
     std::string error;
 
     test_args.ParseParameters(0, (char**)argv_testnet, error);
-    BOOST_CHECK_EQUAL(test_args.GetChainName(), "elementsregtest");
+    std::string default_chain = "elementsregtest";
+#if LIQUID
+    default_chain = "liquidv1";
+#endif
+    BOOST_CHECK_EQUAL(test_args.GetChainName(), default_chain);
 
     test_args.ParseParameters(2, (char**)argv_testnet, error);
     BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -980,7 +980,12 @@ std::string ArgsManager::GetChainName() const
         return CBaseChainParams::REGTEST;
     if (fTestNet)
         return CBaseChainParams::TESTNET;
-    return GetArg("-chain", "elementsregtest");
+
+    std::string default_chain = "elementsregtest";
+#ifdef LIQUID
+    default_chain = "liquidv1";
+#endif
+    return GetArg("-chain", default_chain);
 }
 
 #ifndef WIN32

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -704,6 +704,33 @@ void PrintExceptionContinue(const std::exception* pex, const char* pszThread)
     fprintf(stderr, "\n\n************************\n%s\n", message.c_str());
 }
 
+#ifdef LIQUID
+fs::path GetDefaultDataDir()
+{
+    // Windows < Vista: C:\Documents and Settings\Username\Application Data\Liquid
+    // Windows >= Vista: C:\Users\Username\AppData\Roaming\Liquid
+    // Mac: ~/Library/Application Support/Liquid
+    // Unix: ~/.liquid
+#ifdef WIN32
+    // Windows
+    return GetSpecialFolderPath(CSIDL_APPDATA) / "Liquid";
+#else
+    fs::path pathRet;
+    char* pszHome = getenv("HOME");
+    if (pszHome == nullptr || strlen(pszHome) == 0)
+        pathRet = fs::path("/");
+    else
+        pathRet = fs::path(pszHome);
+#ifdef MAC_OSX
+    // Mac
+    return pathRet / "Library/Application Support/Liquid";
+#else
+    // Unix
+    return pathRet / ".liquid";
+#endif
+#endif
+}
+#else
 fs::path GetDefaultDataDir()
 {
     // Windows < Vista: C:\Documents and Settings\Username\Application Data\Bitcoin
@@ -729,6 +756,7 @@ fs::path GetDefaultDataDir()
 #endif
 #endif
 }
+#endif
 
 static fs::path g_blocks_path_cached;
 static fs::path g_blocks_path_cache_net_specific;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -81,8 +81,14 @@
 // Application startup time (used for uptime calculation)
 const int64_t nStartupTime = GetTime();
 
+
+#ifdef LIQUID
+const char * const BITCOIN_CONF_FILENAME = "liquid.conf";
+const char * const BITCOIN_PID_FILENAME = "liquid.pid";
+#else
 const char * const BITCOIN_CONF_FILENAME = "elements.conf";
 const char * const BITCOIN_PID_FILENAME = "elementsd.pid";
+#endif
 
 ArgsManager gArgs;
 


### PR DESCRIPTION
The only behavior it modifies is that the default chain becomes `liquidv1`. Also added a Travis test for coverage and adapted a unit test, and enabled this mode for gitian descriptors.