### PR TITLE
Use gitian infrastructure to install librsvg2-2 (in lieu of hard-coded wget)

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -25,6 +25,7 @@ packages:
 - "git"
 - "icnsutils"
 - "imagemagick"
+- "librsvg2-2"
 - "librsvg2-bin"
 - "pkg-config"
 - "autoconf"
@@ -61,10 +62,6 @@ script: |
     export BASE_CACHE=${GBUILD_PACKAGE_CACHE}
     mkdir -p ${BASE_CACHE} ${SOURCES_PATH}
   fi
-
-  ls librsvg*.deb || wget http://mirrors.kernel.org/ubuntu/pool/main/libr/librsvg/librsvg2-2_2.40.13-3_amd64.deb
-  dpkg -x librsvg*.deb new-rsvg
-  export LD_LIBRARY_PATH="$(echo $PWD/new-rsvg/usr/lib/*/)"
 
   function create_global_faketime_wrappers {
   for prog in ${FAKETIME_PROGS}; do

--- a/contrib/gitian-descriptors/gitian-liquid-linux.yml
+++ b/contrib/gitian-descriptors/gitian-liquid-linux.yml
@@ -25,6 +25,7 @@ packages:
 - "git"
 - "icnsutils"
 - "imagemagick"
+- "librsvg2-2"
 - "librsvg2-bin"
 - "pkg-config"
 - "autoconf"
@@ -61,10 +62,6 @@ script: |
     export BASE_CACHE=${GBUILD_PACKAGE_CACHE}
     mkdir -p ${BASE_CACHE} ${SOURCES_PATH}
   fi
-
-  ls librsvg*.deb || wget http://mirrors.kernel.org/ubuntu/pool/main/libr/librsvg/librsvg2-2_2.40.13-3_amd64.deb
-  dpkg -x librsvg*.deb new-rsvg
-  export LD_LIBRARY_PATH="$(echo $PWD/new-rsvg/usr/lib/*/)"
 
   function create_global_faketime_wrappers {
   for prog in ${FAKETIME_PROGS}; do

--- a/contrib/gitian-descriptors/gitian-liquid-osx.yml
+++ b/contrib/gitian-descriptors/gitian-liquid-osx.yml
@@ -13,6 +13,7 @@ packages:
 - "icnsutils"
 - "pkg-config"
 - "autoconf"
+- "librsvg2-2"
 - "librsvg2-bin"
 - "libtiff-tools"
 - "libtool"
@@ -54,10 +55,6 @@ script: |
   fi
 
   export ZERO_AR_DATE=1
-
-  ls librsvg*.deb || wget http://mirrors.kernel.org/ubuntu/pool/main/libr/librsvg/librsvg2-2_2.40.13-3_amd64.deb
-  dpkg -x librsvg*.deb new-rsvg
-  export LD_LIBRARY_PATH="$(echo $PWD/new-rsvg/usr/lib/*/)"
 
   function create_global_faketime_wrappers {
   for prog in ${FAKETIME_PROGS}; do

--- a/contrib/gitian-descriptors/gitian-liquid-win.yml
+++ b/contrib/gitian-descriptors/gitian-liquid-win.yml
@@ -11,6 +11,7 @@ packages:
 - "git"
 - "icnsutils"
 - "imagemagick"
+- "librsvg2-2"
 - "librsvg2-bin"
 - "pkg-config"
 - "autoconf"
@@ -50,10 +51,6 @@ script: |
     export BASE_CACHE=${GBUILD_PACKAGE_CACHE}
     mkdir -p ${BASE_CACHE} ${SOURCES_PATH}
   fi
-
-  ls librsvg*.deb || wget http://mirrors.kernel.org/ubuntu/pool/main/libr/librsvg/librsvg2-2_2.40.13-3_amd64.deb
-  dpkg -x librsvg*.deb new-rsvg
-  export LD_LIBRARY_PATH="$(echo $PWD/new-rsvg/usr/lib/*/)"
 
   function create_global_faketime_wrappers {
   for prog in ${FAKETIME_PROGS}; do

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -13,6 +13,7 @@ packages:
 - "icnsutils"
 - "pkg-config"
 - "autoconf"
+- "librsvg2-2"
 - "librsvg2-bin"
 - "libtiff-tools"
 - "libtool"
@@ -54,10 +55,6 @@ script: |
   fi
 
   export ZERO_AR_DATE=1
-
-  ls librsvg*.deb || wget http://mirrors.kernel.org/ubuntu/pool/main/libr/librsvg/librsvg2-2_2.40.13-3_amd64.deb
-  dpkg -x librsvg*.deb new-rsvg
-  export LD_LIBRARY_PATH="$(echo $PWD/new-rsvg/usr/lib/*/)"
 
   function create_global_faketime_wrappers {
   for prog in ${FAKETIME_PROGS}; do

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -11,6 +11,7 @@ packages:
 - "git"
 - "icnsutils"
 - "imagemagick"
+- "librsvg2-2"
 - "librsvg2-bin"
 - "pkg-config"
 - "autoconf"
@@ -50,10 +51,6 @@ script: |
     export BASE_CACHE=${GBUILD_PACKAGE_CACHE}
     mkdir -p ${BASE_CACHE} ${SOURCES_PATH}
   fi
-
-  ls librsvg*.deb || wget http://mirrors.kernel.org/ubuntu/pool/main/libr/librsvg/librsvg2-2_2.40.13-3_amd64.deb
-  dpkg -x librsvg*.deb new-rsvg
-  export LD_LIBRARY_PATH="$(echo $PWD/new-rsvg/usr/lib/*/)"
 
   function create_global_faketime_wrappers {
   for prog in ${FAKETIME_PROGS}; do


### PR DESCRIPTION
This removes the hardcoded `wget` of libsrvg2-2 package from the internal gitian `script` and instead uses the `packages` capability (the `wget`-based implementation causes unintended dependencies on internet infrastructure; it is also brittle).

