### PR TITLE
test: update `createrawtransaction` call in feature_taphash_pegins_issuances.py

### DIFF
--- a/test/functional/feature_taphash_pegins_issuances.py
+++ b/test/functional/feature_taphash_pegins_issuances.py
@@ -136,7 +136,7 @@ class TapHashPeginTest(BitcoinTestFramework):
 
         blind_addr = self.nodes[0].getnewaddress()
         nonblind_addr = self.nodes[0].validateaddress(blind_addr)['unconfidential']
-        raw_tx = self.nodes[0].createrawtransaction([], {nonblind_addr: 1})
+        raw_tx = self.nodes[0].createrawtransaction([], [{nonblind_addr: 1}])
         raw_tx = FromHex(CTransaction(), raw_tx)
 
         # Need to taproot outputs later because fundrawtransaction cannot estimate fees


### PR DESCRIPTION
Should describe the outputs as an array rather than as an object. (The old behavior has long been deprecated but was eliminated entirely in #900.)

Fixes functional tests which were broken in master by simultaneous merge of #1002 and #900.