### PR TITLE
Fix tarball names in guix and gitian builds

### DIFF
--- a/contrib/gitian-descriptors/assign_DISTNAME
+++ b/contrib/gitian-descriptors/assign_DISTNAME
@@ -5,6 +5,7 @@
 # A helper script to be sourced into the gitian descriptors
 
 if RECENT_TAG="$(git describe --exact-match HEAD 2> /dev/null)"; then
+    RECENT_TAG="${RECENT_TAG#elements-}"
     VERSION="${RECENT_TAG#v}"
 else
     VERSION="$(git rev-parse --short=12 HEAD)"

--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -50,7 +50,7 @@ fi
 ################
 
 VERSION="${VERSION:-$(git_head_version)}"
-DISTNAME="${DISTNAME:-bitcoin-${VERSION}}"
+DISTNAME="${DISTNAME:-elements-${VERSION}}"
 
 version_base_prefix="${PWD}/guix-build-"
 VERSION_BASE="${version_base_prefix}${VERSION}"  # TOP

--- a/contrib/shell/git-utils.bash
+++ b/contrib/shell/git-utils.bash
@@ -7,6 +7,7 @@ git_root() {
 git_head_version() {
     local recent_tag
     if recent_tag="$(git describe --exact-match HEAD 2> /dev/null)"; then
+        recent_tag="${recent_tag#elements-}"
         echo "${recent_tag#v}"
     else
         git rev-parse --short=12 HEAD


### PR DESCRIPTION
guix builds are still named `bitcoin-` instead of `elements-`, which is fixed by this PR.

Also, since 21 we've had a problem that our tagged builds are named `elements-elements.....` due to the way we tag, this PR also fixes that for both guix and gitian