### PR TITLE
[0.17 backport] Move MainchainRPCCheck to its own schedule to avoid waiting for itself

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -146,6 +146,7 @@ static std::unique_ptr<ECCVerifyHandle> globalVerifyHandle;
 
 static boost::thread_group threadGroup;
 static CScheduler scheduler;
+static CScheduler reverification_scheduler;
 
 void Interrupt()
 {
@@ -1873,10 +1874,14 @@ bool AppInitMain()
         + strprintf(_("If you haven't setup a %s please get the latest stable version from %s or if you do not need to validate pegins set in your elements configuration %s"), "bitcoind", "https://bitcoincore.org/en/download/", "validatepegin=0"));
     }
 
+    // Start the lightweight block re-evaluation scheduler thread
+    CScheduler::Function reevaluationLoop = std::bind(&CScheduler::serviceQueue, &reverification_scheduler);
+    threadGroup.create_thread(std::bind(&TraceThread<CScheduler::Function>, "reevaluation_scheduler", reevaluationLoop));
+
     CScheduler::Function f2 = boost::bind(&MainchainRPCCheck, false);
-    unsigned int check_rpc_every = gArgs.GetArg("-recheckpeginblockinterval", 120);
+    unsigned int check_rpc_every = gArgs.GetArg("-recheckpeginblockinterval", 120) * 1000;
     if (check_rpc_every) {
-        scheduler.scheduleEvery(f2, check_rpc_every);
+        reverification_scheduler.scheduleEvery(f2, check_rpc_every);
     }
 
     uiInterface.InitMessage(_("Done loading"));


### PR DESCRIPTION
backport of #647 for 0.17