### PR TITLE
Add a failing test case for reissuance from an unblinded output (#259)

### DIFF
--- a/test/functional/feature_issuance.py
+++ b/test/functional/feature_issuance.py
@@ -500,5 +500,14 @@ class IssuanceTest(BitcoinTestFramework):
         txid = self.nodes[1].issueasset(0, 1, False)["txid"]
         tx = self.nodes[1].getrawtransaction(txid, True)
 
+        # Test reissuing with a reissuance token spent from an unblinded output
+        # https://github.com/ElementsProject/elements/issues/259
+        issued = self.nodes[0].issueasset(0, Decimal('0.00000001'), False)
+        # Get a non-confidential address and send the (only) reissuance token to it
+        uc_addr = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())["unconfidential"]
+        self.nodes[0].sendtoaddress(uc_addr, Decimal('0.00000001'), "", "", False, False, 1, "UNSET", False, issued["token"])
+        # This currently fails with 'JSONRPCException: Unable to blind the transaction properly. This should not happen. (-4)'
+        self.nodes[0].reissueasset(issued["asset"], 1)
+
 if __name__ == '__main__':
     IssuanceTest ().main ()


### PR DESCRIPTION
A failing test case for #259.

@instagibbs [mentioned](https://github.com/ElementsProject/elements/issues/259#issuecomment-645392524) that it would be good to have a test for this, hopefully this might nudge someone to give this issue some more thought :-)

(To give some context, I ran into this while experimenting with 'scripted assets', where the reissuance token is under an 'anyone can spend if you follow the rules' covenant rather than managed by an issuing entity. It seems that not blinding the token makes more sense for this use-case?)