### PR TITLE
Remove another mention of Liquid-Qt

### DIFF
--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -49,15 +49,10 @@ static const int MAX_URI_LENGTH = 255;
 #define QAPP_ORG_NAME "Bitcoin"
 #define QAPP_ORG_DOMAIN "bitcoin.org"
 
-#if LIQUID
-#define QAPP_APP_NAME_DEFAULT "Liquid-Qt"
-#define QAPP_APP_NAME_TESTNET "Liquid-Qt-testnet"
-#define QAPP_APP_NAME_REGTEST "Liquid-Qt-regtest"
-#else
 #define QAPP_APP_NAME_DEFAULT "Elements-Qt"
 #define QAPP_APP_NAME_TESTNET "Elements-Qt-testnet"
 #define QAPP_APP_NAME_REGTEST "Elements-Qt-regtest"
-#endif
+#define QAPP_APP_NAME_LIQUID "Elements-Qt (Liquid)"
 
 /* One gigabyte (GB) in bytes */
 static constexpr uint64_t GB_BYTES{1000000000};

--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -19,7 +19,7 @@ static const struct {
 } network_styles[] = {
     {"main", QAPP_APP_NAME_DEFAULT, 0, 0},
     {"test", QAPP_APP_NAME_TESTNET, 70, 30},
-    {"liquidv1", "Liquid-Qt-liquidv1", 0, 0},
+    {"liquidv1", QAPP_APP_NAME_LIQUID, 0, 0},
     {"regtest", QAPP_APP_NAME_REGTEST, 160, 30}
 };
 static const unsigned network_styles_count = sizeof(network_styles)/sizeof(*network_styles);


### PR DESCRIPTION
This should be the last mention of `#if LIQUID` and `Liquid-Qt` that my grep can find.