### PR TITLE
getblockchaininfo: remove incorrect signblock fields

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1444,10 +1444,8 @@ RPCHelpMan getblockchaininfo()
     obj.pushKV("size_on_disk",          CalculateCurrentUsage());
     obj.pushKV("pruned",                fPruneMode);
     if (g_signed_blocks) {
-        CScript sign_block_script = chainparams.GetConsensus().signblockscript;
-        obj.pushKV("signblock_asm", ScriptToAsmStr(sign_block_script));
-        obj.pushKV("signblock_hex", HexStr(sign_block_script));
         if (!IsDynaFedEnabled(::ChainActive().Tip(), chainparams.GetConsensus())) {
+            CScript sign_block_script = chainparams.GetConsensus().signblockscript;
             obj.pushKV("current_signblock_asm", ScriptToAsmStr(sign_block_script));
             obj.pushKV("current_signblock_hex", HexStr(sign_block_script));
             obj.pushKV("max_block_witness", (uint64_t)chainparams.GetConsensus().max_block_signature_size);

--- a/test/functional/feature_blocksign.py
+++ b/test/functional/feature_blocksign.py
@@ -111,7 +111,6 @@ class BlockSignTest(BitcoinTestFramework):
         if is_dyna:
             wsh_wrap = self.nodes[0].decodescript(self.witnessScript)['segwit']['hex']
             assert_equal(wsh_wrap, blockchain_info['current_signblock_hex'])
-            assert blockchain_info['current_signblock_hex'] != blockchain_info['signblock_hex']
 
         # Make a few transactions to make non-empty blocks for compact transmission
         if make_transactions:
@@ -206,10 +205,6 @@ class BlockSignTest(BitcoinTestFramework):
         assert 'signblock_witness_hex' in header
         assert 'signblock_witness_asm' in block
         assert 'signblock_witness_hex' in block
-
-        signblockscript = make_signblockscript(self.num_keys, self.required_signers, self.keys)
-        assert_equal(info['signblock_asm'], self.nodes[0].decodescript(signblockscript)['asm'])
-        assert_equal(info['signblock_hex'], signblockscript)
 
         assert_equal(info['softforks']['dynafed']['bip9']['status'], "defined")
 

--- a/test/functional/feature_dynafed.py
+++ b/test/functional/feature_dynafed.py
@@ -100,7 +100,6 @@ class DynaFedTest(BitcoinTestFramework):
 
             # blocksigner is OP_TRUE, extension space is hardcoded one in chainparams
             signblock_info = self.nodes[i].getblockchaininfo()
-            assert_equal(signblock_info["signblock_hex"], "51")
             assert_equal(signblock_info["current_signblock_hex"], "51")
             assert_equal(signblock_info["max_block_witness"], 74)
             assert_equal(signblock_info["extension_space"], initial_extension)

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -81,8 +81,6 @@ class BlockchainTest(BitcoinTestFramework):
             'max_block_witness',
             'mediantime',
             'pruned',
-            'signblock_asm',
-            'signblock_hex',
             'size_on_disk',
             'softforks',
             'verificationprogress',


### PR DESCRIPTION
Fixes https://github.com/ElementsProject/elements/issues/1109.

To summarize, there are currently two similar sets of fields in the `getblockchaininfo` RPC response which purport to describe the network's current blocksigning script:

```
$ elements-cli getblockchaininfo
{
  "chain": "liquidv1",
  "blocks": 1808648,
  ...
  "signblock_asm": "11 026a2a106ec32c8a1e8052e5d02a7b0a150423dbd9b116fc48d46630ff6e6a05b9 02791646a8b49c2740352b4495c118d876347bf47d0551c01c4332fdc2df526f1a 02888bda53a424466b0451627df22090143bbf7c060e9eacb1e38426f6b07f2ae1 02aee8967150dee220f613de3b239320355a498808084a93eaf39a34dcd6202485 02d46e9259d0a0bb2bcbc461a3e68f34adca27b8d08fbe985853992b4b104e2741 02e9944e35e5750ab621e098145b8e6cf373c273b7c04747d1aa020be0af40ccd6 02f9a9d4b10a6d6c56d8c955c547330c589bb45e774551d46d415e51cd9ad51163 033b421566c124dfde4db9defe4084b7aa4e7f36744758d92806b8f72c2e943309 0353dcc6b4cf6ad28aceb7f7b2db92a4bf07ac42d357adf756f3eca790664314b6 037f55980af0455e4fb55aad9b85a55068bb6dc4740ea87276dc693f4598db45fa 0384001daa88dabd23db878dbb1ce5b4c2a5fa72c3113e3514bf602325d0c37b8e 039056d089f2fe72dbc0a14780b4635b0dc8a1b40b7a59106325dd1bc45cc70493 0397ab8ea7b0bf85bc7fc56bb27bf85e75502e94e76a6781c409f3f2ec3d112219 03b00e3b5b77884bf3cae204c4b4eac003601da75f96982ffcb3dcb29c5ee419b9 03c1f3c0874cfe34b8131af34699589aacec4093399739ae352e8a46f80a6f6837 15 OP_CHECKMULTISIG",
  "signblock_hex": "5b21026a2a106ec32c8a1e8052e5d02a7b0a150423dbd9b116fc48d46630ff6e6a05b92102791646a8b49c2740352b4495c118d876347bf47d0551c01c4332fdc2df526f1a2102888bda53a424466b0451627df22090143bbf7c060e9eacb1e38426f6b07f2ae12102aee8967150dee220f613de3b239320355a498808084a93eaf39a34dcd62024852102d46e9259d0a0bb2bcbc461a3e68f34adca27b8d08fbe985853992b4b104e27412102e9944e35e5750ab621e098145b8e6cf373c273b7c04747d1aa020be0af40ccd62102f9a9d4b10a6d6c56d8c955c547330c589bb45e774551d46d415e51cd9ad5116321033b421566c124dfde4db9defe4084b7aa4e7f36744758d92806b8f72c2e943309210353dcc6b4cf6ad28aceb7f7b2db92a4bf07ac42d357adf756f3eca790664314b621037f55980af0455e4fb55aad9b85a55068bb6dc4740ea87276dc693f4598db45fa210384001daa88dabd23db878dbb1ce5b4c2a5fa72c3113e3514bf602325d0c37b8e21039056d089f2fe72dbc0a14780b4635b0dc8a1b40b7a59106325dd1bc45cc70493210397ab8ea7b0bf85bc7fc56bb27bf85e75502e94e76a6781c409f3f2ec3d1122192103b00e3b5b77884bf3cae204c4b4eac003601da75f96982ffcb3dcb29c5ee419b92103c1f3c0874cfe34b8131af34699589aacec4093399739ae352e8a46f80a6f68375fae",
  ...
  "current_signblock_asm": "0 e51211e91d9cf4aec3bdc370a0303acde5d24baedb12235fdd2786885069d91c",
  "current_signblock_hex": "0020e51211e91d9cf4aec3bdc370a0303acde5d24baedb12235fdd2786885069d91c",
  ...
}
```

The `signblock_asm`/`signblock_hex` fields only display the initial blocksigning script that was used at the time of network genesis. On the other hand, the `current_signblock_asm`/`current_signblock_hex` fields actually show the blocksigning script that is currently being used on the network, and these values change as expected following dynafed transitions.

The `signblock_asm`/`signblock_hex` fields are currently misleading, and they will become entirely incorrect following future dynafed transitions that modify the `signblockscript`.

I have considered the following options:
* Rename these fields to `initial_signblock_asm`/`initial_signblock_hex`
* Remove the fields entirely

In this PR I have removed them entirely, because I don't think they serve any use. However, this will be a breaking change. As such, I am also open to simply renaming them.