### PR TITLE
PSET: Fix blinded coinjoins with 3 or more parties

### DIFF
--- a/doc/pset.mediawiki
+++ b/doc/pset.mediawiki
@@ -94,7 +94,7 @@ The currently defined elements per-input proprietary types are as folows:
 | None
 | No key data
 | <tt><33 byte commitment></tt>
-| The 33 byte Value Commitment.
+| The 33 byte Value Commitment. If provided, <tt>PSBT_ELEMENTS_IN_ISSUANCE_BLIND_VALUE_PROOF</tt> must be provided too.
 |
 | 0
 | 2
@@ -194,7 +194,7 @@ The currently defined elements per-input proprietary types are as folows:
 | None
 | No key data
 | <tt><33 byte commitment></tt>
-| The 33 byte commitment to the inflation keys output value in this issuance.
+| The 33 byte commitment to the inflation keys output value in this issuance. If provided, <tt>PSBT_ELEMENTS_IN_ISSUANCE_BLIND_INFLATION_KEYS_PROOF</tt> must be provided too.
 |
 | 0
 | 2
@@ -228,6 +228,26 @@ The currently defined elements per-input proprietary types are as folows:
 |
 | 0
 | 2
+|-
+| Issuance Blind Value Proof
+| <tt>PSBT_ELEMENTS_IN_ISSUANCE_BLIND_VALUE_PROOF = 0x0f</tt>
+| None
+| No key data
+| <tt><rangeproof></tt>
+| An explicit value rangeproof that proves that the value commitment in <tt>PSBT_ELEMENTS_IN_ISSUANCE_VALUE_COMMITMENT</tt> matches the explicit value in <tt>PSBT_ELEMENTS_IN_ISSUANCE_VALUE</tt>. If provided, <tt>PSBT_ELEMENTS_IN_ISSUANCE_VALUE_COMMITMENT</tt> must be provided too.
+|
+| 0
+| 2
+|-
+| Issuance Inflation Keys Blind Value Proof
+| <tt>PSBT_ELEMENTS_IN_ISSUANCE_BLIND_INFLATION_KEYS_PROOF = 0x10</tt>
+| None
+| No key data
+| <tt><rangeproof></tt>
+| An explicit value rangeproof that proves that the value commitment in <tt>PSBT_ELEMENTS_IN_ISSUANCE_INFLATION_KEYS_COMMITMENT</tt> matches the explicit value in <tt>PSBT_ELEMENTS_IN_ISSUANCE_INFLATION_KEYS</tt>. If provided, <tt>PSBT_ELEMENTS_IN_ISSUANCE_INFLATION_KEYS_COMMITMENT</tt> must be provided too.
+|
+| 0
+| 2
 |}
 
 The currently defined elements per-output proprietary types are as follows:
@@ -248,7 +268,7 @@ The currently defined elements per-output proprietary types are as follows:
 | None
 | No key data
 | <tt><33 byte commitment></tt>
-| The 33 byte Value Commitment for this output. This is mutually exclusive with <tt>PSBT_OUT_VALUE</tt>.
+| The 33 byte Value Commitment for this output. If provided, <tt>PSBT_ELEMENTS_OUT_BLIND_VALUE_PROOF</tt> must be provided too.
 |
 | 0
 | 2
@@ -268,7 +288,7 @@ The currently defined elements per-output proprietary types are as follows:
 | None
 | No key data
 | <tt><33 byte commitment></tt>
-| The 33 byte Asset Commitment for this output.
+| The 33 byte Asset Commitment for this output. If provided, <tt>PSBT_ELEMENTS_OUT_BLIND_ASSET_PROOF</tt> must be provided too.
 |
 | 0
 | 2
@@ -319,6 +339,25 @@ The currently defined elements per-output proprietary types are as follows:
 | No key data
 | <tt><32 bit uint></tt>
 | The unsigned 32-bit little endian integer index of the input whose owner should blind this output.
+|
+| 0
+| 2
+|-
+| Blind Value Proof
+| <tt>PSBT_ELEMENTS_OUT_BLIND_VALUE_PROOF = 0x09</tt>
+| None
+| No key data
+| <tt><rangeproof></tt>
+| An explicit value rangeproof that proves that the value commitment in <tt>PSBT_ELEMENTS_OUT_VALUE_COMMITMENT</tt> matches the explicit value in <tt>PSBT_OUT_VALUE</tt>. If provided, <tt>PSBT_ELEMENTS_OUT_VALUE_COMMITMENT</tt> must be provided too.
+|
+| 0
+| 2|-
+| Blind Asset Proof
+| <tt>PSBT_ELEMENTS_OUT_BLIND_ASSET_PROOF = 0x0a</tt>
+| None
+| No key data
+| <tt><proof></tt>
+| An asset surjection proof with this output's asset as the only asset in the input set in order to prove that the asset commitment in <tt>PSBT_ELEMENTS_OUT_ASSET_COMMITMENT</tt> matches the explicit asset in <tt>PSBT_ELEMENTS_OUT_ASSET</tt>. If provided, <tt>PSBT_ELEMENTS_OUT_ASSET_COMMITMENT</tt> must be provided too.
 |
 | 0
 | 2
@@ -374,10 +413,12 @@ The Blinder adds the blinding data to a transaction.
 For issuance inputs that belong to the Blinder, the Blinder should generate a random blinding factor and create a value commitment for the issuance value.
 It will then add the value commitment in the <tt>PSBT_ELEMENTS_IN_ISSUANCE_VALUE_COMMITMENT</tt>.
 The blinder will also add the issuance value rangeproof and the issuance keys rangeproof in their respective fields.
+The blinder will also add the issuance blind value and issuance keys blind value proofs in their respective fields.
 For ease of identifying the blinder for an issuance, the input the issuance is attached to must belong to the blinder for the issuance.
 
 For the Blinder's outputs that are to be blinded (i.e. they have a blinding pubkey), the Blinder will create value and asset commitments and put them in their respective fields.
 The Blinder will create the Value Rangeproof and Asset Surjection Proof and put them in their respective fields.
+The Blinder will create the blind value and blind asset proofs and put them in their respective fields.
 It will also add the ephemeral pubkey used for ECDH of the nonce for the rangeproof to the <tt>PSBT_ELEMENTS_OUT_ECDH_PUBKEY</tt> field.
 
 The blinder will then compute a scalar offset that will be added as a <tt>PSBT_ELEMENTS_GLOBAL_SCALAR</tt>.

--- a/doc/pset.mediawiki
+++ b/doc/pset.mediawiki
@@ -84,7 +84,7 @@ The currently defined elements per-input proprietary types are as folows:
 | None
 | No key data
 | <tt><64-bit int></tt>
-| The explicit little endian 64-bit integer for the value of this issuance. This is mutually exclusive with <tt>PSBT_ELEMENTS_IN_ISSUANCE_VALUE_COMMITMENT</tt>
+| The explicit little endian 64-bit integer for the value of this issuance.
 |
 | 0
 | 2
@@ -94,7 +94,7 @@ The currently defined elements per-input proprietary types are as folows:
 | None
 | No key data
 | <tt><33 byte commitment></tt>
-| The 33 byte Value Commitment. This is mutually exclusive with <tt>PSBT_IN_ISSUANCE_VALUE</tt>.
+| The 33 byte Value Commitment.
 |
 | 0
 | 2
@@ -184,7 +184,7 @@ The currently defined elements per-input proprietary types are as folows:
 | None
 | No key data
 | <tt><64-bit int></tt>
-| The value for the inflation keys output to set in this issuance. This is mutually exclusive with <tt>PSBT_ELEMENTS_IN_ISSUANCE_INFLATION_KEYS</tt>.
+| The value for the inflation keys output to set in this issuance.
 |
 | 0
 | 2
@@ -194,7 +194,7 @@ The currently defined elements per-input proprietary types are as folows:
 | None
 | No key data
 | <tt><33 byte commitment></tt>
-| The 33 byte commitment to the inflation keys output value in this issuance. This is mutually exclusive with <tt>PSBT_ELEMENTS_IN_ISSUANCE_INFLATION_KEYS</tt>
+| The 33 byte commitment to the inflation keys output value in this issuance.
 |
 | 0
 | 2
@@ -258,7 +258,7 @@ The currently defined elements per-output proprietary types are as follows:
 | None
 | No key data
 | <tt><32 byte asset tag></tt>
-| The explicit 32 byte asset tag for this output. This is mutually exclusive with <tt>PSBT_ELEMENTS_OUT_ASSET_COMMITMENT</tt>.
+| The explicit 32 byte asset tag for this output.
 |
 | 0
 | 2
@@ -268,7 +268,7 @@ The currently defined elements per-output proprietary types are as follows:
 | None
 | No key data
 | <tt><33 byte commitment></tt>
-| The 33 byte Asset Commitment for this output. This is mutually exclusive with <tt>PSBT_ELEMENTS_OUT_ASSET</tt>.
+| The 33 byte Asset Commitment for this output.
 |
 | 0
 | 2
@@ -324,8 +324,6 @@ The currently defined elements per-output proprietary types are as follows:
 | 2
 |}
 
-In addition to these new types, the <tt>PSBT_OUT_AMOUNT</tt> field is no longer required so long as <tt>PSBT_ELEMENTS_OUT_VALUE_COMMITMENT</tt> is present.
-
 The PSET Magic Bytes are <tt>0x70736574</tt>
 
 ===Handling Duplicated Keys===
@@ -373,15 +371,12 @@ A single entity is likely to be both a Creator and Updater.
 PSET requires a role not present in PSBT, the Blinder. Blinders are similar to Signers and own inputs.
 The Blinder adds the blinding data to a transaction.
 
-If Bit 0 of <tt>PSBT_ELEMENTS_GLOBAL_TX_MODIFIABLE</tt> is 0, the Blinder must do nothing.
-
 For issuance inputs that belong to the Blinder, the Blinder should generate a random blinding factor and create a value commitment for the issuance value.
-It will then add the value commitment in the <tt>PSBT_ELEMENTS_IN_ISSUANCE_VALUE_COMMITMENT</tt>. When it does so, it must remove the <tt>PSBT_ELEMENTS_IN_ISSUANCE_VALUE</tt> field.
+It will then add the value commitment in the <tt>PSBT_ELEMENTS_IN_ISSUANCE_VALUE_COMMITMENT</tt>.
 The blinder will also add the issuance value rangeproof and the issuance keys rangeproof in their respective fields.
 For ease of identifying the blinder for an issuance, the input the issuance is attached to must belong to the blinder for the issuance.
 
 For the Blinder's outputs that are to be blinded (i.e. they have a blinding pubkey), the Blinder will create value and asset commitments and put them in their respective fields.
-When they do so, the <tt>PSBT_ELEMENTS_OUT_VALUE</tt> and <tt>PSBT_ELEMENTS_OUT_ASSET</tt> fields must be removed.
 The Blinder will create the Value Rangeproof and Asset Surjection Proof and put them in their respective fields.
 It will also add the ephemeral pubkey used for ECDH of the nonce for the rangeproof to the <tt>PSBT_ELEMENTS_OUT_ECDH_PUBKEY</tt> field.
 
@@ -400,17 +395,13 @@ It will then compute a final scalar offset.
 Then it will subtract all of the scalar offsets from the value blinding factor for the last output and the result is the value blinding factor to be used for that last output.
 The creation of the commitments, proofs, and other fields proceeds as usual.
 Once all outputs are blinded, all <tt>PSBT_ELEMENTS_GLOBAL_SCALAR</tt> fields must be removed from the PSET.
-Once all outputs are blinded, Bit 0 of <tt>PSBT_ELEMENTS_GLOBAL_TX_MODIFIABLE</tt> must be set to 0.
 
 A single entity is likely to be a Creator, Updater, and Blinder.
-In that case, the PSET should never be output with <tt>PSBT_ELEMENTS_IN_ISSUANCE_VALUE</tt>, <tt>PSBT_ELEMENTS_IN_ISSUANCE_INFLATION_KEYS</tt>, <tt>PSBT_ELEMENTS_OUT_VALUE</tt>, or <tt>PSBT_ELEMENTS_OUT_ASSET</tt> except for unblinded issuances and unblinded outputs.
 
 ===Signer===
 
 In addition to the BIP 370 PSBT Signer behavior, PSET specifies some addtional constraints.
 Before signing, the Signer must check whether blinding is complete. If any output contains a blinding pubkey but no commitments or proofs, then it must not sign.
-This is easily done by checking whether Bit 0 of <tt>PSBT_ELEMENTS_GLOBAL_TX_MODIFIABLE</tt> is 1.
-If so, the Signer must do nothing.
 
 ===Combiner===
 

--- a/src/blindpsbt.cpp
+++ b/src/blindpsbt.cpp
@@ -313,11 +313,9 @@ BlindingStatus BlindPSBT(PartiallySignedTransaction& psbt, std::map<uint32_t, st
                         if (blind_value) {
                             input.m_issuance_value_commitment = conf_value;
                             input.m_issuance_rangeproof = rangeproof;
-                            input.m_issuance_value = nullopt;
                         } else {
                             input.m_issuance_inflation_keys_commitment = conf_value;
                             input.m_issuance_inflation_keys_rangeproof = rangeproof;
-                            input.m_issuance_inflation_keys_amount = nullopt;
                         }
                     }
                 }
@@ -407,10 +405,6 @@ BlindingStatus BlindPSBT(PartiallySignedTransaction& psbt, std::map<uint32_t, st
         output.m_ecdh_pubkey = ecdh_key;
         output.m_value_rangeproof = rangeproof;
         output.m_asset_surjection_proof = asp;
-
-        // Drop explicit value and asset
-        output.amount = nullopt;
-        output.m_asset.SetNull();
     }
 
     if (!did_last_blind) {

--- a/src/blindpsbt.h
+++ b/src/blindpsbt.h
@@ -31,9 +31,11 @@ enum class BlindingStatus
 std::string GetBlindingStatusError(const BlindingStatus& status);
 
 bool CreateAssetSurjectionProof(std::vector<unsigned char>& output_proof, const std::vector<secp256k1_fixed_asset_tag>& fixed_input_tags, const std::vector<secp256k1_generator>& ephemeral_input_tags, const std::vector<uint256>& input_asset_blinders, const uint256& output_asset_blinder, const secp256k1_generator& output_asset_tag, const CAsset& asset, size_t num_targets = MAX_SURJECTION_TARGETS);
+bool VerifyBlindAssetProof(const std::vector<unsigned char>& proof, const CConfidentialAsset& conf_asset);
 uint256 GenerateRangeproofECDHKey(CPubKey& ephemeral_pubkey, const CPubKey blinding_pubkey);
 bool CreateValueRangeProof(std::vector<unsigned char>& rangeproof, const uint256& value_blinder, const uint256& nonce, const CAmount amount, const CScript& scriptPubKey, const secp256k1_pedersen_commitment& value_commit, const secp256k1_generator& gen, const CAsset& asset, const uint256& asset_blinder);
 bool CreateBlindValueProof(std::vector<unsigned char>& rangeproof, const uint256& value_blinder, const CAmount amount, const secp256k1_pedersen_commitment& value_commit, const secp256k1_generator& gen);
+bool VerifyBlindValueProof(CAmount value, const CConfidentialValue& conf_value, const std::vector<unsigned char>& proof, const CConfidentialAsset& conf_asset);
 void CreateAssetCommitment(CConfidentialAsset& conf_asset, secp256k1_generator& asset_gen, const CAsset& asset, const uint256& asset_blinder);
 void CreateValueCommitment(CConfidentialValue& conf_value, secp256k1_pedersen_commitment& value_commit, const uint256& value_blinder, const secp256k1_generator& asset_gen, const CAmount amount);
 BlindingStatus BlindPSBT(PartiallySignedTransaction& psbt, std::map<uint32_t, std::tuple<CAmount, CAsset, uint256, uint256>> our_input_data, std::map<uint32_t, std::pair<CKey, CKey>> our_issuances_to_blind);

--- a/src/blindpsbt.h
+++ b/src/blindpsbt.h
@@ -30,9 +30,10 @@ enum class BlindingStatus
 
 std::string GetBlindingStatusError(const BlindingStatus& status);
 
-bool CreateAssetSurjectionProof(std::vector<unsigned char>& output_proof, const std::vector<secp256k1_fixed_asset_tag>& fixed_input_tags, const std::vector<secp256k1_generator>& ephemeral_input_tags, const std::vector<uint256>& input_asset_blinders, const uint256& output_asset_blinder, const secp256k1_generator& output_asset_tag, const CAsset& asset);
+bool CreateAssetSurjectionProof(std::vector<unsigned char>& output_proof, const std::vector<secp256k1_fixed_asset_tag>& fixed_input_tags, const std::vector<secp256k1_generator>& ephemeral_input_tags, const std::vector<uint256>& input_asset_blinders, const uint256& output_asset_blinder, const secp256k1_generator& output_asset_tag, const CAsset& asset, size_t num_targets = MAX_SURJECTION_TARGETS);
 uint256 GenerateRangeproofECDHKey(CPubKey& ephemeral_pubkey, const CPubKey blinding_pubkey);
 bool CreateValueRangeProof(std::vector<unsigned char>& rangeproof, const uint256& value_blinder, const uint256& nonce, const CAmount amount, const CScript& scriptPubKey, const secp256k1_pedersen_commitment& value_commit, const secp256k1_generator& gen, const CAsset& asset, const uint256& asset_blinder);
+bool CreateBlindValueProof(std::vector<unsigned char>& rangeproof, const uint256& value_blinder, const CAmount amount, const secp256k1_pedersen_commitment& value_commit, const secp256k1_generator& gen);
 void CreateAssetCommitment(CConfidentialAsset& conf_asset, secp256k1_generator& asset_gen, const CAsset& asset, const uint256& asset_blinder);
 void CreateValueCommitment(CConfidentialValue& conf_value, secp256k1_pedersen_commitment& value_commit, const uint256& value_blinder, const secp256k1_generator& asset_gen, const CAmount amount);
 BlindingStatus BlindPSBT(PartiallySignedTransaction& psbt, std::map<uint32_t, std::tuple<CAmount, CAsset, uint256, uint256>> our_input_data, std::map<uint32_t, std::pair<CKey, CKey>> our_issuances_to_blind);

--- a/src/blindpsbt.h
+++ b/src/blindpsbt.h
@@ -26,6 +26,7 @@ enum class BlindingStatus
     SCALAR_UNABLE,
     INVALID_BLINDER,
     ASP_UNABLE,
+    NO_BLIND_OUTPUTS,
 };
 
 std::string GetBlindingStatusError(const BlindingStatus& status);

--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -514,10 +514,9 @@ bool PSBTOutput::IsBlinded() const
 
 bool PSBTOutput::IsPartiallyBlinded() const
 {
-    return IsBlinded() && (!amount ||
+    return IsBlinded() && (
         !m_value_commitment.IsNull() ||
         !m_asset_commitment.IsNull() ||
-        m_asset.IsNull() ||
         !m_value_rangeproof.empty() ||
         !m_asset_surjection_proof.empty() ||
         m_ecdh_pubkey.IsValid());
@@ -525,10 +524,9 @@ bool PSBTOutput::IsPartiallyBlinded() const
 
 bool PSBTOutput::IsFullyBlinded() const
 {
-    return IsBlinded() && !amount &&
+    return IsBlinded() &&
         !m_value_commitment.IsNull() &&
         !m_asset_commitment.IsNull() &&
-        m_asset.IsNull() &&
         !m_value_rangeproof.empty() &&
         !m_asset_surjection_proof.empty() &&
         m_ecdh_pubkey.IsValid();

--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -59,6 +59,9 @@ bool PartiallySignedTransaction::Merge(const PartiallySignedTransaction& psbt)
             m_xpubs[xpub_pair.first].insert(xpub_pair.second.begin(), xpub_pair.second.end());
         }
     }
+    for (auto& scalar : psbt.m_scalar_offsets) {
+        m_scalar_offsets.insert(scalar);
+    }
     if (fallback_locktime == nullopt && psbt.fallback_locktime != nullopt) fallback_locktime = psbt.fallback_locktime;
     if (m_tx_modifiable == nullopt && psbt.m_tx_modifiable != nullopt) m_tx_modifiable = psbt.m_tx_modifiable;
     unknown.insert(psbt.unknown.begin(), psbt.unknown.end());
@@ -413,6 +416,8 @@ bool PSBTInput::Merge(const PSBTInput& input)
     }
     if (m_issuance_blinding_nonce.IsNull() && !input.m_issuance_blinding_nonce.IsNull()) m_issuance_blinding_nonce = input.m_issuance_blinding_nonce;
     if (m_issuance_asset_entropy.IsNull() && !input.m_issuance_asset_entropy.IsNull()) m_issuance_asset_entropy = input.m_issuance_asset_entropy;
+    if (m_blind_issuance_value_proof.empty() && !input.m_blind_issuance_value_proof.empty()) m_blind_issuance_value_proof = input.m_blind_issuance_value_proof;
+    if (m_blind_issuance_inflation_keys_proof.empty() && !input.m_blind_issuance_inflation_keys_proof.empty()) m_blind_issuance_inflation_keys_proof = input.m_blind_issuance_inflation_keys_proof;
 
     if (m_peg_in_tx.which() == 0 && input.m_peg_in_tx.which() != 0) m_peg_in_tx = input.m_peg_in_tx;
     if (m_peg_in_txout_proof.which() == 0 && input.m_peg_in_txout_proof.which() != 0) m_peg_in_txout_proof = input.m_peg_in_txout_proof;
@@ -420,6 +425,8 @@ bool PSBTInput::Merge(const PSBTInput& input)
     if (m_peg_in_genesis_hash.IsNull() && !input.m_peg_in_genesis_hash.IsNull()) m_peg_in_genesis_hash = input.m_peg_in_genesis_hash;
     if (m_peg_in_value == nullopt && input.m_peg_in_value != nullopt) m_peg_in_value = input.m_peg_in_value;
     if (m_peg_in_witness.IsNull() && !input.m_peg_in_witness.IsNull()) m_peg_in_witness = input.m_peg_in_witness;
+
+    if (m_utxo_rangeproof.empty() && !input.m_utxo_rangeproof.empty()) m_utxo_rangeproof = input.m_utxo_rangeproof;
 
     return true;
 }
@@ -459,8 +466,7 @@ bool PSBTOutput::Merge(const PSBTOutput& output)
 {
     assert(amount == output.amount);
     assert(script == output.script);
-    assert(m_value_commitment == output.m_value_commitment);
-    assert(m_asset_commitment == output.m_asset_commitment);
+    assert(m_asset == output.m_asset);
 
     hd_keypaths.insert(output.hd_keypaths.begin(), output.hd_keypaths.end());
     unknown.insert(output.unknown.begin(), output.unknown.end());
@@ -481,7 +487,6 @@ bool PSBTOutput::Merge(const PSBTOutput& output)
         if (!m_asset_commitment.IsNull() && !output.m_asset_commitment.IsNull() && (m_asset_commitment != output.m_asset_commitment)) return false;
         if (!m_value_rangeproof.empty() && !output.m_value_rangeproof.empty() && (m_value_rangeproof != output.m_value_rangeproof)) return false;
         if (!m_asset_surjection_proof.empty() && !output.m_asset_surjection_proof.empty() && (m_asset_surjection_proof != output.m_asset_surjection_proof)) return false;
-        if (amount|| output.amount || !m_asset.IsNull() || !output.m_asset.IsNull()) return false;
     }
 
     // If output IsFullyBlinded and this is not, copy the blinding data and remove the explicits
@@ -491,6 +496,8 @@ bool PSBTOutput::Merge(const PSBTOutput& output)
         m_value_rangeproof = output.m_value_rangeproof;
         m_asset_surjection_proof = output.m_asset_surjection_proof;
         m_ecdh_pubkey = output.m_ecdh_pubkey;
+        m_blind_value_proof = output.m_blind_value_proof;
+        m_blind_asset_proof = output.m_blind_asset_proof;
     }
 
     return true;

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -1379,7 +1379,7 @@ struct PartiallySignedTransaction
     void SetupFromTx(const CMutableTransaction& tx);
     void CacheUnsignedTxPieces();
     bool ComputeTimeLock(uint32_t& locktime) const;
-    CMutableTransaction GetUnsignedTx() const;
+    CMutableTransaction GetUnsignedTx(bool foce_unblinded=false) const;
     uint256 GetUniqueID() const;
     PartiallySignedTransaction() {}
     PartiallySignedTransaction(uint32_t version);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1785,7 +1785,7 @@ static RPCHelpMan combinepsbt()
                 is_fully_blinded &= psbt_out.IsFullyBlinded();
             }
         }
-        if (!is_fully_blinded) {
+        if (is_fully_blinded) {
             throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Cannot combine PSETs");
         }
     }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1156,9 +1156,11 @@ static RPCHelpMan decodepsbt()
                                 {RPCResult::Type::NUM, "issuance_value", "The explicit value of the issuance in this input in " + CURRENCY_UNIT},
                                 {RPCResult::Type::STR_HEX, "issuance_value_commitment", "The commitment of the value of the issuance in this input."},
                                 {RPCResult::Type::STR_HEX, "issuance_value_rangeproof", "The rangeproof for the value commitment of the issuance in this input."},
+                                {RPCResult::Type::STR_HEX, "blind_issuance_value_proof", "Explicit value rangeproof that proves the issuance value commitment matches the value"},
                                 {RPCResult::Type::NUM, "issuance_reissuance_amount", "The explicit amount available for the reissuance output."},
                                 {RPCResult::Type::STR_HEX, "issuance_reissuance_amount_commitment", "The commitment of the reissuance amount."},
                                 {RPCResult::Type::STR_HEX, "issuance_reissuance_amount_rangeproof", "The rangeproof for the amount commitment of the reissuance amount."},
+                                {RPCResult::Type::STR_HEX, "blind_reissuance_amount_proof", "Explicit value rangeproof that proves the reissuance value commitment matches the reissuance value"},
                                 {RPCResult::Type::STR_HEX, "issuance_blinding_nonce", "The blinding nonce for the issuance in this input."},
                                 {RPCResult::Type::STR_HEX, "issuance_asset_entropy", "The asset entropy for the issuance in this input."},
                                 {RPCResult::Type::STR_HEX, "pegin_bitcoin_tx", "The tx providing the peg-in in the format of the getrawtransaction RPC"},
@@ -1223,6 +1225,8 @@ static RPCHelpMan decodepsbt()
                                 {RPCResult::Type::STR_HEX, "surjection_proof", "The surjection proof for the output"},
                                 {RPCResult::Type::STR_HEX, "ecdh_pubkey", "The ecdh pubkey for the output"},
                                 {RPCResult::Type::STR_HEX, "blinding_pubkey", "The blinding pubkey for the output"},
+                                {RPCResult::Type::STR_HEX, "blind_value_proof", "Explicit value rangeproof that proves the value commitment matches the value"},
+                                {RPCResult::Type::STR_HEX, "blind_asset_proof", "Assert surjection proof that proves the assert commitment matches the asset"},
                                 {RPCResult::Type::OBJ_DYN, "unknown", "The unknown global fields",
                                 {
                                     {RPCResult::Type::STR_HEX, "key", "(key-value pair) An unknown key-value pair"},
@@ -1458,6 +1462,11 @@ static RPCHelpMan decodepsbt()
             in.pushKV("issuance_value_rangeproof", HexStr(input.m_issuance_rangeproof));
         }
 
+        // Issuance blind value proof
+        if (!input.m_blind_issuance_value_proof.empty()) {
+            in.pushKV("blind_issuance_value_proof", HexStr(input.m_blind_issuance_value_proof));
+        }
+
         // Issuance inflation keys amount
         if (input.m_issuance_inflation_keys_amount != nullopt) {
             in.pushKV("issuance_reissuance_amount", ValueFromAmount(*input.m_issuance_inflation_keys_amount));
@@ -1471,6 +1480,11 @@ static RPCHelpMan decodepsbt()
         // Issuance inflation keys value rangeproof
         if (!input.m_issuance_inflation_keys_rangeproof.empty()) {
             in.pushKV("issuance_reissuance_amount_rangeproof", HexStr(input.m_issuance_inflation_keys_rangeproof));
+        }
+
+        // Issuance blind inflation keys value proof
+        if (!input.m_blind_issuance_value_proof.empty()) {
+            in.pushKV("blind_reissuance_amount_proof", HexStr(input.m_blind_issuance_inflation_keys_proof));
         }
 
         // Issuance blinding nonce
@@ -1647,6 +1661,16 @@ static RPCHelpMan decodepsbt()
         // Blinder index
         if (output.m_blinder_index != nullopt) {
             out.pushKV("blinder_index", (int64_t)*output.m_blinder_index);
+        }
+
+        // Blind value proof
+        if (!output.m_blind_value_proof.empty()) {
+            out.pushKV("blind_value_proof", HexStr(output.m_blind_value_proof));
+        }
+
+        // Blind asset proof
+        if (!output.m_blind_asset_proof.empty()) {
+            out.pushKV("blind_asset_proof", HexStr(output.m_blind_asset_proof));
         }
 
         // Proprietary

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1786,7 +1786,7 @@ static RPCHelpMan combinepsbt()
             }
         }
         if (is_fully_blinded) {
-            throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Cannot combine PSETs");
+            throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Cannot combine PSETs as the values and blinders would become imbalanced");
         }
     }
 

--- a/src/util/error.cpp
+++ b/src/util/error.cpp
@@ -37,6 +37,10 @@ bilingual_str TransactionErrorString(const TransactionError err)
             return Untranslated("Transaction values or blinders are not balanced");
         case TransactionError::UTXOS_MISSING_BALANCE_CHECK:
             return Untranslated("Missing UTXOs that are needed to check transaction balance");
+        case TransactionError::INVALID_VALUE_PROOF:
+            return Untranslated("Proof of blinded value is invalid");
+        case TransactionError::INVALID_ASSET_PROOF:
+            return Untranslated("Proof of blinded asset is invalid");
         // no default case, so the compiler can warn about missing cases
     }
     assert(false);

--- a/src/util/error.h
+++ b/src/util/error.h
@@ -33,6 +33,8 @@ enum class TransactionError {
     BLINDING_REQUIRED,
     VALUE_IMBALANCE,
     UTXOS_MISSING_BALANCE_CHECK,
+    INVALID_VALUE_PROOF,
+    INVALID_ASSET_PROOF,
 };
 
 bilingual_str TransactionErrorString(const TransactionError error);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4749,7 +4749,8 @@ static RPCHelpMan walletprocesspsbt()
     }
     if (needs_blinding) {
         BlindingStatus status = pwallet->WalletBlindPSBT(psbtx);
-        if (status != BlindingStatus::OK) {
+        // Fail if we couldn't blind, but only if it is for reasons other than needing UTXOs
+        if (status != BlindingStatus::OK && status != BlindingStatus::NEEDS_UTXOS) {
             throw JSONRPCError(RPC_WALLET_ERROR, GetBlindingStatusError(status));
         }
     }

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -616,6 +616,9 @@ class PSBTTest(BitcoinTestFramework):
         conf_addr_4 = self.get_address(True, 0)
         psbt = self.nodes[2].createpsbt([{"txid": txid_conf_2, "vout": 1}], [{conf_addr_4: 24.998, "blinder_index": 0}, {"fee": 0.001}])
         psbt = self.nodes[2].walletprocesspsbt(psbt)['psbt']
+        decoded = self.nodes[1].decodepsbt(psbt)
+        assert "blind_value_proof" in decoded["outputs"][0]
+        assert "blind_asset_proof" in decoded["outputs"][0]
         hex_tx = self.nodes[2].finalizepsbt(psbt)['hex']
         assert_equal(self.num_blinded_outputs(hex_tx), 1)
         self.nodes[2].sendrawtransaction(hex_tx)

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -12,6 +12,7 @@ from test_framework.util import (
     assert_greater_than,
     assert_raises_rpc_error,
     find_output,
+    find_vout_for_address,
 )
 from decimal import Decimal
 
@@ -634,6 +635,65 @@ class PSBTTest(BitcoinTestFramework):
         hex_tx = self.nodes[0].finalizepsbt(psbt)['hex']
         assert_equal(self.num_blinded_outputs(hex_tx), 2)
         self.nodes[0].sendrawtransaction(hex_tx)
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        # Try a multiparty blinded tx
+        # Prepare wallets and UTXOs for inputs
+        self.nodes[2].createwallet("w1")
+        w1 = self.nodes[2].get_wallet_rpc("w1")
+        self.nodes[2].createwallet("w2")
+        w2 = self.nodes[2].get_wallet_rpc("w2")
+        self.nodes[2].createwallet("w3")
+        w3 = self.nodes[2].get_wallet_rpc("w3")
+        w1_addr = w1.getaddressinfo(w1.getnewaddress())["confidential"]
+        w2_addr = w2.getaddressinfo(w2.getnewaddress())["confidential"]
+        w3_addr = w3.getaddressinfo(w3.getnewaddress())["confidential"]
+        txid1 = self.nodes[0].sendtoaddress(w1_addr, 10)
+        txid2 = self.nodes[0].sendtoaddress(w2_addr, 10)
+        txid3 = self.nodes[0].sendtoaddress(w3_addr, 10)
+        self.sync_all()
+        vout1 = find_vout_for_address(self.nodes[2], txid1, w1_addr)
+        vout2 = find_vout_for_address(self.nodes[2], txid2, w2_addr)
+        vout3 = find_vout_for_address(self.nodes[2], txid3, w3_addr)
+        self.nodes[0].generate(1)
+        self.sync_all()
+        # Make the PSBT
+        created_psbt = self.nodes[0].createpsbt(
+            [
+                {"txid": txid1, "vout": vout1},
+                {"txid": txid2, "vout": vout2},
+                {"txid": txid3, "vout": vout3},
+            ],
+            [
+                {self.get_address(True, 0): Decimal("9.999"), "blinder_index": 0},
+                {self.get_address(True, 0): Decimal("9.999"), "blinder_index": 1},
+                {self.get_address(True, 0): Decimal("9.999"), "blinder_index": 2},
+                {"fee": Decimal("0.003")}
+            ]
+        )
+        # Update all but don't blind
+        up_psbt1 = w1.walletprocesspsbt(psbt=created_psbt, sign=False)["psbt"]
+        up_psbt2 = w2.walletprocesspsbt(psbt=created_psbt, sign=False)["psbt"]
+        up_psbt3 = w3.walletprocesspsbt(psbt=created_psbt, sign=False)["psbt"]
+        # Combine updated
+        comb_psbt1 = self.nodes[0].combinepsbt([up_psbt1, up_psbt2, up_psbt3])
+        # 1 and 2 blind
+        blind_psbt1 = w1.walletprocesspsbt(psbt=comb_psbt1, sign=False)["psbt"]
+        blind_psbt2 = w2.walletprocesspsbt(psbt=comb_psbt1, sign=False)["psbt"]
+        # Combine 1 and 2 blinded
+        comb_psbt2 = self.nodes[0].combinepsbt([blind_psbt1, blind_psbt2])
+        # 3 Updates and blinds combined
+        blind_psbt = w3.walletprocesspsbt(psbt=comb_psbt2, sign=False)["psbt"]
+        # All sign
+        sign_psbt1 = w1.walletprocesspsbt(psbt=blind_psbt)["psbt"]
+        sign_psbt2 = w2.walletprocesspsbt(psbt=blind_psbt)["psbt"]
+        sign_psbt3 = w3.walletprocesspsbt(psbt=blind_psbt)["psbt"]
+        # Combine sigs
+        comb_psbt2 = self.nodes[0].combinepsbt([sign_psbt1, sign_psbt2, sign_psbt3])
+        # Finalize and send
+        tx = self.nodes[0].finalizepsbt(comb_psbt2)["hex"]
+        self.nodes[0].sendrawtransaction(tx)
         self.nodes[0].generate(1)
         self.sync_all()
 


### PR DESCRIPTION
In order for blinded coinjoins with 3 or more parties to work, some fields need to be added, amounts cannot be removed, and some bugs need fixing.

First and foremost is to no longer remove amounts after blinding. Due to a miscommunication, I had believed that part of the goal of PSET was to hide semi private information (such as output amounts) from other parties in the transaction. However this causes the combiner to fail because the unique ID is dependent on those amounts and their commitments. If multiple parties had blinded just their own outputs, then the resulting PSETs would not combine because the amounts had be removed and so the unique ID calculated was incorrect. In order for this combining to work, amounts must be kept after blinding and the unique ID calculation must only use the computed unblinded transaction. This change has also been made to the spec document.

Second is the addition of explicit value and asset proofs. In order to prove that the commitments commit to the given explicit value or asset, explicit value rangeproofs and explicit asset surjection proofs are added to PSET. Each blinded output must have an explicit value rangeproof and explict asset surjection proof after blinding. For issuances, explicit issuance value proofs and explicit reissuance value proofs must be added after blinding. These proofs are verified prior to signing.

Thirdly, in order to make the coinjoin workflow work, a `blind` option is added `walletprocesspsbt` so that users can tell `walletprocesspsbt` to not attempt to blind. This is important because blinding requires all UTXOs to be present, and UTXOs can only be added via a call to `walletprocesspsbt`. Error messages have been added and improved so that users who do things in the wrong order will be less likely to end up with an unusable PSET.

Lastly, a test case has been added for a 3 party coinjoin workflow.

Fixes #1037