### PR TITLE
Fix liquidv1 sync

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -725,6 +725,9 @@ public:
 
         g_con_blockheightinheader = true;
         g_con_elementsmode = true;
+        // TODO: Pick appropriate value for this network.
+        consensus.total_valid_epochs = 2;
+
 
         consensus.genesis_subsidy = 0;
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -789,6 +789,12 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
 
+        // Not active yet.
+        consensus.vDeployments[Consensus::DEPLOYMENT_DYNA_FED].bit = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_DYNA_FED].nStartTime = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_DYNA_FED].nTimeout = 0;
+
+
         // Finally, create genesis block
         genesis = CreateGenesisBlock(consensus, CScript(commit), CScript(OP_RETURN), 1296688602, 2, 0x207fffff, 1, 0);
         consensus.hashGenesisBlock = genesis.GetHash();

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -106,7 +106,8 @@ struct Params {
     // Used to seed the extension space for first dynamic blocks
     std::vector<std::vector<unsigned char>> first_extension_space;
     // Used to allow M-epoch-old peg-in addresses as deposits
-    size_t total_valid_epochs;
+    // default 1 to not break legacy chains implicitly.
+    size_t total_valid_epochs = 1;
 };
 } // namespace Consensus
 

--- a/src/pegins.cpp
+++ b/src/pegins.cpp
@@ -492,7 +492,7 @@ std::vector<std::pair<CScript, CScript>> GetValidFedpegScripts(const CBlockIndex
             fedpegscripts.push_back(std::make_pair(GetScriptForDestination(ScriptHash(GetScriptForDestination(WitnessV0ScriptHash(params.fedpegScript)))), params.fedpegScript));
         }
     }
-    // Only return up to the latest two of three possible fedpegscripts, which are enforced
+    // Only return up to the latest total_valid_epochs fedpegscripts, which are enforced
     fedpegscripts.resize(std::min(fedpegscripts.size(), params.total_valid_epochs));
     return fedpegscripts;
 }


### PR DESCRIPTION
A single field wasn't given a positive value which
meant it considers no peg-ins to be valid. This is something introduced by dynafed.

I put in a guess placeholder, the important part is that it's > 0.