### PR TITLE
FundTransaction: mark all change keys as kept

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2711,6 +2711,11 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, int& nC
         }
     }
 
+    // Mark all un-returned change keys as used to reduce privacy loss
+    for (auto& changekey : vChangeKey) {
+        changekey->KeepKey();
+    }
+
     return true;
 }
 


### PR DESCRIPTION
Regression from 0.14 due to internal API changes.

If a key has already been marked returned it's a nop.