### PR TITLE
WIP: Support _sat for satoshi level denominations

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -134,9 +134,19 @@ CAmount AmountFromValue(const UniValue& value)
 {
     if (!value.isNum() && !value.isStr())
         throw JSONRPCError(RPC_TYPE_ERROR, "Amount is not a number or string");
+    std::string val_string = value.getValStr();
+
+    // Look for _sat denomination
+    int sat_pos = val_string.find("_sat");
+    if (val_string.size() >= 4 && ((unsigned int)sat_pos == val_string.size() - 4)) {
+        val_string = val_string.substr(0, sat_pos);
+    }
     CAmount amount;
-    if (!ParseFixedPoint(value.getValStr(), 8, &amount))
+    if (!ParseFixedPoint(val_string, 8, &amount))
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
+    if (sat_pos != std::string::npos) {
+        amount /= COIN;
+    }
     if (!MoneyRange(amount))
         throw JSONRPCError(RPC_TYPE_ERROR, "Amount out of range");
     return amount;

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -213,6 +213,17 @@ BOOST_AUTO_TEST_CASE(rpc_parse_monetary_values)
     BOOST_CHECK_THROW(AmountFromValue(ValueFromString("1e+11")), UniValue); //overflow error
     BOOST_CHECK_THROW(AmountFromValue(ValueFromString("1e11")), UniValue); //overflow error signless
     BOOST_CHECK_THROW(AmountFromValue(ValueFromString("93e+9")), UniValue); //overflow error
+
+    // _sat values
+    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0_sat")), 0LL);
+    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("1_sat")), 1LL);
+    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("10_sat")), 10LL);
+    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("100_sat")), 100LL);
+    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("123_sat")), 123LL);
+
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("123_sat_1")), UniValue);
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("2100000000000001_sat")), UniValue);
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("123_sat_sat")), UniValue);
 }
 
 BOOST_AUTO_TEST_CASE(json_parse_errors)


### PR DESCRIPTION
I can write tests and whatever, but this theoretically should allow RPCs to accept `<value>_sat` values.

Opening for comment/concept ACK.