### PR TITLE
Reduce mintxfee to 0.1 sat/vbyte and fallback fee to 2 sat/vb

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -74,11 +74,11 @@ static const unsigned int DEFAULT_KEYPOOL_SIZE = 1000;
 //! -paytxfee default
 constexpr CAmount DEFAULT_PAY_TX_FEE = 0;
 //! -fallbackfee default
-static const CAmount DEFAULT_FALLBACK_FEE = 20000;
+static const CAmount DEFAULT_FALLBACK_FEE = 2000;
 //! -discardfee default
 static const CAmount DEFAULT_DISCARD_FEE = 10000;
 //! -mintxfee default
-static const CAmount DEFAULT_TRANSACTION_MINFEE = 1000;
+static const CAmount DEFAULT_TRANSACTION_MINFEE = 100;
 //! minimum recommended increment for BIP 125 replacement txs
 static const CAmount WALLET_INCREMENTAL_RELAY_FEE = 5000;
 //! Default for -spendzeroconfchange

--- a/test/functional/feature_issuance.py
+++ b/test/functional/feature_issuance.py
@@ -16,7 +16,7 @@ def process_raw_issuance(node, issuance_list):
         raise Exception('Issuance list too long')
     # Make enough outputs for any subsequent spend
     next_destinations = {}
-    output_values = (node.getbalance()['bitcoin']-1)/5
+    output_values = Decimal('%.8f' % ((node.getbalance()['bitcoin']-1)/5))
     for i in range(5):
         next_destinations[node.getnewaddress()] = output_values
 
@@ -382,7 +382,7 @@ class IssuanceTest(BitcoinTestFramework):
                 assert_equal(blinded_multisig, self.nodes[0].getaddressinfo(utxo_info["address"])["confidential"])
                 break
         assert(utxo_info is not None)
-        assert(utxo_info["amountblinder"] is not "0000000000000000000000000000000000000000000000000000000000000000")
+        assert(utxo_info["amountblinder"] != "0000000000000000000000000000000000000000000000000000000000000000")
 
         # Now make transaction spending that input
         raw_tx = self.nodes[0].createrawtransaction([], {issued_address:1}, 0, False, {issued_address:issued_asset["token"]})


### PR DESCRIPTION
This follows the reduction of the `minrelaytxfee` in the previous release to the same value. Using this value, the wallet will be able to make transactions with a 0.1 sat/vbyte fee by default.