### PR TITLE
Change default chain to liquidv1

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -553,10 +553,7 @@ BOOST_AUTO_TEST_CASE(util_GetChainName)
     std::string error;
 
     BOOST_CHECK(test_args.ParseParameters(0, (char**)argv_testnet, error));
-    std::string default_chain = "elementsregtest";
-#if LIQUID
-    default_chain = "liquidv1";
-#endif
+    std::string default_chain = "liquidv1";
     BOOST_CHECK_EQUAL(test_args.GetChainName(), default_chain);
 
     BOOST_CHECK(test_args.ParseParameters(2, (char**)argv_testnet, error));

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -1001,10 +1001,7 @@ std::string ArgsManager::GetChainName() const
     if (fTestNet)
         return CBaseChainParams::TESTNET;
 
-    std::string default_chain = "elementsregtest";
-#ifdef LIQUID
-    default_chain = "liquidv1";
-#endif
+    std::string default_chain = "liquidv1";
     return GetArg("-chain", default_chain);
 }
 


### PR DESCRIPTION
In general if people are running their own experimental chains they should do so by specifying `-chain=<whatever>` rather than relying on defaults. When none is given, most likely the user is trying to use `liquidv` anyways.