### PR TITLE
[cherry-pick] rpc/gui: Remove 'Unknown block versions being mined' warning

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2395,12 +2395,6 @@ void static UpdateTip(const CBlockIndex *pindexNew, const CChainParams& chainPar
         }
         if (nUpgraded > 0)
             AppendWarning(warningMessages, strprintf(_("%d of last 100 blocks have unexpected version"), nUpgraded));
-        if (nUpgraded > 100/2)
-        {
-            std::string strWarning = _("Warning: Unknown block versions being mined! It's possible unknown rules are in effect");
-            // notify GetWarnings(), called by Qt and the JSON-RPC code to warn the user:
-            DoWarning(strWarning);
-        }
     }
     LogPrintf("%s: new best=%s height=%d version=0x%08x tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)", __func__, /* Continued */
       pindexNew->GetBlockHash().ToString(), pindexNew->nHeight, pindexNew->nVersion,

--- a/test/bitcoin_functional/functional/feature_notifications.py
+++ b/test/bitcoin_functional/functional/feature_notifications.py
@@ -64,26 +64,7 @@ class NotificationsTest(BitcoinTestFramework):
         with open(self.tx_filename, 'r', encoding="ascii") as f:
             assert_equal(sorted(txids_rpc), sorted(l.strip() for l in f.read().splitlines()))
 
-        # Mine another 41 up-version blocks. -alertnotify should trigger on the 51st.
-        self.log.info("test -alertnotify")
-        self.nodes[1].generate(41)
-        self.sync_all()
-
-        # Give bitcoind 10 seconds to write the alert notification
-        wait_until(lambda: os.path.isfile(self.alert_filename) and os.path.getsize(self.alert_filename), timeout=10)
-
-        with open(self.alert_filename, 'r', encoding='utf8') as f:
-            alert_text = f.read()
-
-        # Mine more up-version blocks, should not get more alerts:
-        self.nodes[1].generate(2)
-        self.sync_all()
-
-        with open(self.alert_filename, 'r', encoding='utf8') as f:
-            alert_text2 = f.read()
-
-        self.log.info("-alertnotify should not continue notifying for more unknown version blocks")
-        assert_equal(alert_text, alert_text2)
+        # TODO: add test for `-alertnotify` large fork notifications
 
 if __name__ == '__main__':
     NotificationsTest().main()

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -64,26 +64,7 @@ class NotificationsTest(BitcoinTestFramework):
         with open(self.tx_filename, 'r', encoding="ascii") as f:
             assert_equal(sorted(txids_rpc), sorted(l.strip() for l in f.read().splitlines()))
 
-        # Mine another 41 up-version blocks. -alertnotify should trigger on the 51st.
-        self.log.info("test -alertnotify")
-        self.nodes[1].generate(41)
-        self.sync_all()
-
-        # Give bitcoind 10 seconds to write the alert notification
-        wait_until(lambda: os.path.isfile(self.alert_filename) and os.path.getsize(self.alert_filename), timeout=10)
-
-        with open(self.alert_filename, 'r', encoding='utf8') as f:
-            alert_text = f.read()
-
-        # Mine more up-version blocks, should not get more alerts:
-        self.nodes[1].generate(2)
-        self.sync_all()
-
-        with open(self.alert_filename, 'r', encoding='utf8') as f:
-            alert_text2 = f.read()
-
-        self.log.info("-alertnotify should not continue notifying for more unknown version blocks")
-        assert_equal(alert_text, alert_text2)
+        # TODO: add test for `-alertnotify` large fork notifications
 
 if __name__ == '__main__':
     NotificationsTest().main()

--- a/test/functional/feature_versionbits_warning.py
+++ b/test/functional/feature_versionbits_warning.py
@@ -22,7 +22,6 @@ VB_TOP_BITS = 0x20000000
 VB_UNKNOWN_BIT = 27       # Choose a bit unassigned to any deployment
 VB_UNKNOWN_VERSION = VB_TOP_BITS | (1 << VB_UNKNOWN_BIT)
 
-WARN_UNKNOWN_RULES_MINED = "Unknown block versions being mined! It's possible unknown rules are in effect"
 WARN_UNKNOWN_RULES_ACTIVE = "unknown new rules activated (versionbit {})".format(VB_UNKNOWN_BIT)
 VB_PATTERN = re.compile("Warning: unknown new rules activated.*versionbit")
 
@@ -80,14 +79,9 @@ class VersionBitsWarningTest(BitcoinTestFramework):
         assert(not VB_PATTERN.match(node.getmininginfo()["warnings"]))
         assert(not VB_PATTERN.match(node.getnetworkinfo()["warnings"]))
 
-        self.log.info("Check that there is a warning if >50 blocks in the last 100 were an unknown version")
         # Build one period of blocks with VB_THRESHOLD blocks signaling some unknown bit
         self.send_blocks_with_version(node.p2p, VB_THRESHOLD, VB_UNKNOWN_VERSION)
         node.generate(VB_PERIOD - VB_THRESHOLD)
-
-        # Check that get*info() shows the 51/100 unknown block version error.
-        assert(WARN_UNKNOWN_RULES_MINED in node.getmininginfo()["warnings"])
-        assert(WARN_UNKNOWN_RULES_MINED in node.getnetworkinfo()["warnings"])
 
         self.log.info("Check that there is a warning if previous VB_BLOCKS have >=VB_THRESHOLD blocks with unknown versionbits version.")
         # Mine a period worth of expected blocks so the generic block-version warning


### PR DESCRIPTION
Cherry-pick of https://github.com/bitcoin/bitcoin/pull/15471

We are getting versionbit 28 warnings because of liquid functionary liquid-daemon that includes the "dummy" deployment, but elements does not. We can just remove the warning.