### PR TITLE
[0.17 backport] FundTransaction: mark all change keys as kept #660 

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2700,6 +2700,11 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, int& nC
         }
     }
 
+    // Mark all un-returned change keys as used to reduce privacy loss
+    for (auto& changekey : vChangeKey) {
+        changekey->KeepKey();
+    }
+
     return true;
 }
 


### PR DESCRIPTION
Backport of https://github.com/ElementsProject/elements/pull/660.