### PR TITLE
WIP: Streaming SHA256 ops.

### DIFF
--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -716,6 +716,60 @@ void CSHA256::Midstate(unsigned char hash[OUTPUT_SIZE], uint64_t* len, unsigned 
     }
 }
 
+std::vector<unsigned char> CSHA256::Save() const {
+    size_t buf_size = bytes % 64;
+    std::vector<unsigned char> result(40 + buf_size);
+
+    WriteBE32(&result[ 0], s[0]);
+    WriteBE32(&result[ 4], s[1]);
+    WriteBE32(&result[ 8], s[2]);
+    WriteBE32(&result[12], s[3]);
+    WriteBE32(&result[16], s[4]);
+    WriteBE32(&result[20], s[5]);
+    WriteBE32(&result[24], s[6]);
+    WriteBE32(&result[28], s[7]);
+
+    WriteLE64(&result[32], bytes << 3);
+
+    memcpy(&result[40], buf, buf_size);
+
+    return result;
+}
+
+bool CSHA256::Load(const std::vector<unsigned char>& vch) {
+    if (vch.size() < 40) return false;
+
+    uint64_t bits = ReadLE64(&vch[32]);
+    size_t buf_size = (bits >> 3) % 64;
+
+    if ((bits & 0x07) != 0 || vch.size() != 40 + buf_size) return false;
+
+    // We want to leave the internal state of the object unchanged if false is returned.
+    // So no member variables can be modified until now.
+
+    s[0] = ReadBE32(&vch[ 0]);
+    s[1] = ReadBE32(&vch[ 4]);
+    s[2] = ReadBE32(&vch[ 8]);
+    s[3] = ReadBE32(&vch[12]);
+    s[4] = ReadBE32(&vch[16]);
+    s[5] = ReadBE32(&vch[20]);
+    s[6] = ReadBE32(&vch[24]);
+    s[7] = ReadBE32(&vch[28]);
+
+    bytes = bits >> 3;
+
+    memcpy(buf, &vch[40], buf_size);
+
+    return true;
+}
+
+bool CSHA256::SafeWrite(const unsigned char* data, size_t len) {
+  const uint64_t SHA256_MAX = 0x1FFFFFFFFFFFFFFF; // SHA256's maximum allowed message length in bytes.
+  if (SHA256_MAX < bytes || SHA256_MAX - bytes < len) return false;
+  Write(data, len);
+  return true;
+}
+
 CSHA256& CSHA256::Reset()
 {
     bytes = 0;

--- a/src/crypto/sha256.h
+++ b/src/crypto/sha256.h
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string>
+#include <vector>
 
 /** A hasher class for SHA-256. */
 class CSHA256
@@ -26,7 +27,10 @@ public:
     //TODO: Midstate is a hack'ish speedup that probably should make way for something
     //akin to the SHA256D64 speedups
     void Midstate(unsigned char hash[OUTPUT_SIZE], uint64_t* len, unsigned char *buffer);
+    std::vector<unsigned char> Save() const;
+    bool Load(const std::vector<unsigned char>& vch);
     CSHA256& Reset();
+    bool SafeWrite(const unsigned char* data, size_t len);
 };
 
 /** Autodetect the best available SHA256 implementation.

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -130,6 +130,9 @@ const char* GetOpName(opcodetype opcode)
     case OP_DETERMINISTICRANDOM    : return "OP_DETERMINISTICRANDOM";
     case OP_CHECKSIGFROMSTACK      : return "OP_CHECKSIGFROMSTACK";
     case OP_CHECKSIGFROMSTACKVERIFY: return "OP_CHECKSIGFROMSTACKVERIFY";
+    case OP_SHA256INITIALIZE       : return "OP_SHA256INITIALIZE";
+    case OP_SHA256UPDATE           : return "OP_SHA256UPDATE";
+    case OP_SHA256FINALIZE         : return "OP_SHA256FINALIZE";
 
     // expansion
     case OP_NOP1                   : return "OP_NOP1";

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -184,6 +184,9 @@ enum opcodetype
     OP_DETERMINISTICRANDOM = 0xc0,
     OP_CHECKSIGFROMSTACK = 0xc1,
     OP_CHECKSIGFROMSTACKVERIFY = 0xc2,
+    OP_SHA256INITIALIZE = 0xc4,
+    OP_SHA256UPDATE = 0xc5,
+    OP_SHA256FINALIZE = 0xc6,
 
     // expansion
     OP_NOP1 = 0xb0,
@@ -203,7 +206,7 @@ enum opcodetype
 };
 
 // Maximum value that an opcode can be
-static const unsigned int MAX_OPCODE = OP_SUBSTR_LAZY; // 0xc3
+static const unsigned int MAX_OPCODE = OP_SHA256FINALIZE; // 0xc6
 
 const char* GetOpName(opcodetype opcode);
 


### PR DESCRIPTION
My proposal is

* `OP_SHA256INITIALIZE` to pop a bytestring and push SHA256 context creating by adding the bytestring to the initial SHA256 context.
* `OP_SHA256UPDATE` to pop a SHA256 context and bytestring, and push an updated context by adding the bytestring to the data stream being hashed.
* `OP_SHA256FINALIZE` to pop a SHA256 context  and bytestring, and push a SHA256 hash value after adding the bytestring and completing the padding.

I propose defining the SHA256-context as a bytestring that is a 40 to 103 bytes in length where
* The first 32-bytes is the SHA256 midstate
* The next 8-bytes is the (little-endian) unsigned integer value containing the number of **bits** of data processed so far.  This value will always be a multiple of 8.
* The next 0 to 63 bytes is the store of data processed but not compressed.  The length of this "field" is `X/8 % 64` (equiv. `(X % 512) / 8`) where `X` is the integer value of the previous field.

Any invalid SHA256-context will cause the operations that process the context to fail.
If any input would cause the SHA256 bit counter to overflow, the operation will fail.

I could easily be convinced to use bytes instead of bits in the second field.  Bits is nicely aligned with how SHA-256 works, and the size is perfectly aligned.  OTOH Bytes is what the SHA256 internal state uses in practice and would be marginally faster to processes.

**Motivation**:  There already exists a `OP_SH256` opcode that performs computes SHA256 computations.  However because the `MAX_SCRIPT_ELEMENT_SIZE` is 520 bytes, that is the maximum message size that can `OP_SHA256` can operate on.  These proposed operations allow us to circumvent the `MAX_SCRIPT_ELEMENT_SIZE` limit on message size; however these opcode might be subject to abuse (e.g. [SHA-256 with freestart](https://crypto.stackexchange.com/questions/48580/fixed-point-of-the-sha-256-compression-function)).