### PR TITLE
Elements-qt: Fix arrows to increase/decrease Amount

### DIFF
--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -121,7 +121,7 @@ public:
                 currentSingleStep = 100000000;  // a whole asset
             }
         }
-        val.second = val.second + steps * singleStep;
+        val.second = val.second + steps * currentSingleStep;
         val.second = qMax(val.second, CAmount(0));
         val.second = qBound(m_min_amount, val.second, m_max_amount);
         // FIXME: Add this back in when assets can have > MAX_MONEY


### PR DESCRIPTION
Fixes: #1144

The problem was that Elements uses different defaults for the "step" between coins and assets, but these defaults were ignored after calculation.

This PR just uses the right variable for the step calculation.