### PR TITLE
Fix nit in blech32_hrp assignment in Bitcoin chains

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -176,7 +176,7 @@ public:
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x88, 0xAD, 0xE4};
 
         bech32_hrp = "bc";
-        blech32_hrp = blech32_hrp;
+        blech32_hrp = bech32_hrp;
 
         vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_main, pnSeed6_main + ARRAYLEN(pnSeed6_main));
 
@@ -295,7 +295,7 @@ public:
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
 
         bech32_hrp = "tb";
-        blech32_hrp = blech32_hrp;
+        blech32_hrp = bech32_hrp;
 
         vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_test, pnSeed6_test + ARRAYLEN(pnSeed6_test));
 
@@ -412,7 +412,7 @@ public:
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
 
         bech32_hrp = "bcrt";
-        blech32_hrp = blech32_hrp;
+        blech32_hrp = bech32_hrp;
 
         /* enable fallback fee on regtest */
         m_fallback_fee_enabled = true;


### PR DESCRIPTION
I don't think this had a real effect, though since blech32 should be disabled for the Bitcoin networks.