### PR TITLE
chainparams: change magic bytes for liquidv1test

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1155,7 +1155,7 @@ public:
         assert(IsHex(extprvprefix) && extprvprefix.size() == 8 && "-extprvkeyprefix must be hex string of length 8");
         base58Prefixes[EXT_SECRET_KEY] = ParseHex(extprvprefix);
 
-        const std::string magic_str = args.GetArg("-pchmessagestart", "FABFB5DA");
+        const std::string magic_str = args.GetArg("-pchmessagestart", "143EFCB1");
         assert(IsHex(magic_str) && magic_str.size() == 8 && "-pchmessagestart must be hex string of length 8");
         const std::vector<unsigned char> magic_byte = ParseHex(magic_str);
         std::copy(begin(magic_byte), end(magic_byte), pchMessageStart);


### PR DESCRIPTION
This is basically a Liquid-prod-ish version of regtest. Its default magic should not collide with that for Liquid prod.