### PR TITLE
Disallow issuance-stuffing in tx deserialization

### DIFF
--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -212,6 +212,9 @@ public:
         // The asset fields are deserialized only if they are present.
         if (fHasAssetIssuance) {
             READWRITE(assetIssuance);
+            if (assetIssuance.IsNull()) {
+                throw std::ios_base::failure("Superfluous issuance record");
+            }
         } else if (ser_action.ForRead()) {
             assetIssuance.SetNull();
         }


### PR DESCRIPTION
This is not a consensus change, as "honest" serialization for size/txid purposes will not include these, and only the amounts fields are used in "balance" checking later.