### PR TITLE
Typos in pset doc

### DIFF
--- a/doc/pset.mediawiki
+++ b/doc/pset.mediawiki
@@ -24,7 +24,7 @@ This BIP is licensed under the 2-clause BSD license.
 
 ==Specification==
 
-The Partially Signed ELements Transaction (PSET) format is identical to the BIP 370 PSBT format.
+The Partially Signed Elements Transaction (PSET) format is identical to the BIP 370 PSBT format.
 The changes are new proprietary type fields, a new magic sequence, and new roles.
 The fields added for PSET are only allowed when the PSBT version is 2.
 
@@ -60,13 +60,13 @@ The currently defined elements global proprietary types are as follows:
 | None
 | No key data
 | <tt><8-bit uint></tt>
-| An 8 bit little endian unsigned integer as a bitfield for various elements specific transaction modification flags. Bit 0 is the PSBT Blinded flag and it is set to 1 to indicate that the PSET has not been blinded yet. Once all confidential values, rangeproofs, and asset surjection proofs have been attached to the PSET, it must be set to 0.
+| An 8 bit little endian unsigned integer as a bitfield for various elements specific transaction modification flags. Bit 0 is the PSET Blinded flag and it is set to 1 to indicate that the PSET has not been blinded yet. Once all confidential values, rangeproofs, and asset surjection proofs have been attached to the PSET, it must be set to 0.
 |
 | 0
 | 2
 |}
 
-The currently defined elements per-input proprietary types are as folows:
+The currently defined elements per-input proprietary types are as follows:
 
 {|
 ! Name
@@ -213,7 +213,7 @@ The currently defined elements per-input proprietary types are as folows:
 | <tt>PSBT_ELEMENTS_IN_ISSUANCE_ASSET_ENTROPY = 0x0d</tt>
 | None
 | No key data
-| <tt><32 byte entrpy></tt>
+| <tt><32 byte entropy></tt>
 | The 32 byte asset entropy. For new issuances, an arbitrary and optional 32 bytes of no consensus meaning combined used as additional entropy in the asset tag calculation. For reissuances, the original, final entropy used for the asset tag calculation.
 |
 | 0
@@ -423,7 +423,7 @@ It will also add the ephemeral pubkey used for ECDH of the nonce for the rangepr
 
 The blinder will then compute a scalar offset that will be added as a <tt>PSBT_ELEMENTS_GLOBAL_SCALAR</tt>.
 For each input and output owned/blinded by this blinder, the following formula is computed:
-<tt> asset_blinding_factor * amount + amount_blinding_factor (mod n)<tt>.
+<tt> asset_blinding_factor * amount + amount_blinding_factor (mod n)</tt>.
 The scalars for the inputs are summed, and then that sum is subtracted from the sum of the scalars for the outputs.
 The result is the scalar offset added as a <tt>PSBT_ELEMENTS_GLOBAL_SCALAR</tt>.
 
@@ -441,7 +441,7 @@ A single entity is likely to be a Creator, Updater, and Blinder.
 
 ===Signer===
 
-In addition to the BIP 370 PSBT Signer behavior, PSET specifies some addtional constraints.
+In addition to the BIP 370 PSBT Signer behavior, PSET specifies some additional constraints.
 Before signing, the Signer must check whether blinding is complete. If any output contains a blinding pubkey but no commitments or proofs, then it must not sign.
 
 ===Combiner===
@@ -470,4 +470,4 @@ TBD
 
 ==Reference implementation==
 
-The reference implementation of the PSBT format is available at https://github.com/achow101/elements/tree/pset.
+The reference implementation of the PSET format is available at https://github.com/achow101/elements/tree/pset.


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
