### PR TITLE
Fix gitian descriptor major version for yml

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -1,5 +1,5 @@
 ---
-name: "elements-linux-0.18"
+name: "elements-linux-0.17"
 enable_cache: true
 suites:
 - "bionic"

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -1,5 +1,5 @@
 ---
-name: "elements-osx-0.18"
+name: "elements-osx-0.17"
 enable_cache: true
 suites:
 - "bionic"

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -1,5 +1,5 @@
 ---
-name: "elements-win-0.18"
+name: "elements-win-0.17"
 enable_cache: true
 suites:
 - "bionic"


### PR DESCRIPTION
Makes the gitian output wrong otherwise:

```
Generating report
ec40c90d48ea38bb63cf1d36a0695810412ac3676e3359ad62e8ccf5273a0fcf  elements-0.17.0-aarch64-linux-gnu-debug.tar.gz
...
613418e96782c9e7cd5b9427e851a96575b1252fc14a0decad63d9b29bcd515a  src/elements-0.17.0.tar.gz
ba84ba37eb386b51492247edafa5f23c921cb81ca1a9eea06273d6aadc885f36  elements-linux-0.18-res.yml
```