### PR TITLE
Update build docs for FreeBSD 12.1-RELEASE

### DIFF
--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -41,6 +41,7 @@ export BDB_PREFIX="$PWD/db4"
 With wallet:
 ```shell
 ./autogen.sh
+MAKE=gmake CC=cc CXX=c++ CPPFLAGS=-I/usr/local/include \
 ./configure --with-gui=no \
     BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
     BDB_CFLAGS="-I${BDB_PREFIX}/include"
@@ -49,6 +50,7 @@ With wallet:
 Without wallet:
 ```shell
 ./autogen.sh
+MAKE=gmake CC=cc CXX=c++ CPPFLAGS=-I/usr/local/include \
 ./configure --with-gui=no --disable-wallet
 ```
 


### PR DESCRIPTION
Fixes #814 by setting basic build configuration:

* Use gmake instead of make
* Use clang instead of gcc
* Add /usr/local to include path