### PR TITLE
Adds an -fno-stack-check compile time flag to OSX local builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -667,6 +667,8 @@ case $host in
            PKG_CONFIG_PATH="$qt5_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
            export PKG_CONFIG_PATH
          fi
+         dnl On some versions of osx stack check is turned on by default and is broken
+         AX_CHECK_COMPILE_FLAG([-fno-stack-check],[HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -fno-stack-check"])
        fi
      else
        case $build_os in


### PR DESCRIPTION
As a workaround for several elements issues on OSX 10.15 and later, this PR adds the `-fno-stack-check` flag to local (non-cross compile) OSX builds.

Background: There seems to be a general issue with OSX (version >= 10.15) builds and clang's default use of `-fstack-check` which seems to be buggy enough to cause issues with multiple projects.

closes #987 #998
Also related to #782 