### PR TITLE
[RFC] Remove GetNumIssuance from BlindTransaction assert

### DIFF
--- a/src/blind.cpp
+++ b/src/blind.cpp
@@ -226,8 +226,8 @@ int BlindTransaction(std::vector<uint256 >& input_value_blinding_factors, const 
 {
     // Sanity check input data and output_pubkey size, clear other output data
     assert(tx.vout.size() >= output_pubkeys.size());
-    assert(tx.vin.size()+GetNumIssuances(CTransaction(tx)) >= issuance_blinding_privkey.size());
-    assert(tx.vin.size()+GetNumIssuances(CTransaction(tx)) >= token_blinding_privkey.size());
+    assert(tx.vin.size() >= issuance_blinding_privkey.size());
+    assert(tx.vin.size() >= token_blinding_privkey.size());
     out_val_blind_factors.clear();
     out_val_blind_factors.resize(tx.vout.size());
     out_asset_blind_factors.clear();

--- a/src/blind.cpp
+++ b/src/blind.cpp
@@ -206,22 +206,6 @@ void CreateValueCommitment(CConfidentialValue& conf_value, secp256k1_pedersen_co
     assert(conf_value.IsValid());
 }
 
-size_t GetNumIssuances(const CTransaction& tx)
-{
-    unsigned int num_issuances = 0;
-    for (unsigned int i = 0; i < tx.vin.size(); i++) {
-        if (!tx.vin[i].assetIssuance.IsNull()) {
-            if (!tx.vin[i].assetIssuance.nAmount.IsNull()) {
-                num_issuances++;
-            }
-            if (!tx.vin[i].assetIssuance.nInflationKeys.IsNull()) {
-                num_issuances++;
-            }
-        }
-    }
-    return num_issuances;
-}
-
 int BlindTransaction(std::vector<uint256 >& input_value_blinding_factors, const std::vector<uint256 >& input_asset_blinding_factors, const std::vector<CAsset >& input_assets, const std::vector<CAmount >& input_amounts, std::vector<uint256 >& out_val_blind_factors, std::vector<uint256 >& out_asset_blind_factors, const std::vector<CPubKey>& output_pubkeys, const std::vector<CKey>& issuance_blinding_privkey, const std::vector<CKey>& token_blinding_privkey, CMutableTransaction& tx, std::vector<std::vector<unsigned char> >* auxiliary_generators)
 {
     // Sanity check input data and output_pubkey size, clear other output data

--- a/src/blind.h
+++ b/src/blind.h
@@ -61,6 +61,4 @@ int BlindTransaction(std::vector<uint256 >& input_value_blinding_factors, const 
  */
 void RawFillBlinds(CMutableTransaction& tx, std::vector<uint256>& output_value_blinds, std::vector<uint256>& output_asset_blinds, std::vector<CPubKey>& output_pubkeys);
 
-size_t GetNumIssuances(const CTransaction& tx);
-
 #endif //BITCOIN_BLIND_H

--- a/src/issuance.cpp
+++ b/src/issuance.cpp
@@ -4,6 +4,22 @@
 #include <primitives/transaction.h>
 #include <amount.h>
 
+size_t GetNumIssuances(const CTransaction& tx)
+{
+    unsigned int num_issuances = 0;
+    for (unsigned int i = 0; i < tx.vin.size(); i++) {
+        if (!tx.vin[i].assetIssuance.IsNull()) {
+            if (!tx.vin[i].assetIssuance.nAmount.IsNull()) {
+                num_issuances++;
+            }
+            if (!tx.vin[i].assetIssuance.nInflationKeys.IsNull()) {
+                num_issuances++;
+            }
+        }
+    }
+    return num_issuances;
+}
+
 void GenerateAssetEntropy(uint256& entropy, const COutPoint& prevout, const uint256& contracthash)
 {
     // E : entropy

--- a/src/issuance.h
+++ b/src/issuance.h
@@ -8,6 +8,11 @@
 #include <consensus/merkle.h>
 
 /**
+ * Get the number of issuances in the given transaction.
+ */
+size_t GetNumIssuances(const CTransaction& tx);
+
+/**
  * Calculate the asset entropy from an COutPoint and a tx-author specified
  * Ricardian contract. See Definition 18 of the confidential assets paper.
  *


### PR DESCRIPTION
This is in response to @dgpv 's https://github.com/ElementsProject/elements/issues/842.

I'm not 100% confident this is correct, but it seems so. It also passed all tests on my machine.