### PR TITLE
Fix elements naming in gitian builds

### DIFF
--- a/contrib/gitian-descriptors/assign_DISTNAME
+++ b/contrib/gitian-descriptors/assign_DISTNAME
@@ -5,6 +5,7 @@
 # A helper script to be sourced into the gitian descriptors
 
 if RECENT_TAG="$(git describe --exact-match HEAD)"; then
+    RECENT_TAG="${RECENT_TAG#elements-}"
     VERSION="${RECENT_TAG#v}"
 else
     VERSION="$(git rev-parse --short=12 HEAD)"


### PR DESCRIPTION
Currently, our gitian builds for releases generate tarballs called `elements-elements-xxxxx` instead of `elements-xxxxx`. This is fixed by correctly trimming the `elements-` prefix in our release tags (just as bitcoin trims the initial `v`)