### PR TITLE
Allow up to 30 minutes of no output from travis runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,9 +64,9 @@ before_script:
 script:
   - export CONTINUE=1
   - if [ $SECONDS -gt 1200 ]; then export CONTINUE=0; fi  # Likely the depends build took very long
-  - if [ $CONTINUE = "1" ]; then set -o errexit; source .travis/test_06_script_a.sh; else set +o errexit; echo "$CACHE_ERR_MSG"; false; fi
+  - if [ $CONTINUE = "1" ]; then set -o errexit; travis_wait 30 source .travis/test_06_script_a.sh; else set +o errexit; echo "$CACHE_ERR_MSG"; false; fi
   - if [ $SECONDS -gt 1800 ]; then export CONTINUE=0; fi  # Likely the build took very long
-  - if [ $CONTINUE = "1" ]; then set -o errexit; source .travis/test_06_script_b.sh; else set +o errexit; echo "$CACHE_ERR_MSG"; false; fi
+  - if [ $CONTINUE = "1" ]; then set -o errexit; travis_wait 30 source .travis/test_06_script_b.sh; else set +o errexit; echo "$CACHE_ERR_MSG"; false; fi
 after_script:
   - echo $TRAVIS_COMMIT_RANGE
   - echo $TRAVIS_COMMIT_LOG

--- a/test/functional/feature_fedpeg.py
+++ b/test/functional/feature_fedpeg.py
@@ -6,7 +6,6 @@ from test_framework.authproxy import JSONRPCException
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     connect_nodes_bi,
-    disconnect_nodes,
     get_auth_cookie,
     get_datadir_path,
     rpc_port,
@@ -615,23 +614,14 @@ class FedPegTest(BitcoinTestFramework):
             assert(final_decoded["vout"][1]["commitmentnonce_fully_valid"])
             assert("value" in final_decoded["vout"][2])
             assert("asset" in final_decoded["vout"][2])
-            # check that it is accepted in the mempool
+            # check that it is accepted in either mempool
             accepted = sidechain.testmempoolaccept([pegin_signed["hex"]])[0]
             if not accepted["allowed"]:
                 raise Exception(accepted["reject-reason"])
+            accepted = sidechain2.testmempoolaccept([pegin_signed["hex"]])[0]
+            if not accepted["allowed"]:
+                raise Exception(accepted["reject-reason"])
             print("Blinded transaction looks ok!") # need this print to distinguish failures in for loop
-        # check if they get mined; since we're trying to mine two double spends, disconnect the nodes
-        disconnect_nodes(sidechain, 3)
-        disconnect_nodes(sidechain2, 2)
-        txid1 = sidechain.sendrawtransaction(pegin_signed1["hex"])
-        blocks = sidechain.generate(3)
-        assert_equal(sidechain.getrawtransaction(txid1, True, blocks[0])["confirmations"], 3)
-        txid2 = sidechain2.sendrawtransaction(pegin_signed2["hex"])
-        blocks = sidechain2.generate(3)
-        assert_equal(sidechain2.getrawtransaction(txid2, True, blocks[0])["confirmations"], 3)
-        # reconnect in case we extend the test
-        connect_nodes_bi(self.nodes, 2, 3)
-        sidechain.generate(10)
 
         print('Success!')
 


### PR DESCRIPTION
Unit tests seem to be randomly timing out, this should lengthen the "legal" wait from 10 minutes to 20 minutes.

Also make the feature_fedpeg test non-racey: https://github.com/ElementsProject/elements/issues/728 . Testing block confirmations after splitting the network is overkill and is causing weird connection races.