### PR TITLE
regtest: change network magic away from liquid v1

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -658,7 +658,7 @@ class CCustomParams : public CRegTestParams {
         assert(IsHex(extprvprefix) && extprvprefix.size() == 8 && "-extprvkeyprefix must be hex string of length 8");
         base58Prefixes[EXT_SECRET_KEY] = ParseHex(extprvprefix);
 
-        const std::string magic_str = args.GetArg("-pchmessagestart", "FABFB5DA");
+        const std::string magic_str = args.GetArg("-pchmessagestart", "5319F20E");
         assert(IsHex(magic_str) && magic_str.size() == 8 && "-pchmessagestart must be hex string of length 8");
         const std::vector<unsigned char> magic_byte = ParseHex(magic_str);
         std::copy(begin(magic_byte), end(magic_byte), pchMessageStart);

--- a/src/test/fuzz/FuzzedDataProvider.h
+++ b/src/test/fuzz/FuzzedDataProvider.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_FUZZER_FUZZED_DATA_PROVIDER_H_
 #define LLVM_FUZZER_FUZZED_DATA_PROVIDER_H_
 
+#include <limits>
 #include <algorithm>
 #include <climits>
 #include <cstddef>

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -114,7 +114,7 @@ MAGIC_BYTES = {
     "testnet3": b"\x0b\x11\x09\x07",  # testnet3
     "regtest": b"\xfa\xbf\xb5\xda",   # regtest
     "signet": b"\x0a\x03\xcf\x40",    # signet
-    "elementsregtest": b"\xfa\xbf\xb5\xda",
+    "elementsregtest": b"\x53\x19\xf2\x0e",
 }
 
 


### PR DESCRIPTION
We don't want connectivity issues between Liquid and custom test networks.
