### PR TITLE
[0.18 backport] macos: Use correct application name

### DIFF
--- a/contrib/macdeploy/custom_dsstore.py
+++ b/contrib/macdeploy/custom_dsstore.py
@@ -53,7 +53,7 @@ ds['.']['icvp'] = icvp
 ds['.']['vSrn'] = ('long', 1)
 
 ds['Applications']['Iloc'] = (370, 156)
-ds['Bitcoin-Qt.app']['Iloc'] = (128, 156)
+ds['Elements-Qt.app']['Iloc'] = (128, 156)
 
 ds.flush()
 ds.close()


### PR DESCRIPTION
Backport of https://github.com/ElementsProject/elements/pull/786.