### PR TITLE
Make MainchainRPCCheck a bit less aggressive

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1866,16 +1866,17 @@ bool AppInitMain()
     SetRPCWarmupFinished();
 
     // ELEMENTS:
-    CScheduler::Function f2 = boost::bind(&MainchainRPCCheck, false);
-    unsigned int check_rpc_every = gArgs.GetArg("-recheckpeginblockinterval", 120);
-    if (check_rpc_every) {
-        scheduler.scheduleEvery(f2, check_rpc_every);
-    }
     uiInterface.InitMessage(_("Awaiting mainchain RPC warmup"));
     if (!MainchainRPCCheck(true)) { //Initial check, fail immediately
         return InitError(_("ERROR: elementsd is set to verify pegins but cannot get valid response from the mainchain daemon. Please check debug.log for more information.")
         + "\n\n"
         + strprintf(_("If you haven't setup a %s please get the latest stable version from %s or if you do not need to validate pegins set in your elements configuration %s"), "bitcoind", "https://bitcoincore.org/en/download/", "validatepegin=0"));
+    }
+
+    CScheduler::Function f2 = boost::bind(&MainchainRPCCheck, false);
+    unsigned int check_rpc_every = gArgs.GetArg("-recheckpeginblockinterval", 120);
+    if (check_rpc_every) {
+        scheduler.scheduleEvery(f2, check_rpc_every);
     }
 
     uiInterface.InitMessage(_("Done loading"));

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5161,7 +5161,8 @@ bool MainchainRPCCheck(const bool init)
                 if (!error.isNull()) {
                     // On the first call, it's possible to node is still in
                     // warmup; in that case, just wait and retry.
-                    if (error["code"].get_int() == RPC_IN_WARMUP) {
+                    // If this is not the initial call, just report failure.
+                    if (init && error["code"].get_int() == RPC_IN_WARMUP) {
                         MilliSleep(1000);
                         continue;
                     }


### PR DESCRIPTION
First, only start scheduling checks if the initial check on load succeeds. This initial check is a sanity-check that makes sure all daemons are spun up and communicating correctly. Second, for the initial check only we want to spin-wait for the mainchaind to finish warming up, otherwise elementsd may fail rather than wait a couple seconds for bitcoind to start up, for instance, which can occur when automating the processes.

Previously we were spin-waiting for all instances of MainchainRPCCheck, which means if your bitcoind falls over mid-run for whatever reason and is in warmup state for a long time(say, updating UTXO db), these checks will pile up on each other, spamming your bitcoind with useless RPC calls. Post-init it's completely fine for the call to simply fail and try again in N minutes.

resolves https://github.com/ElementsProject/elements/issues/608