### PR TITLE
Fix claimpegin and createrawpegin support for multiwallet.

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -5554,6 +5554,12 @@ extern UniValue sendrawtransaction(const JSONRPCRequest& request);
 template<typename T_tx_ref, typename T_tx, typename T_merkle_block>
 static UniValue createrawpegin(const JSONRPCRequest& request, T_tx_ref& txBTCRef, T_tx& tx_aux, T_merkle_block& merkleBlock)
 {
+    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
+    CWallet* const pwallet = wallet.get();
+
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
+        return NullUniValue;
+
     if (request.fHelp || request.params.size() < 2 || request.params.size() > 3)
         throw std::runtime_error(
             RPCHelpMan{"createrawpegin",
@@ -5576,9 +5582,6 @@ static UniValue createrawpegin(const JSONRPCRequest& request, T_tx_ref& txBTCRef
             + HelpExampleRpc("createrawpegin", "\"0200000002b80a99d63ca943d72141750d983a3eeda3a5c5a92aa962884ffb141eb49ffb4f000000006a473044022031ffe1d76decdfbbdb7e2ee6010e865a5134137c261e1921da0348b95a207f9e02203596b065c197e31bcc2f80575154774ac4e80acd7d812c91d93c4ca6a3636f27012102d2130dfbbae9bd27eee126182a39878ac4e117d0850f04db0326981f43447f9efeffffffb80a99d63ca943d72141750d983a3eeda3a5c5a92aa962884ffb141eb49ffb4f010000006b483045022100cf041ce0eb249ae5a6bc33c71c156549c7e5ad877ae39e2e3b9c8f1d81ed35060220472d4e4bcc3b7c8d1b34e467f46d80480959183d743dad73b1ed0e93ec9fd14f012103e73e8b55478ab9c5de22e2a9e73c3e6aca2c2e93cd2bad5dc4436a9a455a5c44feffffff0200e1f5050000000017a914da1745e9b549bd0bfa1a569971c77eba30cd5a4b87e86cbe00000000001976a914a25fe72e7139fd3f61936b228d657b2548b3936a88acc0020000\", \"00000020976e918ed537b0f99028648f2a25c0bd4513644fb84d9cbe1108b4df6b8edf6ba715c424110f0934265bf8c5763d9cc9f1675a0f728b35b9bc5875f6806be3d19cd5b159ffff7f2000000000020000000224eab3da09d99407cb79f0089e3257414c4121cb85a320e1fd0f88678b6b798e0713a8d66544b6f631f9b6d281c71633fb91a67619b189a06bab09794d5554a60105\", \"0014058c769ffc7d12c35cddec87384506f536383f9c\"")
                 },
             }.ToString());
-
-    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
-    CWallet* const pwallet = wallet.get();
 
     auto locked_chain = pwallet->chain().lock();
     LOCK(pwallet->cs_wallet);
@@ -5695,6 +5698,11 @@ UniValue createrawpegin(const JSONRPCRequest& request)
 
 UniValue claimpegin(const JSONRPCRequest& request)
 {
+    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
+    CWallet* const pwallet = wallet.get();
+
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
+        return NullUniValue;
 
     if (request.fHelp || request.params.size() < 2 || request.params.size() > 3)
         throw std::runtime_error(
@@ -5716,8 +5724,6 @@ UniValue claimpegin(const JSONRPCRequest& request)
                 },
             }.ToString());
 
-    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
-    CWallet* const pwallet = wallet.get();
     CTransactionRef tx_ref;
     CMutableTransaction mtx;
 
@@ -5728,8 +5734,17 @@ UniValue claimpegin(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_WALLET_ERROR, "Peg-ins cannot be completed during initial sync or reindexing.");
     }
 
+    // NOTE: Making an RPC from within another RPC is not generally a good idea. In particular, it
+    //   is necessary to copy the URI, which contains the wallet if one was given; otherwise
+    //   multi-wallet support will silently break. The resulting request object is still missing a
+    //   bunch of other fields, although they are usually not used by RPC handlers. This is a
+    //   brittle hack, and further examples of this pattern should not be introduced.
+
     // Get raw peg-in transaction
-    UniValue ret(createrawpegin(request));
+    JSONRPCRequest req;
+    req.URI = request.URI;
+    req.params = request.params;
+    UniValue ret(createrawpegin(req));  // See the note above, on why this is a bad idea.
 
     // Make sure it can be propagated and confirmed
     if (!ret["mature"].isNull() && ret["mature"].get_bool() == false) {
@@ -5737,11 +5752,12 @@ UniValue claimpegin(const JSONRPCRequest& request)
     }
 
     // Sign it
-    JSONRPCRequest request2;
+    JSONRPCRequest req2;
+    req2.URI = request.URI;
     UniValue varr(UniValue::VARR);
     varr.push_back(ret["hex"]);
-    request2.params = varr;
-    UniValue result = signrawtransactionwithwallet(request2);
+    req2.params = varr;
+    UniValue result = signrawtransactionwithwallet(req2);  // See the note above, on why this is a bad idea.
 
     if (!DecodeHexTx(mtx, result["hex"].get_str(), false, true)) {
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");

--- a/test/functional/feature_fedpeg.py
+++ b/test/functional/feature_fedpeg.py
@@ -229,6 +229,14 @@ class FedPegTest(BitcoinTestFramework):
 
         raw = parent.gettransaction(txid1)["hex"]
 
+        # Create a wallet in order to test that multi-wallet support works correctly for claimpegin
+        #   (Regression test for https://github.com/ElementsProject/elements/issues/812 .)
+        sidechain.createwallet("throwaway")
+        # Set up our sidechain RPCs to use the first wallet (with empty name). We do this by
+        #   overriding the RPC object in a hacky way, to avoid breaking a different hack on TestNode
+        #   that enables generate() to work despite the deprecation of the generate RPC.
+        sidechain.rpc = sidechain.get_wallet_rpc("")
+
         print("Attempting peg-ins")
         # First attempt fails the consensus check but gives useful result
         try:


### PR DESCRIPTION
Fixes #812. @stevenroose, take a look when you get back?

Fix multiple issues with claimpegin and createrawpegin support for
multiple loaded wallets:

- Failure to call EnsureWalletIsAvailable would cause a crash when multiple
  wallets were loaded, but one was not specified in the RPC call.
- Failure to propagate the request URL from claimpegin when making an
  internal call to another RPC would result in failure when multiple
  wallets were loaded, by failing to specify one for that call.

Add a regression test to the feature_fedpeg.py test: at a critical point,
create a second wallet on the sidechaind, and set up the RPC client to
use the first one, to check that it still works correctly.
