### PR TITLE
fix len check in blech32 decode() in test framework

### DIFF
--- a/test/functional/feature_confidential_transactions.py
+++ b/test/functional/feature_confidential_transactions.py
@@ -28,6 +28,11 @@ from test_framework.util import (
 import os
 import re
 
+from test_framework.liquid_addr import (
+    encode,
+    decode,
+)
+
 class CTTest (BitcoinTestFramework):
 
     def set_test_params(self):
@@ -103,6 +108,15 @@ class CTTest (BitcoinTestFramework):
 
         print("Testing wallet secret recovery")
         self.test_wallet_recovery()
+
+        print("Test blech32 python roundtrip")
+        # blech/bech are aliased, both are blech32
+        for addrtype in ["bech32", "blech32"]:
+            addr_to_rt = self.nodes[0].getnewaddress("", addrtype)
+            hrp = addr_to_rt[:2]
+            assert_equal(hrp, "el")
+            (witver, witprog) = decode(hrp, addr_to_rt)
+            assert_equal(encode(hrp, witver, witprog), addr_to_rt)
 
         # Test that "blech32" gives a blinded segwit address.
         blech32_addr = self.nodes[0].getnewaddress("", "blech32")

--- a/test/functional/test_framework/liquid_addr.py
+++ b/test/functional/test_framework/liquid_addr.py
@@ -84,16 +84,19 @@ def convertbits(data, frombits, tobits, pad=True):
 
 
 def decode(hrp, addr):
-    """Decode a segwit address."""
+    """Decode a segwit confidential address.
+    Its payload is longer than the payload for unconfidential address
+    by 33 bytes (the length of blinding pubkey)"""
+
     hrpgot, data = blech32_decode(addr)
     if hrpgot != hrp:
         return (None, None)
     decoded = convertbits(data[1:], 5, 8, False)
-    if decoded is None or len(decoded) < 2 or len(decoded) > 40:
+    if decoded is None or len(decoded) < 2 or len(decoded) > 40+33:
         return (None, None)
     if data[0] > 16:
         return (None, None)
-    if data[0] == 0 and len(decoded) != 20 and len(decoded) != 32:
+    if data[0] == 0 and len(decoded) != 20+33 and len(decoded) != 32+33:
         return (None, None)
     return (data[0], decoded)
 


### PR DESCRIPTION
I used the code from test/functional/test_framework/liquid_addr.py with the same length check adjustments in python-elementstx to decode Liquid's blech32 addresses, and it seems to be working fine.