### PR TITLE
doc: specify how to burn non-bitcoin assets in `createrawtransaction`

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -436,6 +436,7 @@ static RPCHelpMan createrawtransaction()
                             {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
                                 {
                                     {"burn", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "A key-value pair. The key must be \"burn\", the value is the amount that will be burned."},
+                                    {"asset", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "The asset tag for this output if it is not the main chain asset"},
                                 },
                                 },
                             {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",


### PR DESCRIPTION

In order to burn a non -bitcoin asset, we need to pass also the `asset` key beside `burn` in the object of the array passed as second parameter in `createrawtransaction`.

This makes it explicit in the helper documentation `elements-cli createrawtransaction`



