### PR TITLE
minor PSET fix

### DIFF
--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -434,7 +434,7 @@ bool PSBTInput::Merge(const PSBTInput& input)
     }
     if (m_issuance_rangeproof.empty() && !input.m_issuance_rangeproof.empty()) m_issuance_rangeproof = input.m_issuance_rangeproof;
     if (m_issuance_inflation_keys_rangeproof.empty() && !input.m_issuance_inflation_keys_rangeproof.empty()) m_issuance_inflation_keys_rangeproof = input.m_issuance_inflation_keys_rangeproof;
-    if (m_issuance_inflation_keys_amount == nullopt && m_issuance_inflation_keys_commitment.IsNull() && input.m_issuance_inflation_keys_amount != nullopt) m_issuance_inflation_keys_amount = m_issuance_inflation_keys_amount;
+    if (m_issuance_inflation_keys_amount == nullopt && m_issuance_inflation_keys_commitment.IsNull() && input.m_issuance_inflation_keys_amount != nullopt) m_issuance_inflation_keys_amount = input.m_issuance_inflation_keys_amount;
     if (m_issuance_inflation_keys_commitment.IsNull() && !input.m_issuance_inflation_keys_commitment.IsNull()) {
         m_issuance_inflation_keys_commitment = input.m_issuance_inflation_keys_commitment;
         m_issuance_inflation_keys_amount.reset();


### PR DESCRIPTION
Noticed because it triggered a compiler warning.

No test -- we will add one in a future "end-to-end issuance via PSET" tutorial script which is out of scope for the 0.21 release.