### PR TITLE
Add link to RPC docs in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Elements deferred for additional research and standardization:
  * [Schnorr Signatures][schnorr-signatures]
 
 Additional RPC commands and parameters:
-* [RPC Docs](https://github.com/ElementsProject/elementsbp-api-reference/blob/master/api.md)
+* [RPC Docs](https://elementsproject.org/en/doc/)
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Previous elements that have been integrated into Bitcoin:
 Elements deferred for additional research and standardization:
  * [Schnorr Signatures][schnorr-signatures]
 
+Additional RPC commands and parameters:
+* [RPC Docs](https://github.com/ElementsProject/elementsbp-api-reference/blob/master/api.md)
+
 License
 -------
 Elements is released under the terms of the MIT license. See [COPYING](COPYING) for more


### PR DESCRIPTION
The RPC docs are a great way to understand the difference between Bitcoin and Elements. 

It should be highlighted along with the other differences from Bitcoin Core in the same section.

Alternatively, add them to Elements/Doc
