### PR TITLE
finalizecompactblock: Fix it

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1368,7 +1368,7 @@ UniValue finalizecompactblock(const JSONRPCRequest& request)
 
     // Cached transactions
     std::vector<unsigned char> found_tx(ParseHex(request.params[2].get_str()));
-    CDataStream ssFound(block_tx, SER_NETWORK, PROTOCOL_VERSION);
+    CDataStream ssFound(found_tx, SER_NETWORK, PROTOCOL_VERSION);
 
     std::vector<CTransactionRef> found;
     ssFound >> found;
@@ -1380,10 +1380,21 @@ UniValue finalizecompactblock(const JSONRPCRequest& request)
     CTxMemPool dummy_pool;
     PartiallyDownloadedBlock partialBlock(&dummy_pool);
 
-    const std::vector<std::pair<uint256, CTransactionRef>> dummy;
+    // "Extra" list is really our combined list that will be put into place using InitData
+    std::vector<std::pair<uint256, CTransactionRef>> extra_txn;
+    for (const auto& found_tx : found) {
+        extra_txn.push_back(std::make_pair(found_tx->GetWitnessHash(), found_tx));
+    }
     std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>();
-    if (partialBlock.InitData(cmpctblock, dummy) != READ_STATUS_OK || partialBlock.FillBlock(*pblock, found, false /* pow_check*/) != READ_STATUS_OK) {
+    if (partialBlock.InitData(cmpctblock, extra_txn) != READ_STATUS_OK) {
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "compact_hex appears malformed.");
+    }
+    const std::vector<CTransactionRef> dummy_missing;
+    auto result = partialBlock.FillBlock(*pblock, dummy_missing, false /* pow_check*/);
+    if (result == READ_STATUS_FAILED) {
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Failed to complete block though all transactions were apparently found. Could be random short ID collision; requires full block instead.");
+    } else if (result != READ_STATUS_OK) {
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Failed to complete block though all transactions were apparently found.");
     }
 
     CDataStream ssBlock(SER_NETWORK, PROTOCOL_VERSION);

--- a/test/functional/feature_blocksign.py
+++ b/test/functional/feature_blocksign.py
@@ -111,7 +111,7 @@ class BlockSignTest(BitcoinTestFramework):
 
         # Make a few transactions to make non-empty blocks for compact transmission
         if make_transactions:
-            for i in range(5):
+            for i in range(20):
                 miner.sendtoaddress(miner_next.getnewaddress(), int(miner.getbalance()['bitcoin']/10), "", "", True)
         # miner makes a block
         block = miner.getnewblockhex()


### PR DESCRIPTION
We were putting together the block wrong in a couple ways.

The order of the transactions matter when give as the "missing transactions" list. We're simply feeding it two lists of transactions that together should contain the full block. Also we should actually serialized the 2nd argument rather than the 1st, again.