### PR TITLE
build: Fix search for brew-installed BDB 4 on OS X (backport of upstream fix)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -563,9 +563,10 @@ case $host in
            PKG_CONFIG_PATH="$openssl_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
            export PKG_CONFIG_PATH
          fi
-         if test x$bdb_prefix != x; then
-           CPPFLAGS="$CPPFLAGS -I$bdb_prefix/include"
-           LIBS="$LIBS -L$bdb_prefix/lib"
+         if test x$bdb_prefix != x && test "x$BDB_CFLAGS" = "x" && test "x$BDB_LIBS" = "x"; then
+           dnl This must precede the call to BITCOIN_FIND_BDB48 below.
+           BDB_CFLAGS="-I$bdb_prefix/include"
+           BDB_LIBS="-L$bdb_prefix/lib -ldb_cxx-4.8"
          fi
          if test x$qt5_prefix != x; then
            PKG_CONFIG_PATH="$qt5_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"


### PR DESCRIPTION
Backport of my upstream fix https://github.com/bitcoin/bitcoin/pull/19356 .

Net effect is to change the include order slightly for macOS homebrew users with BDB 4.8 installed privately (not linked into system directories) -- our configure scripts will prefer BDB 4.8 if they find it there, even if it is not system default. This fixes a build break that would occur in this situation when some _other_ BDB _is_ installed in system directories. The previous search order would use headers from system directories, but libs from 4.8, causing a crash.

----
On OS X, when searching Homebrew keg-only packages for BDB 4.8, if we find it,
use BDB_CPPFLAGS and BDB_LIBS instead of CFLAGS and LIBS for the result. This
is (1) more correct, and (2) necessary in order to give this location
priority over other directories in the include search path, which may include
system include directories with other versions of BDB.