### PR TITLE
All peg-out related detection pushes should be <= OP_PUSHDATA4

### DIFF
--- a/src/primitives/pak.cpp
+++ b/src/primitives/pak.cpp
@@ -185,7 +185,7 @@ bool ScriptHasValidPAKProof(const CScript& script, const uint256& genesis_hash)
     std::vector<unsigned char> extracted_pubkey_hash;
 
     // Get full pubkey
-    if (!script.GetOp(pc, opcode, data) || opcode != 33 || data.size() != 33) {
+    if (!script.GetOp(pc, opcode, data) || data.size() != 33 || opcode > OP_PUSHDATA4) {
         return false;
     }
     CPubKey full_pubkey(data.begin(), data.end());

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -213,16 +213,23 @@ bool CScript::IsPegoutScript(uint256& genesis_hash, CScript& pegout_scriptpubkey
         return false;
     }
 
-    if (!GetOp(pc, opcode, data) || data.size() != 32 ) {
+    if (!GetOp(pc, opcode, data) || data.size() != 32 || opcode > OP_PUSHDATA4) {
         return false;
     }
     genesis_hash = uint256(data);
 
     // Read in parent chain destination scriptpubkey
-    if (!GetOp(pc, opcode, data) || data.size() == 0 ) {
+    if (!GetOp(pc, opcode, data) || opcode > OP_PUSHDATA4 ) {
         return false;
     }
     pegout_scriptpubkey = CScript(data.begin(), data.end());
+
+    // All extra opcodes must be pushes
+    while(GetOp(pc, opcode, data)) {
+        if (opcode > OP_PUSHDATA4) {
+            return false;
+        }
+    }
 
     return true;
 }


### PR DESCRIPTION
related to https://github.com/ElementsProject/elements/issues/598 , https://github.com/ElementsProject/elements/issues/596, https://github.com/ElementsProject/elements/pull/597

This does not affect consensus, but affects consumers of these parsing rules such as rust-elements.

cc @apoelstra @roconnor-blockstream 