### PR TITLE
fuzz: update psbt fuzztest for PSBT2 changes

### DIFF
--- a/src/test/fuzz/psbt.cpp
+++ b/src/test/fuzz/psbt.cpp
@@ -42,11 +42,8 @@ void test_one_input(const std::vector<uint8_t>& buffer)
 
     (void)psbt.IsNull();
 
-    Optional<CMutableTransaction> tx = psbt.tx;
-    if (tx) {
-        const CMutableTransaction& mtx = *tx;
-        const PartiallySignedTransaction psbt_from_tx{mtx};
-    }
+    const CMutableTransaction& mtx = psbt.GetUnsignedTx();
+    const PartiallySignedTransaction psbt_from_tx{mtx};
 
     for (const PSBTInput& input : psbt.inputs) {
         (void)PSBTInputSigned(input);
@@ -57,9 +54,9 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         (void)output.IsNull();
     }
 
-    for (size_t i = 0; i < psbt.tx->vin.size(); ++i) {
+    for (const auto& input : psbt.inputs) {
         CTxOut tx_out;
-        if (psbt.inputs.at(i).GetUTXO(tx_out)) {
+        if (input.GetUTXO(tx_out)) {
             (void)tx_out.IsNull();
             (void)tx_out.ToString();
         }


### PR DESCRIPTION
The `psbt.tx` Optional is no longer safe to dereference just because decoding succeeded.
