### PR TITLE
RPC: correctly display signblock_witness post-dynafed

### DIFF
--- a/src/core_io.h
+++ b/src/core_io.h
@@ -15,6 +15,7 @@
 class CBlock;
 class CBlockHeader;
 class CScript;
+struct CScriptWitness;
 class CTransaction;
 struct CMutableTransaction;
 class uint256;
@@ -44,6 +45,7 @@ int ParseSighashString(const UniValue& sighash);
 UniValue ValueFromAmount(const CAmount& amount);
 std::string FormatScript(const CScript& script);
 std::string EncodeHexTx(const CTransaction& tx, const int serializeFlags = 0);
+UniValue EncodeHexScriptWitness(const CScriptWitness& witness);
 std::string SighashToStr(unsigned char sighash_type);
 void ScriptPubKeyToUniv(const CScript& scriptPubKey, UniValue& out, bool fIncludeHex);
 void ScriptToUniv(const CScript& script, UniValue& out, bool include_address);

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -164,6 +164,15 @@ std::string EncodeHexTx(const CTransaction& tx, const int serializeFlags)
     return HexStr(ssTx);
 }
 
+UniValue EncodeHexScriptWitness(const CScriptWitness& witness)
+{
+    UniValue witness_hex(UniValue::VARR);
+    for (const auto &item : witness.stack) {
+        witness_hex.push_back(HexStr(item));
+    }
+    return witness_hex;
+}
+
 void ScriptToUniv(const CScript& script, UniValue& out, bool include_address)
 {
     out.pushKV("asm", ScriptToAsmStr(script));

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -161,9 +161,11 @@ UniValue blockheaderToJSON(const CBlockIndex* tip, const CBlockIndex* blockindex
         result.pushKV("difficulty", GetDifficulty(blockindex));
         result.pushKV("chainwork", blockindex->nChainWork.GetHex());
     } else {
-        result.pushKV("signblock_witness_asm", ScriptToAsmStr(blockindex->proof.solution));
-        result.pushKV("signblock_witness_hex", HexStr(blockindex->proof.solution));
-        if (!blockindex->dynafed_params.IsNull()) {
+        if (blockindex->dynafed_params.IsNull()) {
+            result.pushKV("signblock_witness_asm", ScriptToAsmStr(blockindex->proof.solution));
+            result.pushKV("signblock_witness_hex", HexStr(blockindex->proof.solution));
+        } else {
+            result.pushKV("signblock_witness_hex", EncodeHexScriptWitness(blockindex->m_signblock_witness));
             result.pushKV("dynamic_parameters", dynaParamsToJSON(blockindex->dynafed_params));
         }
     }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -220,6 +220,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIn
             result.pushKV("signblock_witness_hex", HexStr(blockindex->proof.solution));
             result.pushKV("signblock_challenge", HexStr(blockindex->proof.challenge));
         } else {
+            result.pushKV("signblock_witness_hex", EncodeHexScriptWitness(blockindex->m_signblock_witness));
             result.pushKV("dynamic_parameters", dynaParamsToJSON(block.m_dynafed_params));
         }
     }


### PR DESCRIPTION
Fixes https://github.com/ElementsProject/elements/issues/1102.

Note: the following examples were all run on the liquidv1 network.

Before this change, headers for all dynafed blocks were displayed as follows (note the empty `signblock_witness_*` fields):
```
$ elements-cli getblockheader 68b99e3c1d75663b1d8822c57e5605fedd94d9190db7b01d3d24910576f8ec22
{
  "hash": "68b99e3c1d75663b1d8822c57e5605fedd94d9190db7b01d3d24910576f8ec22",
  "confirmations": 1,
  "height": 1800219,
  "version": 536870912,
  "versionHex": "20000000",
  "merkleroot": "c063fb1a72aa6466e10ffbdb1125809b8d4b3bb87a2a38c8492febac20b8d4a3",
  "time": 1650567188,
  "mediantime": 1650566888,
  "signblock_witness_asm": "",
  "signblock_witness_hex": "",
  "dynamic_parameters": {
    "current": {
      "signblockscript": "0020e51211e91d9cf4aec3bdc370a0303acde5d24baedb12235fdd2786885069d91c",
      "max_block_witness": 1325,
      "fedpegscript": "",
      "extension_space": [
      ]
    },
    "proposed": {
      "signblockscript": "",
      "max_block_witness": 0,
      "fedpegscript": "",
      "extension_space": [
      ]
    }
  },
  "nTx": 1,
  "previousblockhash": "55469a29214ba34ffba4a6a3a0df9ae192a8b71dc1a2fbbe8a6d283515f88974"
}
```


With this change, the same RPC call will produce the following response:
```
$ elements-cli getblockheader 68b99e3c1d75663b1d8822c57e5605fedd94d9190db7b01d3d24910576f8ec22
{
  "hash": "68b99e3c1d75663b1d8822c57e5605fedd94d9190db7b01d3d24910576f8ec22",
  "confirmations": 1,
  "height": 1800219,
  "version": 536870912,
  "versionHex": "20000000",
  "merkleroot": "c063fb1a72aa6466e10ffbdb1125809b8d4b3bb87a2a38c8492febac20b8d4a3",
  "time": 1650567188,
  "mediantime": 1650566888,
  "signblock_witness_asm": [
    "",
    "30440220264c169619fd8212d7b6033ea9d84154fa0a7c55904eff4e3fffaedadcc983ad02205271a435bd9103525fea09945660cfb410677fefa7130a13ce17a2eb059f61d901",
    "30440220156d1fb93716723b552317dc64ae4f039ef560d19283e1e546e9c0e37c4c781802206b14f7968ec26f90f0711085bab3aee268271fddf769f3f17a1bac44c0a2a46801",
    "304402202e8c1f1594631c58e746815f54011825a9b82c9837366f49850ce30d42812d1602202c5fac3786a2540bf86cf585f4cdf876e6a7559a10779608cda52933ff4dbca401",
    "3044022057d3e4688da76b3b45705a914ab5c16f906bdf9075a1ca822495751545c3afb502205f1caa3f1df1a63fb1183f47c706cb7f66763cf07af62d5e9aff9ccfe6509cc201",
    "30440220786d0f9aaabbb8858bdc8ba8c60541edc0f08ab343a6269c4ce2cf596e38c73f02202e907e5d12f776542053036b74944cc563e68b8ff212eca0c9b9ed4235cb5ab801",
    "3045022100fd08be1d4a3beebb5115c0b0ea401ad6bd48f55fa7a10c1ccc833c804fd6cc170220190304bdfe1a6426d1f2c69b601a17ad35ddba02e7ce10fbaafdf54b3dfe962201",
    "3045022100a6c46af74e7d7abc220ea937ff08f2067ba076b61a42728b8e20612d84e25d5102204e4a6438dc97f7fe6c6100972ac4b33f50c63f2946ad5e047340b2a2b783f45e01",
    "304402201b569401dded963b143332904afe518221b4d3459c1a53dbcf77887fc342e1ad02201b2bd16b5a7b32aa84f74cbdbab26f2bcbc4e860a9c3b360468f24fec28f54c701",
    "3044022032b40c58a089da715022f36bbfaff5d3359c888ba330e1f6598cf707ce414a300220615938d30432dcda9c1bc634dca592295e26d0771e556d08ddb9e21b889fa59a01",
    "30440220611940fefcd59b8333ceaaa165704bf66a5c9e248fd764e51983109ae25ccd33022067e7c69913f318989b9f574a1d91bc608f7207b6300a86ff5ae1154c6585f43f01",
    "3044022071c0fb880f4c3145aa3b7dd4febb0bdc7d39cc018be9c0906a46b07bbff7f4b4022014f7d8fca4f68e05405eb9e8a97db87b807ea616a44667725088443c0e604aa601",
    "11 026a2a106ec32c8a1e8052e5d02a7b0a150423dbd9b116fc48d46630ff6e6a05b9 02791646a8b49c2740352b4495c118d876347bf47d0551c01c4332fdc2df526f1a 02888bda53a424466b0451627df22090143bbf7c060e9eacb1e38426f6b07f2ae1 02aee8967150dee220f613de3b239320355a498808084a93eaf39a34dcd6202485 02d46e9259d0a0bb2bcbc461a3e68f34adca27b8d08fbe985853992b4b104e2741 02e9944e35e5750ab621e098145b8e6cf373c273b7c04747d1aa020be0af40ccd6 02f9a9d4b10a6d6c56d8c955c547330c589bb45e774551d46d415e51cd9ad51163 033b421566c124dfde4db9defe4084b7aa4e7f36744758d92806b8f72c2e943309 0353dcc6b4cf6ad28aceb7f7b2db92a4bf07ac42d357adf756f3eca790664314b6 037f55980af0455e4fb55aad9b85a55068bb6dc4740ea87276dc693f4598db45fa 0384001daa88dabd23db878dbb1ce5b4c2a5fa72c3113e3514bf602325d0c37b8e 039056d089f2fe72dbc0a14780b4635b0dc8a1b40b7a59106325dd1bc45cc70493 0397ab8ea7b0bf85bc7fc56bb27bf85e75502e94e76a6781c409f3f2ec3d112219 03b00e3b5b77884bf3cae204c4b4eac003601da75f96982ffcb3dcb29c5ee419b9 03c1f3c0874cfe34b8131af34699589aacec4093399739ae352e8a46f80a6f6837 15 OP_CHECKMULTISIG"
  ],
  "signblock_witness_hex": [
    "",
    "30440220264c169619fd8212d7b6033ea9d84154fa0a7c55904eff4e3fffaedadcc983ad02205271a435bd9103525fea09945660cfb410677fefa7130a13ce17a2eb059f61d901",
    "30440220156d1fb93716723b552317dc64ae4f039ef560d19283e1e546e9c0e37c4c781802206b14f7968ec26f90f0711085bab3aee268271fddf769f3f17a1bac44c0a2a46801",
    "304402202e8c1f1594631c58e746815f54011825a9b82c9837366f49850ce30d42812d1602202c5fac3786a2540bf86cf585f4cdf876e6a7559a10779608cda52933ff4dbca401",
    "3044022057d3e4688da76b3b45705a914ab5c16f906bdf9075a1ca822495751545c3afb502205f1caa3f1df1a63fb1183f47c706cb7f66763cf07af62d5e9aff9ccfe6509cc201",
    "30440220786d0f9aaabbb8858bdc8ba8c60541edc0f08ab343a6269c4ce2cf596e38c73f02202e907e5d12f776542053036b74944cc563e68b8ff212eca0c9b9ed4235cb5ab801",
    "3045022100fd08be1d4a3beebb5115c0b0ea401ad6bd48f55fa7a10c1ccc833c804fd6cc170220190304bdfe1a6426d1f2c69b601a17ad35ddba02e7ce10fbaafdf54b3dfe962201",
    "3045022100a6c46af74e7d7abc220ea937ff08f2067ba076b61a42728b8e20612d84e25d5102204e4a6438dc97f7fe6c6100972ac4b33f50c63f2946ad5e047340b2a2b783f45e01",
    "304402201b569401dded963b143332904afe518221b4d3459c1a53dbcf77887fc342e1ad02201b2bd16b5a7b32aa84f74cbdbab26f2bcbc4e860a9c3b360468f24fec28f54c701",
    "3044022032b40c58a089da715022f36bbfaff5d3359c888ba330e1f6598cf707ce414a300220615938d30432dcda9c1bc634dca592295e26d0771e556d08ddb9e21b889fa59a01",
    "30440220611940fefcd59b8333ceaaa165704bf66a5c9e248fd764e51983109ae25ccd33022067e7c69913f318989b9f574a1d91bc608f7207b6300a86ff5ae1154c6585f43f01",
    "3044022071c0fb880f4c3145aa3b7dd4febb0bdc7d39cc018be9c0906a46b07bbff7f4b4022014f7d8fca4f68e05405eb9e8a97db87b807ea616a44667725088443c0e604aa601",
    "5b21026a2a106ec32c8a1e8052e5d02a7b0a150423dbd9b116fc48d46630ff6e6a05b92102791646a8b49c2740352b4495c118d876347bf47d0551c01c4332fdc2df526f1a2102888bda53a424466b0451627df22090143bbf7c060e9eacb1e38426f6b07f2ae12102aee8967150dee220f613de3b239320355a498808084a93eaf39a34dcd62024852102d46e9259d0a0bb2bcbc461a3e68f34adca27b8d08fbe985853992b4b104e27412102e9944e35e5750ab621e098145b8e6cf373c273b7c04747d1aa020be0af40ccd62102f9a9d4b10a6d6c56d8c955c547330c589bb45e774551d46d415e51cd9ad5116321033b421566c124dfde4db9defe4084b7aa4e7f36744758d92806b8f72c2e943309210353dcc6b4cf6ad28aceb7f7b2db92a4bf07ac42d357adf756f3eca790664314b621037f55980af0455e4fb55aad9b85a55068bb6dc4740ea87276dc693f4598db45fa210384001daa88dabd23db878dbb1ce5b4c2a5fa72c3113e3514bf602325d0c37b8e21039056d089f2fe72dbc0a14780b4635b0dc8a1b40b7a59106325dd1bc45cc70493210397ab8ea7b0bf85bc7fc56bb27bf85e75502e94e76a6781c409f3f2ec3d1122192103b00e3b5b77884bf3cae204c4b4eac003601da75f96982ffcb3dcb29c5ee419b92103c1f3c0874cfe34b8131af34699589aacec4093399739ae352e8a46f80a6f68375fae"
  ],
  "dynamic_parameters": {
    "current": {
      "signblockscript": "0020e51211e91d9cf4aec3bdc370a0303acde5d24baedb12235fdd2786885069d91c",
      "max_block_witness": 1325,
      "fedpegscript": "",
      "extension_space": [
      ]
    },
    "proposed": {
      "signblockscript": "",
      "max_block_witness": 0,
      "fedpegscript": "",
      "extension_space": [
      ]
    }
  },
  "nTx": 1,
  "previousblockhash": "55469a29214ba34ffba4a6a3a0df9ae192a8b71dc1a2fbbe8a6d283515f88974"
}
```

This MR also fixes an identical issue with the `getblock` RPC.

I had to add dedicated logic to parse script witnesses into the human-readable ASM format, since I couldn't find anything in the codebase that would do that already.

It is useful to decode the signblock_witness like this because it allows a user to quickly see the script that the network is currently using for block signing. The actual `signblockscript` field does not tell a user much on its own, since it is just a P2WSH -- the pertinent script is the final item in the witness.
