### PR TITLE
[elements-0.18] Specify the dynafed epoch length for liquidv1

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -734,8 +734,8 @@ public:
         g_con_blockheightinheader = true;
         g_con_elementsmode = true;
         consensus.elements_mode = g_con_elementsmode;
-        // TODO: Pick appropriate value for this network.
         consensus.total_valid_epochs = 2;
+        consensus.dynamic_epoch_length = 20160;
 
 
         consensus.genesis_subsidy = 0;


### PR DESCRIPTION
Backport of #970.