### PR TITLE
Disallow issuance calls in bitcoin mode

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -5850,6 +5850,10 @@ UniValue issueasset(const JSONRPCRequest& request)
     auto locked_chain = pwallet->chain().lock();
     LOCK(pwallet->cs_wallet);
 
+    if (!g_con_elementsmode) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "Issuance can only be done on elements-style chains. Note: `-regtest` is Bitcoin's regtest mode, instead try `-chain=<custom chain name>`");
+    }
+
     CAmount nAmount = AmountFromValue(request.params[0]);
     CAmount nTokens = AmountFromValue(request.params[1]);
     if (nAmount == 0 && nTokens == 0) {
@@ -5937,6 +5941,10 @@ UniValue reissueasset(const JSONRPCRequest& request)
 
     auto locked_chain = pwallet->chain().lock();
     LOCK(pwallet->cs_wallet);
+
+    if (!g_con_elementsmode) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "Issuance can only be done on elements-style chains. Note: `-regtest` is Bitcoin's regtest mode, instead try `-chain=<custom chain name>`");
+    }
 
     std::string assetstr = request.params[0].get_str();
     CAsset asset = GetAssetFromString(assetstr);


### PR DESCRIPTION
Enough people are running `-regtest` and getting confused as to why they cannot issue assets to make some checks worth it even though we don't intend people to run bitcoin mode at all.