### PR TITLE
Don't embed a build-id when building libdmg-hfsplus

### DIFF
--- a/depends/packages/native_libdmg-hfsplus.mk
+++ b/depends/packages/native_libdmg-hfsplus.mk
@@ -10,7 +10,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_config_cmds
-  cmake -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix)/bin ..
+  cmake -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix)/bin -DCMAKE_C_FLAGS="-Wl,--build-id=none" ..
 endef
 
 define $(package)_build_cmds


### PR DESCRIPTION
This is a change that is included in more advanced branches that should help with gitian reproducibility on osx. 