### PR TITLE
When decoding or signing a PSBT, check blinded values.

### DIFF
--- a/src/blind.h
+++ b/src/blind.h
@@ -23,6 +23,14 @@ static const size_t SURJECTION_PROOF_SIZE = 67;
 static const size_t SIDECHANNEL_MSG_SIZE = 64;
 
 /*
+ * Verify a pair of confidential asset and value, given the blinding factors for both.
+ * Unlike UnblindConfidentialPair, this does _not_ require the recipient's blinding
+ * key, but it _does_ require the blinding factors be provided (rather than extracting
+ * them from the rangeproof.)
+*/
+bool VerifyConfidentialPair(const CConfidentialValue& conf_value, const CConfidentialAsset& conf_asset, const CAmount& claimed_value, const CAsset& claimed_asset, const uint256& value_blinding_factor, const uint256& asset_blinding_factor);
+
+/*
  * Unblind a pair of confidential asset and value.
  * Note that unblinded data will only be outputted if *BOTH* asset and value could be unblinded.
  *

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -74,6 +74,41 @@ static void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& 
     }
 }
 
+void RPCCheckPSBTBlinding(const PartiallySignedTransaction& psbtx) {
+    // Plausibly, we may want a way to let the user continue anyway. However, we
+    //   want to fail by default, to make it as hard as possible to do something
+    //   really dangerous. And since this way of handling blinded PSBTs is going
+    //   away "real soon now" in favor of a better one, no sense in trying too
+    //   hard about it.
+
+    for (size_t i = 0; i < psbtx.outputs.size(); ++i) {
+        const PSBTOutput& output = psbtx.outputs[i];
+        const CTxOut& txo = psbtx.tx->vout[i];
+
+        if (txo.nValue.IsCommitment() || txo.nAsset.IsCommitment()) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "PSBT's 'tx' field may not have pre-blinded outputs.");
+        }
+
+        if (!output.value_commitment.IsCommitment() &&
+            !output.asset_commitment.IsCommitment() &&
+            output.value_blinding_factor.IsNull() &&
+            output.asset_blinding_factor.IsNull()) {
+            // Nothing blinded, nothing to check.
+            continue;
+        } else if (!output.value_commitment.IsCommitment() ||
+            !output.asset_commitment.IsCommitment() ||
+            output.value_blinding_factor.IsNull() ||
+            output.asset_blinding_factor.IsNull()) {
+            // Something blinded, but not everything? That's not expected.
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "PSBT has a partially-blinded output. Blinded outputs must be fully blinded.");
+        }
+
+        if (!VerifyConfidentialPair(output.value_commitment, output.asset_commitment, txo.nValue.GetAmount(), txo.nAsset.GetAsset(), output.value_blinding_factor, output.asset_blinding_factor)) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "PSBT's 'tx' field output values do not match blinded output values (or are invalid in some way)! Either there is a bug, or the blinder is attacking you.");
+        }
+    }
+}
+
 static UniValue getrawtransaction(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 3)
@@ -1722,6 +1757,7 @@ UniValue decodepsbt(const JSONRPCRequest& request)
     if (!DecodeBase64PSBT(psbtx, request.params[0].get_str(), error)) {
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, strprintf("TX decode failed %s", error));
     }
+    RPCCheckPSBTBlinding(psbtx);
 
     UniValue result(UniValue::VOBJ);
 

--- a/src/rpc/rawtransaction.h
+++ b/src/rpc/rawtransaction.h
@@ -13,6 +13,9 @@ namespace interfaces {
 class Chain;
 } // namespace interfaces
 
+/** Check that the blinder did not tamper with the values in a blinded PSBT. */
+void RPCCheckPSBTBlinding(const PartiallySignedTransaction& psbtx);
+
 /** Sign a transaction with the given keystore and previous transactions */
 UniValue SignTransaction(interfaces::Chain& chain, CMutableTransaction& mtx, const UniValue& prevTxs, CBasicKeyStore *keystore, bool tempKeystore, const UniValue& hashType);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4561,6 +4561,7 @@ UniValue walletsignpsbt(const JSONRPCRequest& request)
     if (!DecodeBase64PSBT(psbtx, request.params[0].get_str(), error)) {
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, strprintf("TX decode failed %s", error));
     }
+    RPCCheckPSBTBlinding(psbtx);
 
     // Get the sighash type
     int nHashType = ParseSighashString(request.params[1]);


### PR DESCRIPTION
When we decode or sign a PSBT given to us via RPC, first check that, if it contains blinded output values, they verifiably match the unblinded output values contained in the original transaction proposal. Otherwise fail.