### PR TITLE
Specify BIP9 deployment for DynaFed

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -613,16 +613,16 @@ class CCustomParams : public CRegTestParams {
             consensus.subsidy_asset = CAsset(uint256S(gArgs.GetArg("-subsidyasset", "0x00")));
         }
 
+        consensus.vDeployments[Consensus::DEPLOYMENT_DYNA_FED].bit = 25;
+        consensus.vDeployments[Consensus::DEPLOYMENT_DYNA_FED].nStartTime = args.GetArg("-con_dyna_deploy_start", Consensus::BIP9Deployment::ALWAYS_ACTIVE);
+        consensus.vDeployments[Consensus::DEPLOYMENT_DYNA_FED].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+
         // END ELEMENTS fields
 
         // CSV always active by default, unlike regtest
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = args.GetArg("-con_csv_deploy_start", Consensus::BIP9Deployment::ALWAYS_ACTIVE);
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
-
-        consensus.vDeployments[Consensus::DEPLOYMENT_DYNA_FED].bit = 25;
-        consensus.vDeployments[Consensus::DEPLOYMENT_DYNA_FED].nStartTime = args.GetArg("-con_dyna_deploy_start", Consensus::BIP9Deployment::ALWAYS_ACTIVE);
-        consensus.vDeployments[Consensus::DEPLOYMENT_DYNA_FED].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
 
     }
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -861,9 +861,9 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
 
         // Not active yet.
-        consensus.vDeployments[Consensus::DEPLOYMENT_DYNA_FED].bit = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_DYNA_FED].nStartTime = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_DYNA_FED].nTimeout = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_DYNA_FED].bit = 25;
+        consensus.vDeployments[Consensus::DEPLOYMENT_DYNA_FED].nStartTime = 1000000;
+        consensus.vDeployments[Consensus::DEPLOYMENT_DYNA_FED].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
 
 
         // Finally, create genesis block

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -34,8 +34,10 @@ struct BIP9Deployment {
     /** Bit position to select the particular bit in nVersion. */
     int bit;
     /** Start MedianTime for version bits miner confirmation. Can be a date in the past */
+    // ELEMENTS: Interpreted as block height!
     int64_t nStartTime;
     /** Timeout/expiry MedianTime for the deployment attempt. */
+    // ELEMENTS: Interpreted as block height!
     int64_t nTimeout;
 
     /** Constant for nTimeout very far in the future. */


### PR DESCRIPTION
Bit: 25 (identical to current elementsregtest dynafed bit)
Start: block 1,000,000 (recent past)
Timeout: never