### PR TITLE
CreateTransaction: Place blinding pubkey into nNonce in case of fundraw

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -5189,16 +5189,16 @@ static UniValue createrawpegin(const JSONRPCRequest& request, T_tx_ref& txBTCRef
     CPubKey newKey;
     if (!pwallet->GetKeyFromPool(newKey))
         throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Error: Keypool ran out, please call keypoolrefill first");
-    PKHash pkhash(newKey);
+    WitnessV0KeyHash wpkhash(newKey.GetID());
 
-    pwallet->SetAddressBook(pkhash, "", "receive");
+    pwallet->SetAddressBook(wpkhash, "", "receive");
 
     // One peg-in input, one wallet output and one fee output
     CMutableTransaction mtx;
     mtx.vin.push_back(CTxIn(COutPoint(txHashes[0], nOut), CScript(), ~(uint32_t)0));
     // mark as peg-in input
     mtx.vin[0].m_is_pegin = true;
-    mtx.vout.push_back(CTxOut(Params().GetConsensus().pegged_asset, value, GetScriptForDestination(pkhash)));
+    mtx.vout.push_back(CTxOut(Params().GetConsensus().pegged_asset, value, GetScriptForDestination(wpkhash)));
     mtx.vout.push_back(CTxOut(Params().GetConsensus().pegged_asset, 0, CScript()));
 
     // Construct pegin proof

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3166,15 +3166,17 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
                         }
 
                         std::vector<CTxOut>::iterator position = txNew.vout.begin()+vChangePosInOut[assetChange.first];
-                        txNew.vout.insert(position, newTxOut);
-                        CPubKey blind_pub = GetBlindingPubKey(itScript->second.second);
                         if (blind_details) {
+                            CPubKey blind_pub = GetBlindingPubKey(itScript->second.second);
                             blind_details->o_pubkeys.insert(blind_details->o_pubkeys.begin() + vChangePosInOut[assetChange.first], blind_pub);
                             assert(blind_pub.IsFullyValid());
                             blind_details->num_to_blind++;
                             blind_details->change_to_blind++;
                             blind_details->only_change_pos = vChangePosInOut[assetChange.first];
+                            // Place the blinding pubkey here in case of fundraw calls
+                            newTxOut.nNonce.vchCommitment = std::vector<unsigned char>(blind_pub.begin(), blind_pub.end());
                         }
+                        txNew.vout.insert(position, newTxOut);
                     }
                 }
                 // Set the correct nChangePosInOut for output.  Should be policyAsset's position.

--- a/test/functional/feature_confidential_transactions.py
+++ b/test/functional/feature_confidential_transactions.py
@@ -379,6 +379,9 @@ class CTTest (BitcoinTestFramework):
         self.sync_all()
 
         # Check for value accounting when asset issuance is null but token not, ie unblinded
+        # HACK: Self-send to sweep up bitcoin inputs into blinded output.
+        # We were hitting https://github.com/ElementsProject/elements/issues/473 for the following issuance
+        self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), self.nodes[0].getwalletinfo()["balance"]["bitcoin"], "", "", True)
         issued = self.nodes[0].issueasset(0, 1, False)
         walletinfo = self.nodes[0].getwalletinfo()
         assert(issued["asset"] not in walletinfo["balance"])
@@ -559,7 +562,6 @@ class CTTest (BitcoinTestFramework):
         self.nodes[0].sendtoaddress(blinded_addr, 1)
         self.nodes[0].sendtoaddress(blinded_addr, 3)
         unspent = self.nodes[0].listunspent(0, 0)
-        assert_equal(len(unspent), 4)
         rawtx = self.nodes[0].createrawtransaction([{"txid":unspent[0]["txid"], "vout":unspent[0]["vout"]}, {"txid":unspent[1]["txid"], "vout":unspent[1]["vout"]}], {addr:unspent[0]["amount"]+unspent[1]["amount"]-Decimal("0.2"), "fee":Decimal("0.2")})
         # Blinding will fail with 2 blinded inputs and 0 blinded outputs
         # since it has no notion of a wallet to fill in a 0-value OP_RETURN output


### PR DESCRIPTION
Currently any fundrawtransaction call will result in unblinded change output. Automated flow isn't effected by this bug.