### PR TITLE
 Make claimpegin fail in the case of a double claim 

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -5317,6 +5317,15 @@ UniValue claimpegin(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
     }
 
+    // To check if it's not double spending an existing pegin UTXO, we check mempool acceptance.
+    CValidationState acceptState;
+    bool accepted = ::AcceptToMemoryPool(mempool, acceptState, MakeTransactionRef(mtx), nullptr /* pfMissingInputs */,
+                            nullptr /* plTxnReplaced */, false /* bypass_limits */, maxTxFee, true /* test_accept */);
+    if (!accepted) {
+        std::string strError = strprintf("Error: The transaction was rejected! Reason given: %s", FormatStateMessage(acceptState));
+        throw JSONRPCError(RPC_WALLET_ERROR, strError);
+    }
+
     // Send it
     CValidationState state;
     mapValue_t mapValue;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -5209,7 +5209,7 @@ static UniValue createrawpegin(const JSONRPCRequest& request, T_tx_ref& txBTCRef
     // We re-check depth before returning with more descriptive result
     std::string err;
     if (!IsValidPeginWitness(pegin_witness, mtx.vin[0].prevout, err, false)) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Constructed peg-in witness is invalid.");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Constructed peg-in witness is invalid: %s", err));
     }
 
     // Put input witness in transaction

--- a/test/functional/feature_fedpeg.py
+++ b/test/functional/feature_fedpeg.py
@@ -225,6 +225,9 @@ class FedPegTest(BitcoinTestFramework):
         sample_pegin_witness = sample_pegin_struct.wit.vtxinwit[0].peginWitness
 
         pegtxid1 = sidechain.claimpegin(raw, proof)
+        # Make sure it can't get accepted twice.
+        pegtxid2 = sidechain.claimpegin(raw, proof)
+        assert(pegtxid2 not in sidechain.getrawmempool())
 
         # Will invalidate the block that confirms this transaction later
         self.sync_all(self.node_groups)
@@ -261,6 +264,13 @@ class FedPegTest(BitcoinTestFramework):
         sidechain.reconsiderblock(blockhash[0])
         if sidechain.gettransaction(pegtxid1)["confirmations"] != 6:
             raise Exception("Peg-in should be back to 6 confirms.")
+
+        # Make sure it can't get accepted twice.
+        pegtxid2 = sidechain.claimpegin(raw, proof)
+        assert(pegtxid2 not in sidechain.getrawmempool())
+        sidechain.generate(7)
+        if sidechain.gettransaction(pegtxid2)["confirmations"] > 0:
+            raise Exception("Pegin should not be able to get confirmed")
 
         # Do multiple claims in mempool
         n_claims = 6


### PR DESCRIPTION
Fixes #613. Builds on #614.