### PR TITLE
Update macOS build instructions to support building dmg

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -20,9 +20,9 @@ Dependencies
 
 See [dependencies.md](dependencies.md) for a complete overview.
 
-If you want to build the disk image with `make deploy` (.dmg / optional), you need RSVG:
+If you want to build the disk image with `make deploy` (.dmg / optional), you need image manipulation tools:
 
-    brew install librsvg
+    brew install librsvg libicns imagemagick
 
 Berkeley DB
 -----------


### PR DESCRIPTION
on macOS 10.14.6 (Mojave) at least the following tools are required from homebrew:


- libicns provides png2icon
- imagemagick provides convert