### PR TITLE
fix config err

### DIFF
--- a/contrib/assets_tutorial/elements2.conf
+++ b/contrib/assets_tutorial/elements2.conf
@@ -1,3 +1,5 @@
+chain=elementsregtest
+
 rpcuser=user2
 rpcpassword=password2
 elementsregtest.rpcport=18885


### PR DESCRIPTION
I was confused to instructions in [Elements code tutorial](https://elementsproject.org/elements-code-tutorial/working-environment):

> `cp ~/elements/contrib/assets_tutorial/elements2.conf ~/elementsdir2/elements.conf`

But, in `~/elements/contrib/assets_tutorial/elements2.conf`, the network type is not specified at the beginning.

I got an error after `e2-cli`:

```
$ e2-cli getwalletinfo
error: Could not connect to the server 127.0.0.1:7041

Make sure the daemon server is running and that you are connecting to the correct RPC port.
```

because elements default network is liquid, the port is 7041, so if you don't point the correct chain, you wouldn't get correct info.

So I think the correct elements2.conf as below:

```
chain=elementsregtest

rpcuser=user2
rpcpassword=password2
elementsregtest.rpcport=18885
elementsregtest.port=18887
elementsregtest.connect=localhost:18886

daemon=1
listen=1
txindex=1

#fedpegscript=51<pubkey>51ae
#signblockscript=51<pubkey2>51ae

mainchainrpcport=18888
mainchainrpcuser=user3
mainchainrpcpassword=password3
validatepegin=1

initialfreecoins=2100000000000000
```

I got correct result:

```
$ e2-cli -getinfo
{
  "version": 189900,
  "protocolversion": 70015,
  "walletversion": 169900,
  "balance": {
    "bitcoin": 21000000.00000000
  },
  "blocks": 0,
  "timeoffset": 0,
  "connections": 0,
  "proxy": "",
  "difficulty": null,
  "testnet": false,
  "keypoololdest": 1565173696,
  "keypoolsize": 1000,
  "paytxfee": 0.00000000,
  "relayfee": 0.00001000,
  "warnings": ""
}
```
