### PR TITLE
Improve logging of failures during block signature validation

### DIFF
--- a/src/block_proof.h
+++ b/src/block_proof.h
@@ -14,11 +14,12 @@ class CBlockHeader;
 class CBlockIndex;
 class CProof;
 class CScript;
+class CValidationState;
 
 // Elements signed chain functionality
 
 /** Check on header proof, depending on chain type, PoW or signed **/
-bool CheckProof(const CBlockHeader& block, const Consensus::Params&);
+bool CheckProof(const CBlockHeader& block, CValidationState& state, const Consensus::Params&);
 bool CheckProofSignedParent(const CBlockHeader& block, const Consensus::Params&);
 bool CheckChallenge(const CBlockHeader& block, const CBlockIndex& indexLast, const Consensus::Params&);
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1189,7 +1189,8 @@ UniValue combineblocksigs(const JSONRPCRequest& request)
     ssBlock << block;
     UniValue result(UniValue::VOBJ);
     result.pushKV("hex", HexStr(ssBlock.begin(), ssBlock.end()));
-    result.pushKV("complete", CheckProof(block, params));
+    CValidationState state;  // ignored
+    result.pushKV("complete", CheckProof(block, state, params));
     return result;
 }
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -6,6 +6,7 @@
 #include <txdb.h>
 
 #include <chainparams.h>
+#include <consensus/validation.h>
 #include <hash.h>
 #include <random.h>
 #include <pow.h>
@@ -13,6 +14,7 @@
 #include <uint256.h>
 #include <util/system.h>
 #include <ui_interface.h>
+#include <validation.h>
 
 #include <stdint.h>
 
@@ -323,10 +325,11 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
 
                 const uint256 block_hash = pindexNew->GetBlockHash();
                 // Only validate one of every 1000 block header for sanity check
+                CValidationState state;
                 if (pindexNew->nHeight % 1000 == 0 &&
                         block_hash != consensusParams.hashGenesisBlock &&
-                        !CheckProof(pindexNew->GetBlockHeader(), consensusParams)) {
-                    return error("%s: CheckProof: %s, %s", __func__, block_hash.ToString(), pindexNew->ToString());
+                        !CheckProof(pindexNew->GetBlockHeader(), state, consensusParams)) {
+                    return error("%s: CheckProof: (%s, %s): %s", __func__, block_hash.ToString(), pindexNew->ToString(), FormatStateMessage(state));
                 }
                 pcursor->Next();
             } else {


### PR DESCRIPTION
Pass in a ValidationState object to CheckProof and friends, so that we can
provide helpful error messages when validation fails.

@stevenroose This came out of the time I spent figuring out the problem we were seeing with Elements and Liquid regtest syncing.