### PR TITLE
Make it clear that the CRangeCheck is not called on explicit values

### DIFF
--- a/src/confidential_validation.cpp
+++ b/src/confidential_validation.cpp
@@ -52,9 +52,7 @@ CAmountMap GetFeeMap(const CTransaction& tx) {
 }
 
 bool CRangeCheck::operator()() {
-    if (val->IsExplicit()) {
-        return true;
-    }
+    assert(val->IsCommitment());
 
     if (!CachingRangeProofChecker(store).VerifyRangeProof(rangeproof, val->vchCommitment, assetCommitment, scriptPubKey, secp256k1_ctx_verify_amounts)) {
         error = SCRIPT_ERR_RANGEPROOF;


### PR DESCRIPTION
That is enforced by the `VerifyAmounts` method for regular transactions
and by the `VerifyIssuanceAmounts` method for issuance values.
