### PR TITLE
Fix importmasterblindingkey help

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -1679,9 +1679,9 @@ UniValue importmasterblindingkey(const JSONRPCRequest& request)
 
     if (request.fHelp || request.params.size() != 1)
         throw std::runtime_error(
-            RPCHelpMan{"importblindingkey",
-                "\nImports a master private blinding key in hex for a CT address."
-                "Note: wallets can only have one master blinding key at a time. Funds could be permanently lost if user doesn't know what they are doing. Recommended use is only for wallet recovery using this in conjunction with `sethdseed`.\n",
+            RPCHelpMan{"importmasterblindingkey",
+                "\nImports a master private blinding key in hex for the wallet."
+                "\nNote: wallets can only have one master blinding key at a time. Funds could be permanently lost if user doesn't know what they are doing. Recommended use is only for wallet recovery using this in conjunction with `sethdseed`.\n",
                 {
                     {"hexkey", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The blinding key in hex"},
                 },


### PR DESCRIPTION
Before:

    $ elements-cli help | grep importblindingkey
    importblindingkey "address" "hexkey"
    importblindingkey "hexkey"
    $ elements-cli help | grep importmasterblindingkey

After:

    $ elements-cli help | grep importblindingkey
    importblindingkey "address" "hexkey"
    $ elements-cli help | grep importmasterblindingkey
    importmasterblindingkey "hexkey"
