### PR TITLE
Fix HasValidFee potential overflow

### DIFF
--- a/src/confidential_validation.cpp
+++ b/src/confidential_validation.cpp
@@ -33,9 +33,12 @@ bool HasValidFee(const CTransaction& tx) {
             if (fee == 0 || !MoneyRange(fee))
                 return false;
             totalFee[tx.vout[i].nAsset.GetAsset()] += fee;
+            if (!MoneyRange(totalFee)) {
+                return false;
+            }
         }
     }
-    return MoneyRange(totalFee);
+    return true;
 }
 
 CAmountMap GetFeeMap(const CTransaction& tx) {

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -306,6 +306,9 @@ bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoins
             return state.DoS(100, false, REJECT_INVALID, "bad-txns-in-ne-out", false, "value in != value out");
         }
         fee_map += GetFeeMap(tx);
+        if (!MoneyRange(fee_map)) {
+            return state.DoS(100, false, REJECT_INVALID, "bad-block-total-fee-outofrange");
+        }
     } else {
         const CAmount value_out = tx.GetValueOutMap()[CAsset()];
         if (nValueIn < value_out) {


### PR DESCRIPTION
Dmitry pointed out this potential overflow. They can't really happen
because of the `CheckTransaction` check on explicit amounts that
happens earlier in the verification chain. But it's a good idea to
add the check here as well so that a potential relaxing of other rules
cannot accidentally introduce an overflow risk.