### PR TITLE
[0.18] Reduce Travis errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -154,6 +154,7 @@ jobs:
         DOCKER_NAME_TAG=ubuntu:16.04
         PACKAGES="clang llvm python3-zmq qtbase5-dev qttools5-dev-tools libssl-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libprotobuf-dev protobuf-compiler libqrencode-dev"
         NO_DEPENDS=1
+        RUN_FUNCTIONAL_TESTS=false
         GOAL="install"
         BITCOIN_CONFIG="--enable-zmq --disable-wallet --with-gui=qt5 CPPFLAGS=-DDEBUG_LOCKORDER --with-sanitizers=thread --disable-hardening --disable-asm CC=clang CXX=clang++"
 
@@ -163,6 +164,7 @@ jobs:
         HOST=x86_64-unknown-linux-gnu
         PACKAGES="clang llvm python3-zmq qtbase5-dev qttools5-dev-tools libssl1.0-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libprotobuf-dev protobuf-compiler libqrencode-dev"
         NO_DEPENDS=1
+        RUN_FUNCTIONAL_TESTS=false
         GOAL="install"
         BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --enable-glibc-back-compat --enable-reduce-exports --with-gui=qt5 CPPFLAGS=-DDEBUG_LOCKORDER --with-sanitizers=integer,undefined CC=clang CXX=clang++"
 # x86_64 Linux, No wallet, no QT(build timing out with for some reason)

--- a/.travis.yml
+++ b/.travis.yml
@@ -192,6 +192,7 @@ jobs:
         HOST=x86_64-unknown-linux-gnu
         PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools libssl1.0-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libprotobuf-dev protobuf-compiler libqrencode-dev"
         NO_DEPENDS=1
+        RUN_UNIT_TESTS=false
         RUN_BITCOIN_TESTS=true
         RUN_FUNCTIONAL_TESTS=false
         GOAL="install"

--- a/.travis.yml
+++ b/.travis.yml
@@ -190,6 +190,7 @@ jobs:
 
 # x86_64 Linux w/ Bitcoin functional tests (Qt5 & system libs)
     - stage: test
+      name: 'x86_64 Linux  [GOAL: install]  [bitcoin functional]'
       env: >-
         HOST=x86_64-unknown-linux-gnu
         PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools libssl1.0-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libprotobuf-dev protobuf-compiler libqrencode-dev"
@@ -202,6 +203,7 @@ jobs:
 
 # x86_64 Linux w/ single fedpeg test that uses upstream bitcoind as mainchain
     - stage: test
+      name: 'x86_64 Linux  [GOAL: install]  [bitcoind fedpeg test]'
       env: >-
         HOST=x86_64-unknown-linux-gnu
         PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools libssl1.0-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libprotobuf-dev protobuf-compiler libqrencode-dev"
@@ -214,6 +216,7 @@ jobs:
         BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --enable-glibc-back-compat --enable-reduce-exports --with-gui=no --disable-tests --disable-bench CPPFLAGS=-DDEBUG_LOCKORDER"
 # x86_64 Linux (uses qt5 dev package instead of depends Qt to speed up build and avoid timeout), no functional tests, LIQUID BUILD
     - stage: test
+      name: 'x86_64 Linux  [GOAL: install]  [liquid build]'
       env: >-
         HOST=x86_64-unknown-linux-gnu
         PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools protobuf-compiler libdbus-1-dev libharfbuzz-dev libprotobuf-dev"

--- a/.travis/test_06_script_a.sh
+++ b/.travis/test_06_script_a.sh
@@ -47,36 +47,4 @@ BEGIN_FOLD build
 DOCKER_EXEC make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && DOCKER_EXEC make $GOAL V=1 ; false )
 END_FOLD
 
-if [ "$RUN_UNIT_TESTS" = "true" ]; then
-  BEGIN_FOLD unit-tests
-  DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make $MAKEJOBS check VERBOSE=1
-  END_FOLD
-fi
-
-if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
-  extended="--extended --exclude feature_pruning"
-fi
-
-if [ "$RUN_FUNCTIONAL_TESTS" = "true" ]; then
-  BEGIN_FOLD functional-tests
-  DOCKER_EXEC test/functional/test_runner.py --ci --combinedlogslen=4000 --coverage --quiet --failfast ${extended}
-  END_FOLD
-fi
-
-if [ "$RUN_BITCOIN_TESTS" = "true" ]; then
-    BEGIN_FOLD bitcoin-functional-tests
-    DOCKER_EXEC test/bitcoin_functional/functional/test_runner.py --combinedlogslen=4000 --coverage --quiet --failfast ${extended}
-    END_FOLD
-fi
-
-if [ "$RUN_FEDPEG_BITCOIND_TEST" = "true" ]; then
-    BEGIN_FOLD fedpeg-bitcoind-test
-    BITCOIND_VERSION=0.18.0
-    BITCOIND_ARCH=x86_64-linux-gnu
-    DOCKER_EXEC curl -O https://bitcoincore.org/bin/bitcoin-core-$BITCOIND_VERSION/bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz
-    DOCKER_EXEC tar -zxf bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz
-    DOCKER_EXEC test/functional/feature_fedpeg.py --parent_bitcoin --parent_binpath $(pwd)/bitcoin-$BITCOIND_VERSION/bin/bitcoind
-    END_FOLD
-fi
-
 cd ${TRAVIS_BUILD_DIR} || (echo "could not enter travis build dir $TRAVIS_BUILD_DIR"; exit 1)

--- a/.travis/test_06_script_b.sh
+++ b/.travis/test_06_script_b.sh
@@ -25,3 +25,29 @@ if [ "$RUN_FUZZ_TESTS" = "true" ]; then
   DOCKER_EXEC test/fuzz/test_runner.py -l DEBUG ${DIR_FUZZ_IN}
   END_FOLD
 fi
+
+if [ "$RUN_UNIT_TESTS" = "true" ]; then
+  BEGIN_FOLD unit-tests
+  DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make $MAKEJOBS check VERBOSE=1
+  END_FOLD
+fi
+
+if [ "$RUN_BITCOIN_TESTS" = "true" ]; then
+    BEGIN_FOLD bitcoin-functional-tests
+    DOCKER_EXEC test/bitcoin_functional/functional/test_runner.py --combinedlogslen=4000 --coverage --quiet --failfast ${extended}
+    END_FOLD
+fi
+
+if [ "$RUN_FEDPEG_BITCOIND_TEST" = "true" ]; then
+    BEGIN_FOLD fedpeg-bitcoind-test
+    BITCOIND_VERSION=0.18.0
+    BITCOIND_ARCH=x86_64-linux-gnu
+    DOCKER_EXEC curl -O https://bitcoincore.org/bin/bitcoin-core-$BITCOIND_VERSION/bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz
+    DOCKER_EXEC tar -zxf bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz
+    DOCKER_EXEC test/functional/feature_fedpeg.py --parent_bitcoin --parent_binpath $(pwd)/bitcoin-$BITCOIND_VERSION/bin/bitcoind
+    END_FOLD
+fi
+
+if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
+  extended="--extended --exclude feature_pruning"
+fi

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1376,9 +1376,9 @@ UniValue finalizecompactblock(const JSONRPCRequest& request)
     // Make mega-list
     found.insert(found.end(), transactions.txn.begin(), transactions.txn.end());
 
-    // Now construct the final block!
-    LOCK(mempool.cs);
-    PartiallyDownloadedBlock partialBlock(&mempool);
+    // Now construct the final block! (use dummy mempool here, otherwise reconstruction may fail)
+    CTxMemPool dummy_pool;
+    PartiallyDownloadedBlock partialBlock(&dummy_pool);
 
     const std::vector<std::pair<uint256, CTransactionRef>> dummy;
     std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>();

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1245,6 +1245,7 @@ UniValue consumecompactsketch(const JSONRPCRequest& request)
     CBlockHeaderAndShortTxIDs cmpctblock;
     ssBlock >> cmpctblock;
 
+    LOCK(mempool.cs);
     PartiallyDownloadedBlock partialBlock(&mempool);
     const std::vector<std::pair<uint256, CTransactionRef>> dummy;
     ReadStatus status = partialBlock.InitData(cmpctblock, dummy);
@@ -1376,6 +1377,7 @@ UniValue finalizecompactblock(const JSONRPCRequest& request)
     found.insert(found.end(), transactions.txn.begin(), transactions.txn.end());
 
     // Now construct the final block!
+    LOCK(mempool.cs);
     PartiallyDownloadedBlock partialBlock(&mempool);
 
     const std::vector<std::pair<uint256, CTransactionRef>> dummy;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1368,7 +1368,7 @@ UniValue finalizecompactblock(const JSONRPCRequest& request)
 
     // Cached transactions
     std::vector<unsigned char> found_tx(ParseHex(request.params[2].get_str()));
-    CDataStream ssFound(block_tx, SER_NETWORK, PROTOCOL_VERSION);
+    CDataStream ssFound(found_tx, SER_NETWORK, PROTOCOL_VERSION);
 
     std::vector<CTransactionRef> found;
     ssFound >> found;
@@ -1380,10 +1380,21 @@ UniValue finalizecompactblock(const JSONRPCRequest& request)
     CTxMemPool dummy_pool;
     PartiallyDownloadedBlock partialBlock(&dummy_pool);
 
-    const std::vector<std::pair<uint256, CTransactionRef>> dummy;
+    // "Extra" list is really our combined list that will be put into place using InitData
+    std::vector<std::pair<uint256, CTransactionRef>> extra_txn;
+    for (const auto& found_tx : found) {
+        extra_txn.push_back(std::make_pair(found_tx->GetWitnessHash(), found_tx));
+    }
     std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>();
-    if (partialBlock.InitData(cmpctblock, dummy) != READ_STATUS_OK || partialBlock.FillBlock(*pblock, found, false /* pow_check*/) != READ_STATUS_OK) {
+    if (partialBlock.InitData(cmpctblock, extra_txn) != READ_STATUS_OK) {
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "compact_hex appears malformed.");
+    }
+    const std::vector<CTransactionRef> dummy_missing;
+    auto result = partialBlock.FillBlock(*pblock, dummy_missing, false /* pow_check*/);
+    if (result == READ_STATUS_FAILED) {
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Failed to complete block though all transactions were apparently found. Could be random short ID collision; requires full block instead.");
+    } else if (result != READ_STATUS_OK) {
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Failed to complete block though all transactions were apparently found.");
     }
 
     CDataStream ssBlock(SER_NETWORK, PROTOCOL_VERSION);

--- a/test/functional/feature_blocksign.py
+++ b/test/functional/feature_blocksign.py
@@ -109,7 +109,7 @@ class BlockSignTest(BitcoinTestFramework):
 
         # Make a few transactions to make non-empty blocks for compact transmission
         if make_transactions:
-            for i in range(5):
+            for i in range(20):
                 miner.sendtoaddress(miner_next.getnewaddress(), int(miner.getbalance()['bitcoin']/10), "", "", True)
         # miner makes a block
         block = miner.getnewblockhex()

--- a/test/functional/feature_fedpeg.py
+++ b/test/functional/feature_fedpeg.py
@@ -537,6 +537,7 @@ class FedPegTest(BitcoinTestFramework):
         # Watch the address so we can get tx without txindex
         parent.importaddress(mainchain_addr)
         claim_block = parent.generatetoaddress(50, mainchain_addr)[0]
+        self.sync_all(self.node_groups)
         block_coinbase = parent.getblock(claim_block, 2)["tx"][0]
         claim_txid = block_coinbase["txid"]
         claim_tx = block_coinbase["hex"]
@@ -552,11 +553,13 @@ class FedPegTest(BitcoinTestFramework):
 
         # 50 more blocks to allow wallet to make it succeed by relay and consensus
         parent.generatetoaddress(50, parent.getnewaddress())
+        self.sync_all(self.node_groups)
         # Wallet still doesn't want to for 2 more confirms
         assert_equal(sidechain.createrawpegin(claim_tx, claim_proof)["mature"], False)
         # But we can just shoot it off
         claim_txid = sidechain.sendrawtransaction(signed_pegin)
         sidechain.generatetoaddress(1, sidechain.getnewaddress())
+        self.sync_all(self.node_groups)
         assert_equal(sidechain.gettransaction(claim_txid)["confirmations"], 1)
 
         # Test a confidential pegin.
@@ -568,6 +571,7 @@ class FedPegTest(BitcoinTestFramework):
         txid_fund = parent.sendtoaddress(pegin_addr, 10)
         # 10+2 confirms required to get into mempool and confirm
         parent.generate(11)
+        self.sync_all(self.node_groups)
         proof = parent.gettxoutproof([txid_fund])
         raw = parent.gettransaction(txid_fund)["hex"]
         raw_pegin = sidechain.createrawpegin(raw, proof)['hex']


### PR DESCRIPTION
1) Don't run unit tests for compatibility run(redundant)
2) Disable functional tests for sanitizer runs which have been OOM for a while now
3) only use mempool sync in fedpeg test to avoid connection complexity, add a bunch of sync calls to avoid hanging validation failure corner cases
4) run functional tests exactly once
5) fix finalizecompactblock RPC