### PR TITLE
[BACKPORT 0.18] Make dynafed signaling opt-out instead of opt-in

### DIFF
--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -51,7 +51,7 @@ void SetupChainParamsBaseOptions()
     gArgs.AddArg("-multi_data_permitted", "Allow relay of multiple OP_RETURN outputs. (default: -enforce_pak)", false, OptionsCategory::ELEMENTS);
     gArgs.AddArg("-con_csv_deploy_start", "Starting height for CSV deployment. (default: -1, which means ACTIVE from genesis)", false, OptionsCategory::ELEMENTS);
     gArgs.AddArg("-con_dyna_deploy_start", "Starting height for Dynamic Federations deployment. Once active, signblockscript becomes a BIP141 WSH scriptPubKey of the original signblockscript. All other dynamic parameters stay constant.(default: -1, which means ACTIVE from genesis)", false, OptionsCategory::ELEMENTS);
-    gArgs.AddArg("-con_dyna_deploy_signal", "Whether to signal for the Dynamic Federations deployment (default: false).", false, OptionsCategory::ELEMENTS);
+    gArgs.AddArg("-con_dyna_deploy_signal", "Whether to signal for the Dynamic Federations deployment (default: true).", false, OptionsCategory::ELEMENTS);
     gArgs.AddArg("-dynamic_epoch_length", "Per-chain parameter that sets how many blocks dynamic federation voting and enforcement are in effect for.", false, OptionsCategory::ELEMENTS);
     gArgs.AddArg("-total_valid_epochs", "Per-chain parameter that sets how long a particular fedpegscript is in effect for.", false, OptionsCategory::ELEMENTS);
     // END ELEMENTS

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1831,7 +1831,7 @@ int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Para
     }
 
     // Undo default signalling behavior for dynafed unless explicitly enabled.
-    if (!gArgs.GetBoolArg("-con_dyna_deploy_signal", false)) {
+    if (!gArgs.GetBoolArg("-con_dyna_deploy_signal", true)) {
         auto dynafed = Consensus::DeploymentPos::DEPLOYMENT_DYNA_FED;
         int bit = params.vDeployments[dynafed].bit;
         if (bit > 0 && bit < VERSIONBITS_NUM_BITS) {


### PR DESCRIPTION
(cherry picked from commit a06aac152a0b3535890c6a1f0118b255838ae6c5)

Back in 0.18.1.12, dynafed signaling was disabled to simplify some deployments. This was reverted in the 0.21 branch, for consistency, let's revert it here too.