### PR TITLE
Fix default permitsigdata value not working on converttopsbt command

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1765,13 +1765,13 @@ UniValue converttopsbt(const JSONRPCRequest& request)
 
     // Remove all scriptSigs and scriptWitnesses from inputs
     for (CTxIn& input : tx.vin) {
-        if ((!input.scriptSig.empty()) && (request.params[1].isNull() || (!request.params[1].isNull() && request.params[1].get_bool()))) {
+        if (!input.scriptSig.empty() && !permitsigdata) {
             throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Inputs must not have scriptSigs");
         }
         input.scriptSig.clear();
     }
     for (CTxInWitness& witness: tx.witness.vtxinwit) {
-        if ((!witness.scriptWitness.IsNull()) && (request.params[1].isNull() || (!request.params[1].isNull() && request.params[1].get_bool()))) {
+        if (!witness.scriptWitness.IsNull() && !permitsigdata) {
             throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Inputs must not have scriptWitnesses");
         }
     }

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -106,6 +106,7 @@ class PSBTTest(BitcoinTestFramework):
 
         # Make sure that a psbt with signatures cannot be converted
         signedtx = self.nodes[0].signrawtransactionwithwallet(rawtx['hex'])
+        assert_raises_rpc_error(-22, "Inputs must not have scriptWitnesses", self.nodes[0].converttopsbt, signedtx['hex'], False)
         assert_raises_rpc_error(-22, "Inputs must not have scriptWitnesses", self.nodes[0].converttopsbt, signedtx['hex'])
 
         # Explicitly allow converting non-empty txs


### PR DESCRIPTION
We're not really supporting PSBT for Elements yet. The `rpc_psbt.py` integration test is disabled because of this; that's also why we didn't catch this. It's fixed upstream. 

I added an extra test to catch the error, but it's not actually executed.

@instagibbs, up to you to decide if it's worth having this patched right now. I cherry-picked that fix commit literally from the catchup PR I'm working on, so if we don't patch it here, it will get patched while catching up.