### PR TITLE
Don't assert on user-inputed values

### DIFF
--- a/src/blind.cpp
+++ b/src/blind.cpp
@@ -284,7 +284,10 @@ int BlindTransaction(std::vector<uint256 >& input_value_blinding_factors, const 
             }
         } else {
             ret = secp256k1_generator_generate_blinded(secp256k1_blind_context, &target_asset_generators[totalTargets], input_assets[i].begin(), input_asset_blinding_factors[i].begin());
-            assert(ret == 1);
+            if (ret != 1) {
+                // Possibly invalid blinding factor provided by user.
+                return -1;
+            }
         }
         memcpy(&surjection_targets[totalTargets], input_assets[i].begin(), 32);
         target_asset_blinders.push_back(input_asset_blinding_factors[i]);
@@ -519,7 +522,10 @@ int BlindTransaction(std::vector<uint256 >& input_value_blinding_factors, const 
 
                 // Generate value we intend to insert
                 ret = secp256k1_pedersen_blind_generator_blind_sum(secp256k1_blind_context, &blinded_amounts[0], &asset_blindptrs[0], &value_blindptrs[0], num_blind_attempts + num_known_input_blinds, num_issuance_blind_attempts + num_known_input_blinds);
-                assert(ret);
+                if (!ret) {
+                    // Possibly invalid blinding factor provided by user.
+                    return -1;
+                }
 
                 // Resulting blinding factor can sometimes be 0
                 // where inputs are the negations of each other

--- a/test/functional/feature_confidential_transactions.py
+++ b/test/functional/feature_confidential_transactions.py
@@ -609,6 +609,11 @@ class CTTest (BitcoinTestFramework):
         except JSONRPCException:
             pass
 
+        # Make sure RPC throws when an invalid blinding factor is provided.
+        bad_blinder = 'FF'*32
+        assert_raises_rpc_error(-8, "Unable to blind transaction: Are you sure each asset type to blind is represented in the inputs?", self.nodes[0].rawblindrawtransaction, rawtx, [unspent[0]["amountblinder"], bad_blinder], [unspent[0]["amount"], unspent[1]["amount"]], [unspent[0]["asset"], unspent[1]["asset"]], [unspent[0]["assetblinder"], unspent[1]["assetblinder"]])
+        assert_raises_rpc_error(-8, "Unable to blind transaction: Are you sure each asset type to blind is represented in the inputs?", self.nodes[0].rawblindrawtransaction, rawtx, [unspent[0]["amountblinder"], unspent[1]["amountblinder"]], [unspent[0]["amount"], unspent[1]["amount"]], [unspent[0]["asset"], unspent[1]["asset"]], [unspent[0]["assetblinder"], bad_blinder])
+
         blindtx = self.nodes[0].rawblindrawtransaction(rawtx, [unspent[0]["amountblinder"], unspent[1]["amountblinder"]], [unspent[0]["amount"], unspent[1]["amount"]], [unspent[0]["asset"], unspent[1]["asset"]], [unspent[0]["assetblinder"], unspent[1]["assetblinder"]])
         signtx = self.nodes[0].signrawtransactionwithwallet(blindtx)
         txid = self.nodes[0].sendrawtransaction(signtx["hex"])


### PR DESCRIPTION
This prevents the assertion from crashing the node when an RPC user
enters invalid blinding factors.

Fixes #540.