### PR TITLE
Index the genesis block with txindex

### DIFF
--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -246,7 +246,8 @@ bool TxIndex::Init()
 bool TxIndex::WriteBlock(const CBlock& block, const CBlockIndex* pindex)
 {
     // Exclude genesis block transaction because outputs are not spendable.
-    if (pindex->nHeight == 0) return true;
+    //ELEMENTS: we do index the genesis block
+    //if (pindex->nHeight == 0) return true;
 
     CDiskTxPos pos(pindex->GetBlockPos(), GetSizeOfCompactSize(block.vtx.size()));
     std::vector<std::pair<uint256, CDiskTxPos>> vPos;

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -40,9 +40,10 @@ BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
     }
 
     // Check that txindex excludes genesis block transactions.
+    //ELEMENTS: we do include them
     const CBlock& genesis_block = Params().GenesisBlock();
     for (const auto& txn : genesis_block.vtx) {
-        BOOST_CHECK(!txindex.FindTx(txn->GetHash(), block_hash, tx_disk));
+        BOOST_CHECK(txindex.FindTx(txn->GetHash(), block_hash, tx_disk));
     }
 
     // Check that txindex has all txs that were in the chain before it started.


### PR DESCRIPTION
This reverts commit ed12d5df1ba52b5ef3dd3799de26bb5e1d3fc654 in which Core removed the genesis txs from the txindex.

Since they are spendable in Elements (as opposed to Core), they should be added to the index as well.