### PR TITLE
Make 'librsvg2-2_2.40.13-3_amd64.deb' a required input to gitian build scripts

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -37,7 +37,8 @@ packages:
 remotes:
 - "url": "https://github.com/ElementsProject/elements.git"
   "dir": "elements"
-files: []
+files:
+- "librsvg2-2_2.40.13-3_amd64.deb"
 script: |
 
   WRAP_DIR=$HOME/wrapped

--- a/contrib/gitian-descriptors/gitian-liquid-linux.yml
+++ b/contrib/gitian-descriptors/gitian-liquid-linux.yml
@@ -37,7 +37,8 @@ packages:
 remotes:
 - "url": "https://github.com/ElementsProject/elements.git"
   "dir": "elements"
-files: []
+files:
+- "librsvg2-2_2.40.13-3_amd64.deb"
 script: |
 
   WRAP_DIR=$HOME/wrapped

--- a/contrib/gitian-descriptors/gitian-liquid-osx.yml
+++ b/contrib/gitian-descriptors/gitian-liquid-osx.yml
@@ -33,6 +33,7 @@ remotes:
   "dir": "elements"
 files:
 - "MacOSX10.11.sdk.tar.gz"
+- "librsvg2-2_2.40.13-3_amd64.deb"
 script: |
   WRAP_DIR=$HOME/wrapped
   HOSTS="x86_64-apple-darwin14"

--- a/contrib/gitian-descriptors/gitian-liquid-win.yml
+++ b/contrib/gitian-descriptors/gitian-liquid-win.yml
@@ -28,7 +28,8 @@ packages:
 remotes:
 - "url": "https://github.com/ElementsProject/elements.git"
   "dir": "elements"
-files: []
+files:
+- "librsvg2-2_2.40.13-3_amd64.deb"
 script: |
   WRAP_DIR=$HOME/wrapped
   HOSTS="i686-w64-mingw32 x86_64-w64-mingw32"

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -33,6 +33,7 @@ remotes:
   "dir": "elements"
 files:
 - "MacOSX10.11.sdk.tar.gz"
+- "librsvg2-2_2.40.13-3_amd64.deb"
 script: |
   WRAP_DIR=$HOME/wrapped
   HOSTS="x86_64-apple-darwin14"

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -28,7 +28,8 @@ packages:
 remotes:
 - "url": "https://github.com/ElementsProject/elements.git"
   "dir": "elements"
-files: []
+files:
+- "librsvg2-2_2.40.13-3_amd64.deb"
 script: |
   WRAP_DIR=$HOME/wrapped
   HOSTS="i686-w64-mingw32 x86_64-w64-mingw32"


### PR DESCRIPTION
Building elements on gitian requires an internet connection because the file 'librsvg2-2_2.40.13-3_amd64.deb' is fetched from the network.  This can be avoided if the file is listed as one of the required dependencies.  Be sure to put it in the 'inputs' directory prior to executing gbuild.