### PR TITLE
Add DEFAULT chain and set to liquidv1

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -36,7 +36,7 @@ static void SetupCliArgs()
 {
     SetupHelpOptions(gArgs);
 
-    const auto defaultBaseParams = CreateBaseChainParams(CBaseChainParams::MAIN);
+    const auto defaultBaseParams = CreateBaseChainParams(CBaseChainParams::DEFAULT);
     const auto testnetBaseParams = CreateBaseChainParams(CBaseChainParams::TESTNET);
     const auto regtestBaseParams = CreateBaseChainParams(CBaseChainParams::REGTEST);
 

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -16,6 +16,8 @@ const std::string CBaseChainParams::TESTNET = "test";
 const std::string CBaseChainParams::REGTEST = "regtest";
 const std::string CBaseChainParams::LIQUID1 = "liquidv1";
 
+const std::string CBaseChainParams::DEFAULT = CBaseChainParams::LIQUID1;
+
 void SetupChainParamsBaseOptions()
 {
     gArgs.AddArg("-chain=<chain>", "Use the chain <chain> (default: main). Reserved values: main, test, regtest", false, OptionsCategory::CHAINPARAMS);

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -22,6 +22,8 @@ public:
     static const std::string REGTEST;
     static const std::string LIQUID1;
 
+    static const std::string DEFAULT;
+
     const std::string& DataDir() const { return strDataDir; }
     int RPCPort() const { return nRPCPort; }
     int MainchainRPCPort() const { return nMainchainRPCPort; }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -363,10 +363,12 @@ void SetupServerArgs()
     SetupHelpOptions(gArgs);
     gArgs.AddArg("-help-debug", "Print help message with debugging options and exit", false, OptionsCategory::DEBUG_TEST); // server-only for now
 
-    const auto defaultBaseParams = CreateBaseChainParams(CBaseChainParams::MAIN);
+    const auto defaultBaseParams = CreateBaseChainParams(CBaseChainParams::DEFAULT);
+    const auto mainnetBaseParams = CreateBaseChainParams(CBaseChainParams::MAIN);
     const auto testnetBaseParams = CreateBaseChainParams(CBaseChainParams::TESTNET);
     const auto regtestBaseParams = CreateBaseChainParams(CBaseChainParams::REGTEST);
-    const auto defaultChainParams = CreateChainParams(CBaseChainParams::MAIN);
+    const auto defaultChainParams = CreateChainParams(CBaseChainParams::DEFAULT);
+    const auto mainnetChainParams = CreateChainParams(CBaseChainParams::MAIN);
     const auto testnetChainParams = CreateChainParams(CBaseChainParams::TESTNET);
     const auto regtestChainParams = CreateChainParams(CBaseChainParams::REGTEST);
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -547,9 +547,11 @@ fs::path static StartupShortcutPath()
     std::string chain = gArgs.GetChainName();
     if (chain == CBaseChainParams::MAIN)
         return GetSpecialFolderPath(CSIDL_STARTUP) / "Bitcoin.lnk";
+    if (chain == CBaseChainParams::LIQUID1)
+        return GetSpecialFolderPath(CSIDL_STARTUP) / "Liquid.lnk";
     if (chain == CBaseChainParams::TESTNET) // Remove this special case when CBaseChainParams::TESTNET = "testnet4"
         return GetSpecialFolderPath(CSIDL_STARTUP) / "Bitcoin (testnet).lnk";
-    return GetSpecialFolderPath(CSIDL_STARTUP) / strprintf("Bitcoin (%s).lnk", chain);
+    return GetSpecialFolderPath(CSIDL_STARTUP) / strprintf("Elements (%s).lnk", chain);
 }
 
 bool GetStartOnSystemStartup()
@@ -630,7 +632,9 @@ fs::path static GetAutostartFilePath()
     std::string chain = gArgs.GetChainName();
     if (chain == CBaseChainParams::MAIN)
         return GetAutostartDir() / "bitcoin.desktop";
-    return GetAutostartDir() / strprintf("bitcoin-%s.lnk", chain);
+    if (chain == CBaseChainParams::LIQUID1)
+        return GetAutostartDir() / "liquid.desktop";
+    return GetAutostartDir() / strprintf("elements-%s.lnk", chain);
 }
 
 bool GetStartOnSystemStartup()
@@ -675,8 +679,10 @@ bool SetStartOnSystemStartup(bool fAutoStart)
         optionFile << "Type=Application\n";
         if (chain == CBaseChainParams::MAIN)
             optionFile << "Name=Bitcoin\n";
+        else if (chain == CBaseChainParams::LIQUID1)
+            optionFile << "Name=Liquid\n";
         else
-            optionFile << strprintf("Name=Bitcoin (%s)\n", chain);
+            optionFile << strprintf("Name=Elements (%s)\n", chain);
         optionFile << "Exec=" << pszExePath << strprintf(" -min -chain=%s\n", chain);
         optionFile << "Terminal=false\n";
         optionFile << "Hidden=false\n";

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -480,7 +480,7 @@ BOOST_AUTO_TEST_CASE(util_ReadConfigStream)
     test_args.SetNetworkOnlyArg("-ccc");
     test_args.SetNetworkOnlyArg("-h");
 
-    test_args.SelectConfigNetwork(CBaseChainParams::MAIN);
+    test_args.SelectConfigNetwork(CBaseChainParams::DEFAULT);
     BOOST_CHECK(test_args.GetArg("-d", "xxx") == "e");
     BOOST_CHECK(test_args.GetArgs("-ccc").size() == 2);
     BOOST_CHECK(test_args.GetArg("-h", "xxx") == "0");

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -174,7 +174,7 @@ public:
      *  See also comments around ArgsManager::ArgsManager() below. */
     static inline bool UseDefaultSection(const ArgsManager& am, const std::string& arg) EXCLUSIVE_LOCKS_REQUIRED(am.cs_args)
     {
-        return (am.m_network == CBaseChainParams::MAIN || am.m_network_only_args.count(arg) == 0);
+        return (am.m_network == CBaseChainParams::DEFAULT || am.m_network_only_args.count(arg) == 0);
     }
 
     /** Convert regular argument into the network-specific setting */
@@ -336,7 +336,7 @@ const std::set<std::string> ArgsManager::GetUnsuitableSectionOnlyArgs() const
     if (m_network.empty()) return std::set<std::string> {};
 
     // if it's okay to use the default section for this network, don't worry
-    if (m_network == CBaseChainParams::MAIN) return std::set<std::string> {};
+    if (m_network == CBaseChainParams::DEFAULT) return std::set<std::string> {};
 
     for (const auto& arg : m_network_only_args) {
         std::pair<bool, std::string> found_result;
@@ -1001,7 +1001,7 @@ std::string ArgsManager::GetChainName() const
     if (fTestNet)
         return CBaseChainParams::TESTNET;
 
-    std::string default_chain = "liquidv1";
+    std::string default_chain = CBaseChainParams::DEFAULT;
     return GetArg("-chain", default_chain);
 }
 

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -359,25 +359,6 @@ const std::set<std::string> ArgsManager::GetUnsuitableSectionOnlyArgs() const
     return unsuitables;
 }
 
-
-const std::set<std::string> ArgsManager::GetUnrecognizedSections() const
-{
-    // Section names to be recognized in the config file.
-    static const std::set<std::string> available_sections{
-        CBaseChainParams::REGTEST,
-        CBaseChainParams::TESTNET,
-        CBaseChainParams::MAIN
-    };
-    std::set<std::string> diff;
-
-    LOCK(cs_args);
-    std::set_difference(
-        m_config_sections.begin(), m_config_sections.end(),
-        available_sections.begin(), available_sections.end(),
-        std::inserter(diff, diff.end()));
-    return diff;
-}
-
 void ArgsManager::SelectConfigNetwork(const std::string& network)
 {
     LOCK(cs_args);

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -251,8 +251,8 @@ public:
     void ForceSetArg(const std::string& strArg, const std::string& strValue);
 
     /**
-     * Looks for -regtest, -testnet and returns the appropriate BIP70 chain name.
-     * @return CBaseChainParams::MAIN by default; raises runtime error if an invalid combination is given.
+     * Returns the chain name based on the parameters.
+     * @return CBaseChainParams::DEFAULT by default.
      */
     std::string GetChainName() const;
 

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -172,11 +172,6 @@ public:
     const std::set<std::string> GetUnsuitableSectionOnlyArgs() const;
 
     /**
-     * Log warnings for unrecognized section names in the config file.
-     */
-    const std::set<std::string> GetUnrecognizedSections() const;
-
-    /**
      * Return a vector of strings of the given argument
      *
      * @param strArg Argument to get (e.g. "-foo")


### PR DESCRIPTION
This fixes f.e. that when arguments are set in CLI or the config file
without a network attached (`port` instead of `liquidv1.port`), they
will now be assigned to the liquidv1 instead of Bitcoin mainnet.

------

With 
```toml
port=9953
```
Before:
```
➜  elements git:(master) ✗ ./src/elementsd -chain=elementsregtest | rg 9953
Warning: Config setting for -port only applied on elementsregtest network when in [elementsregtest] section.
➜  elements git:(master) ✗ ./src/elementsd -chain=main | rg 9953           
➜  elements git:(master) ✗ ./src/elementsd -chain=liquidv1 | rg 9953   
Warning: Config setting for -port only applied on main network when in [liquidv1] section.
```
After:
```
➜  elements git:(master) ✗ ./src/elementsd -chain=elementsregtest | rg 9953
Warning: Config setting for -port only applied on elementsregtest network when in [elementsregtest] section.
➜  elements git:(master) ✗ ./src/elementsd -chain=main | rg 9953           
Warning: Config setting for -port only applied on main network when in [main] section.
➜  elements git:(master) ✗ ./src/elementsd -chain=liquidv1 | rg 9953
```