### PR TITLE
Added force application activation on macosx with qt 5.5.1

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -59,9 +59,10 @@
 #if defined(Q_OS_MAC)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#include <QProcess>
 
-#include <objc/objc-runtime.h>
-#include <CoreServices/CoreServices.h>
+void ForceActivation();
+
 #endif
 
 namespace GUIUtil {
@@ -359,10 +360,7 @@ bool isObscured(QWidget *w)
 void bringToFront(QWidget* w)
 {
 #ifdef Q_OS_MAC
-    // Force application activation on macOS. With Qt 5.4 this is required when
-    // an action in the dock menu is triggered.
-    id app = objc_msgSend((id) objc_getClass("NSApplication"), sel_registerName("sharedApplication"));
-    objc_msgSend(app, sel_registerName("activateIgnoringOtherApps:"), YES);
+    ForceActivation();
 #endif
 
     if (w) {

--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -5,8 +5,8 @@
 #include "macdockiconhandler.h"
 
 #undef slots
-#include <objc/objc.h>
-#include <objc/message.h>
+#include <AppKit/AppKit.h>
+#include <objc/runtime.h>
 
 static MacDockIconHandler *s_instance = nullptr;
 
@@ -21,9 +21,7 @@ bool dockClickHandler(id self, SEL _cmd, ...) {
 }
 
 void setupDockClickHandler() {
-    id app = objc_msgSend((id)objc_getClass("NSApplication"), sel_registerName("sharedApplication"));
-    id delegate = objc_msgSend(app, sel_registerName("delegate"));
-    Class delClass = (Class)objc_msgSend(delegate, sel_registerName("class"));
+    Class delClass = (Class)[[[NSApplication sharedApplication] delegate] class];
     SEL shouldHandle = sel_registerName("applicationShouldHandleReopen:hasVisibleWindows:");
     class_replaceMethod(delClass, shouldHandle, (IMP)dockClickHandler, "B@:");
 }
@@ -43,4 +41,14 @@ MacDockIconHandler *MacDockIconHandler::instance()
 void MacDockIconHandler::cleanup()
 {
     delete s_instance;
+}
+
+/**
+ * Force application activation on macOS. With Qt 5.5.1 this is required when
+ * an action in the Dock menu is triggered.
+ * TODO: Define a Qt version where it's no-longer necessary.
+ */
+void ForceActivation()
+{
+    [[NSApplication sharedApplication] activateIgnoringOtherApps:YES];
 }


### PR DESCRIPTION
I was getting the following errors when trying to build using MacOSX Catalina 10.15.4:

CXX      qt/libbitcoinqt_a-guiutil.o
qt/guiutil.cpp:364:14: error: no matching function for call to 'objc_msgSend'
    id app = objc_msgSend((id) objc_getClass("NSApplication"), sel_registerName("sharedApplication"));
             ^~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/objc/message.h:63:1: note:
      candidate function not viable: requires 0 arguments, but 2 were provided
objc_msgSend(void /* id self, SEL op, ... */ )
^
qt/guiutil.cpp:365:5: error: no matching function for call to 'objc_msgSend'
    objc_msgSend(app, sel_registerName("activateIgnoringOtherApps:"), YES);
    ^~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/objc/message.h:63:1: note:
      candidate function not viable: requires 0 arguments, but 3 were provided
objc_msgSend(void /* id self, SEL op, ... */ )
^
2 errors generated.

Basically i was able to build getting the changes from the latest bitcoin core source code.

Please let me know if there is anything else i need/should do ?

