### PR TITLE
Add output_assets arg to createpsbt rpc

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -2131,7 +2131,7 @@ UniValue createpsbt(const JSONRPCRequest& request)
     if (!g_con_elementsmode)
         throw std::runtime_error("PSBT operations are disabled when not in elementsmode.\n");
 
-    if (request.fHelp || request.params.size() < 2 || request.params.size() > 4)
+    if (request.fHelp || request.params.size() < 2 || request.params.size() > 5)
         throw std::runtime_error(
             RPCHelpMan{"createpsbt",
                 "\nCreates a transaction in the Partially Signed Transaction format.\n"
@@ -2192,6 +2192,7 @@ UniValue createpsbt(const JSONRPCRequest& request)
         UniValueType(), // ARR or OBJ, checked later
         UniValue::VNUM,
         UniValue::VBOOL,
+        UniValue::VOBJ
         }, true
     );
 
@@ -3206,7 +3207,7 @@ static const CRPCCommand commands[] =
     { "rawtransactions",    "combinepsbt",                  &combinepsbt,               {"txs"} },
     { "rawtransactions",    "blindpsbt",                    &blindpsbt,                 {"psbt","ignoreblindfail"} },
     { "rawtransactions",    "finalizepsbt",                 &finalizepsbt,              {"psbt", "extract"} },
-    { "rawtransactions",    "createpsbt",                   &createpsbt,                {"inputs","outputs","locktime","replaceable"} },
+    { "rawtransactions",    "createpsbt",                   &createpsbt,                {"inputs","outputs","locktime","replaceable", "output_assets"} },
     { "rawtransactions",    "converttopsbt",                &converttopsbt,             {"hexstring","permitsigdata","iswitness"} },
     { "rawtransactions",    "utxoupdatepsbt",               &utxoupdatepsbt,            {"psbt"} },
     { "rawtransactions",    "joinpsbts",                    &joinpsbts,                 {"txs"} },


### PR DESCRIPTION
- createpsbt used to fail when called with an output_assets.
- update the rpc code to make it work with other assets than bitcoin

Fix issue #875 

I noticed that the cause for `createpsbt` not working with `output_assets` argument was that the code had obviously not been updated to account for the new `output_assets` argument compared to the Bitcoin Core version of the rpc, so I made a couple of changes and it works now. 