### PR TITLE
[WIP] Do not DoS ban peers for giving you valid headers

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3692,8 +3692,9 @@ bool CChainState::AcceptBlockHeader(const CBlockHeader& block, CValidationState&
         if (mi == mapBlockIndex.end())
             return state.DoS(10, error("%s: prev block not found", __func__), 0, "prev-blk-not-found");
         pindexPrev = (*mi).second;
-        if (pindexPrev->nStatus & BLOCK_FAILED_MASK)
-            return state.DoS(100, error("%s: prev block invalid", __func__), REJECT_INVALID, "bad-prevblk");
+        if (pindexPrev->nStatus & BLOCK_FAILED_MASK) {
+            return state.DoS(g_signed_blocks ? 0 : 100, error("%s: prev block invalid", __func__), REJECT_INVALID, "bad-prevblk");
+        }
         if (!ContextualCheckBlockHeader(block, state, chainparams, pindexPrev, GetAdjustedTime()))
             return error("%s: Consensus::ContextualCheckBlockHeader: %s, %s", __func__, hash.ToString(), FormatStateMessage(state));
 
@@ -3730,7 +3731,7 @@ bool CChainState::AcceptBlockHeader(const CBlockHeader& block, CValidationState&
                         setDirtyBlockIndex.insert(invalid_walk);
                         invalid_walk = invalid_walk->pprev;
                     }
-                    return state.DoS(100, error("%s: prev block invalid", __func__), REJECT_INVALID, "bad-prevblk");
+                    return state.DoS(g_signed_blocks ? 0 : 100, error("%s: prev block invalid", __func__), REJECT_INVALID, "bad-prevblk");
                 }
             }
         }


### PR DESCRIPTION
When the headers are only considered bad because they connect to known-bad blocks.

When a node has a temporary peg-in validation failure, any additional blocks sent will increase the misbehavior score and may result in a ban. Don't do that.

Also augmented test to expose this corner case and prevent future regressions.