### PR TITLE
Reevaluate descriptor post parse

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -5656,7 +5656,7 @@ static RPCHelpMan sendtomainchain_pak()
 
     FlatSigningProvider provider;
     std::string error;
-    const auto descriptor = Parse(pwallet->offline_desc, provider, error);
+    auto descriptor = Parse(pwallet->offline_desc, provider, error);
 
     LegacyScriptPubKeyMan* spk_man = pwallet->GetLegacyScriptPubKeyMan();
     if (!spk_man) {
@@ -5668,6 +5668,11 @@ static RPCHelpMan sendtomainchain_pak()
         std::string offline_desc = "pkh(" + EncodeExtPubKey(xpub) + "0/*)";
         if (!pwallet->SetOfflineDescriptor(offline_desc)) {
             throw JSONRPCError(RPC_WALLET_ERROR, "Couldn't set wallet descriptor for peg-outs.");
+        }
+
+        descriptor = Parse(pwallet->offline_desc, provider, error);
+        if (!descriptor) {
+            throw JSONRPCError(RPC_WALLET_ERROR, "descriptor still null. This is a bug in elementsd.");
         }
     }
 


### PR DESCRIPTION
In `sendtomainchain_pak()` a check is made if the associated `descriptor` is null and an attempt to remedy is made -- but the remedy is never applied to `descriptor` (which results in a SEGV later).  This code fixes that.

Note: unfortunately it also removes the `const` qualifier.  I'm not sure what/if there are conventions for dealing with that (e.g., creating a new `const` of, like, `sanitized_descriptor` for subsequent use in the function?).