### PR TITLE
Give more descriptive error for non-WSH(OP_TRUE) block generation

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -142,11 +142,13 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
             }
         }
 
-        // Fill out block witness if dynamic federation is enabled
-        // since we are assuming WSH(OP_TRUE)
-        if (!pblock->m_dynafed_params.IsNull()) {
-            CScript op_true(OP_TRUE);
+        // Handle OP_TRUE m_signblockscript case
+        CScript op_true(OP_TRUE);
+        if (pblock->m_dynafed_params.m_current.m_signblockscript ==
+                GetScriptForDestination(WitnessV0ScriptHash(op_true))) {
             pblock->m_signblock_witness.stack.push_back(std::vector<unsigned char>(op_true.begin(), op_true.end()));
+        } else if (!pblock->m_dynafed_params.IsNull()) {
+            throw JSONRPCError(RPC_MISC_ERROR, "Unable to fill out dynamic federation signblockscript witness, are you sure it's WSH(OP_TRUE)?");
         }
 
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);


### PR DESCRIPTION
If someone transitions to a different block type, including something else op_true-ey but not exactly, `generatetoaddress` and ilk will complain without much recourse.