### PR TITLE
Fix finalizecompactblock filling in more found txs from mempool

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1376,9 +1376,9 @@ UniValue finalizecompactblock(const JSONRPCRequest& request)
     // Make mega-list
     found.insert(found.end(), transactions.txn.begin(), transactions.txn.end());
 
-    // Now construct the final block!
-    LOCK(mempool.cs);
-    PartiallyDownloadedBlock partialBlock(&mempool);
+    // Now construct the final block! (use dummy mempool here, otherwise reconstruction may fail)
+    CTxMemPool dummy_pool;
+    PartiallyDownloadedBlock partialBlock(&dummy_pool);
 
     const std::vector<std::pair<uint256, CTransactionRef>> dummy;
     std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>();


### PR DESCRIPTION
If you instantiate `InitData` with a non-empty mempool, it may find "missing transactions", fill them in, and then the missing transaction index vector is now faulty and fails.

All data is already available to finish the block(or not in case of collision), just use given data.

Fixes intermittent feature_blocksign.py failure.