### PR TITLE
Take mempool locks when doing compact block RPC calls touching mempool

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1245,6 +1245,7 @@ UniValue consumecompactsketch(const JSONRPCRequest& request)
     CBlockHeaderAndShortTxIDs cmpctblock;
     ssBlock >> cmpctblock;
 
+    LOCK(mempool.cs);
     PartiallyDownloadedBlock partialBlock(&mempool);
     const std::vector<std::pair<uint256, CTransactionRef>> dummy;
     ReadStatus status = partialBlock.InitData(cmpctblock, dummy);
@@ -1376,6 +1377,7 @@ UniValue finalizecompactblock(const JSONRPCRequest& request)
     found.insert(found.end(), transactions.txn.begin(), transactions.txn.end());
 
     // Now construct the final block!
+    LOCK(mempool.cs);
     PartiallyDownloadedBlock partialBlock(&mempool);
 
     const std::vector<std::pair<uint256, CTransactionRef>> dummy;


### PR DESCRIPTION
This may help reduce the failures in `feature_blocksign.py` that seem to occur fairly often. It could be that the mempool is in an inconsistent state, which messed up compact block finalization.