### PR TITLE
feature_blocksign.py: Allot for possibility of non-empty block 0.5RTT

### DIFF
--- a/test/functional/feature_blocksign.py
+++ b/test/functional/feature_blocksign.py
@@ -116,16 +116,19 @@ class BlockSignTest(BitcoinTestFramework):
         # miner makes a block
         block = miner.getnewblockhex()
 
-        # other signing nodes get fed compact blocks
+        # All nodes get compact blocks, first node may get complete
+        # block in 0.5 RTT even with transactions thanks to p2p connection
+        # with non-signing node being miner
         for i in range(self.num_keys):
             if i == mineridx:
                 continue
             sketch = miner.getcompactsketch(block)
             compact_response = self.nodes[i].consumecompactsketch(sketch)
-            if make_transactions:
+            if "block_tx_req" in compact_response:
                 block_txn =  self.nodes[i].consumegetblocktxn(block, compact_response["block_tx_req"])
                 final_block = self.nodes[i].finalizecompactblock(sketch, block_txn, compact_response["found_transactions"])
             else:
+                assert (mineridx == 4 and i == 0) or not make_transactions
                 # If there's only coinbase, it should succeed immediately
                 final_block = compact_response["blockhex"]
             # Block should be complete, sans signatures


### PR DESCRIPTION
The way the test is run, the last node(non-signer) can actually become the block producer.

This, in conjunction with its p2p connection to node 0, means that when node 0 is doing it's compact block back and forth, it can actually create a complete block in 0.5 RTT even if transactions were generated for that block.

Allow this to happen.

This may have been a bug in that the non-signer shouldn't have been making blocks, but this is actually more interesting behavior to test, where sometimes partially-complete compact blocks are made, sometimes full, sometimes empty. This exercises more code paths, and so I'm just making sure this succeeds instead, and assert it only succeeds in the expected situation.