### PR TITLE
macos: Use correct application name

### DIFF
--- a/contrib/macdeploy/custom_dsstore.py
+++ b/contrib/macdeploy/custom_dsstore.py
@@ -53,7 +53,7 @@ ds['.']['icvp'] = icvp
 ds['.']['vSrn'] = ('long', 1)
 
 ds['Applications']['Iloc'] = (370, 156)
-ds['Bitcoin-Qt.app']['Iloc'] = (128, 156)
+ds['Elements-Qt.app']['Iloc'] = (128, 156)
 
 ds.flush()
 ds.close()


### PR DESCRIPTION
fixes #724
- generated DS_Store for dmg was referencing Bitcoin-Qt instead
of the locally built application Elements-Qt


![image](https://user-images.githubusercontent.com/565792/69210165-b9085480-0b0e-11ea-80f5-6acef74d6929.png)
