### PR TITLE
Fix Icon position in dmg

### DIFF
--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -536,7 +536,7 @@ ds['.']['icvp'] = icvp
 ds['.']['vSrn'] = ('long', 1)
 
 ds['Applications']['Iloc'] = (370, 156)
-ds['Bitcoin-Qt.app']['Iloc'] = (128, 156)
+ds['Elements-Qt.app']['Iloc'] = (128, 156)
 
 ds.flush()
 ds.close()


### PR DESCRIPTION
Mac installer is showing the elements icon in a bad position 
![image](https://user-images.githubusercontent.com/12950210/184251990-2496a5fc-de3a-450f-88d7-bce4188224f2.png)

This small fix puts it back where it should be 
![image](https://user-images.githubusercontent.com/12950210/184252039-0455a9ce-39f8-44cf-8d78-e8b1669e15e3.png)

