### PR TITLE
pset: Add input explicit value, assets, and proofs, and issuance blinding flag

### DIFF
--- a/doc/pset.mediawiki
+++ b/doc/pset.mediawiki
@@ -295,6 +295,16 @@ The currently defined elements per-input proprietary types are as follows:
 |
 | 0
 | 2
+|-
+| Blinded Issuance Flag
+| <tt>PSBT_ELEMENTS_IN_BLINDED_ISSUANCE = 0x15</tt>
+| None
+| No key data
+| <tt><1 byte boolean></tt>
+| A boolean flag. <tt>0x00</tt> indicates the issuance should not be blinded, <tt>0x01</tt> indicates it should be. If not specified, assumed to be <tt>0x01</tt>. Note that this does not indicate actual blinding status, but rather the expected blinding status prior to signing.
+|
+| 0
+| 2
 |}
 
 The currently defined elements per-output proprietary types are as follows:

--- a/doc/pset.mediawiki
+++ b/doc/pset.mediawiki
@@ -255,6 +255,46 @@ The currently defined elements per-input proprietary types are as follows:
 |
 | 0
 | 2
+|-
+| Explicit Value
+| <tt>PSBT_ELEMENTS_IN_EXPLICIT_VALUE = 0x11</tt>
+| None
+| No key data
+| <tt><64-bit little endian int value></tt>
+| The explicit value for the input being spent. If provided, <tt>PSBT_ELEMENTS_IN_VALUE_PROOF</tt> must be provided too. Must not be provided if the input's value in the UTXO is already explicit.
+|
+| 0
+| 2
+|-
+| Explicit Value Proof
+| <tt>PSBT_ELEMENTS_IN_VALUE_PROOF = 0x12</tt>
+| None
+| No key data
+| <tt><rangeproof></tt>
+| An explicit value rangeproof that proves that the value commitment in this input's UTXO matches the explicit value in <tt>PSBT_ELEMENTS_IN_EXPLICIT_VALUE</tt>. If provided, <tt>PSBT_ELEMENTS_IN_EXPLICIT_VALUE</tt> must be provided too.
+|
+| 0
+| 2
+|-
+| Explicit Asset
+| <tt>PSBT_ELEMENTS_IN_EXPLICIT_ASSET = 0x13</tt>
+| None
+| No key data
+| <tt><32 byte asset tag></tt>
+| The explicit asset for the input being spent. If provided, <tt>PSBT_ELEMENTS_IN_ASSET_PROOF</tt> must be provided too. Must not be provided if the input's asset in the UTXO is already explicit.
+|
+| 0
+| 2
+|-
+| Explicit Asset Proof
+| <tt>PSBT_ELEMENTS_IN_ASSET_PROOF = 0x14</tt>
+| None
+| No key data
+| <tt><proof></tt>
+| An asset surjection proof with this input's asset as the only asset in the input set in order to prove that the asset commitment in the UTXO matches the explicit asset in <tt>PSBT_ELEMENTS_IN_EXPLICIT_ASSET</tt>. If provided, <tt>PSBT_ELEMENTS_IN_EXPLICIT_ASSET</tt> must be provided too.
+|
+| 0
+| 2
 |}
 
 The currently defined elements per-output proprietary types are as follows:

--- a/src/blindpsbt.cpp
+++ b/src/blindpsbt.cpp
@@ -415,7 +415,8 @@ BlindingStatus BlindPSBT(PartiallySignedTransaction& psbt, std::map<uint32_t, st
         }
 
         // Handle issuances
-        if (input.m_issuance_value != std::nullopt || input.m_issuance_value_commitment.IsCommitment() || input.m_issuance_inflation_keys_amount != std::nullopt || input.m_issuance_inflation_keys_commitment.IsCommitment()) {
+        if ((!input.m_blinded_issuance.has_value() || input.m_blinded_issuance.value()) &&
+            (input.m_issuance_value != std::nullopt || input.m_issuance_value_commitment.IsCommitment() || input.m_issuance_inflation_keys_amount != std::nullopt || input.m_issuance_inflation_keys_commitment.IsCommitment())) {
             CAsset issuance_asset;
             CAsset reissuance_asset;
 

--- a/src/blindpsbt.h
+++ b/src/blindpsbt.h
@@ -17,6 +17,7 @@
 
 struct PartiallySignedTransaction;
 struct PSBTOutput;
+struct PSBTInput;
 
 enum class BlindingStatus
 {
@@ -52,5 +53,6 @@ BlindingStatus BlindPSBT(PartiallySignedTransaction& psbt, std::map<uint32_t, st
 bool VerifyBlindValueProof(CAmount value, const CConfidentialValue& conf_value, const std::vector<unsigned char>& proof, const CConfidentialAsset& conf_asset);
 bool VerifyBlindAssetProof(const uint256& asset, const std::vector<unsigned char>& proof, const CConfidentialAsset& conf_asset);
 BlindProofResult VerifyBlindProofs(const PSBTOutput& o);
+BlindProofResult VerifyBlindProofs(const PSBTInput& i);
 
 #endif //BITCOIN_BLINDPSBT_H

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -77,6 +77,7 @@ static constexpr uint8_t PSBT_ELEMENTS_IN_EXPLICIT_VALUE = 0x11;
 static constexpr uint8_t PSBT_ELEMENTS_IN_VALUE_PROOF = 0x12;
 static constexpr uint8_t PSBT_ELEMENTS_IN_EXPLICIT_ASSET = 0x13;
 static constexpr uint8_t PSBT_ELEMENTS_IN_ASSET_PROOF = 0x14;
+static constexpr uint8_t PSBT_ELEMENTS_IN_BLINDED_ISSUANCE = 0x15;
 
 // Output types
 static constexpr uint8_t PSBT_OUT_REDEEMSCRIPT = 0x00;
@@ -252,6 +253,7 @@ struct PSBTInput
     uint256 m_issuance_asset_entropy;
     std::vector<unsigned char> m_blind_issuance_value_proof;
     std::vector<unsigned char> m_blind_issuance_inflation_keys_proof;
+    std::optional<bool> m_blinded_issuance;
 
     // Peg-in
     std::variant<std::monostate, Sidechain::Bitcoin::CTransactionRef, CTransactionRef> m_peg_in_tx;
@@ -500,6 +502,11 @@ struct PSBTInput
             if (!m_asset_proof.empty()) {
                 SerializeToVector(s, CompactSizeWriter(PSBT_IN_PROPRIETARY), PSBT_ELEMENTS_ID, CompactSizeWriter(PSBT_ELEMENTS_IN_ASSET_PROOF));
                 s << m_asset_proof;
+            }
+
+            if (m_blinded_issuance.has_value()) {
+                SerializeToVector(s, CompactSizeWriter(PSBT_IN_PROPRIETARY), PSBT_ELEMENTS_ID, CompactSizeWriter(PSBT_ELEMENTS_IN_BLINDED_ISSUANCE));
+                SerializeToVector(s, *m_blinded_issuance);
             }
         }
 
@@ -954,6 +961,18 @@ struct PSBTInput
                                     throw std::ios_base::failure("Input explicit asset proof is more than one byte type");
                                 }
                                 s >> m_value_proof;
+                                break;
+                            }
+                            case PSBT_ELEMENTS_IN_BLINDED_ISSUANCE:
+                            {
+                                if (!key_lookup.emplace(key).second) {
+                                    throw std::ios_base::failure("Duplicate Key, issuance needs blinded flag is already provided");
+                                } else if (key.size() != 1) {
+                                    throw std::ios_base::failure("Input issuance needs blinded flag is more than one byte type");
+                                }
+                                bool b;
+                                UnserializeFromVector(s, b);
+                                m_blinded_issuance = b;
                                 break;
                             }
                             default:

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -73,6 +73,10 @@ static constexpr uint8_t PSBT_ELEMENTS_IN_ISSUANCE_ASSET_ENTROPY = 0x0d;
 static constexpr uint8_t PSBT_ELEMENTS_IN_UTXO_RANGEPROOF = 0x0e;
 static constexpr uint8_t PSBT_ELEMENTS_IN_ISSUANCE_BLIND_VALUE_PROOF = 0x0f;
 static constexpr uint8_t PSBT_ELEMENTS_IN_ISSUANCE_BLIND_INFLATION_KEYS_PROOF = 0x10;
+static constexpr uint8_t PSBT_ELEMENTS_IN_EXPLICIT_VALUE = 0x11;
+static constexpr uint8_t PSBT_ELEMENTS_IN_VALUE_PROOF = 0x12;
+static constexpr uint8_t PSBT_ELEMENTS_IN_EXPLICIT_ASSET = 0x13;
+static constexpr uint8_t PSBT_ELEMENTS_IN_ASSET_PROOF = 0x14;
 
 // Output types
 static constexpr uint8_t PSBT_OUT_REDEEMSCRIPT = 0x00;
@@ -259,6 +263,10 @@ struct PSBTInput
 
     // Auxiliary elements stuff
     std::vector<unsigned char> m_utxo_rangeproof;
+    std::optional<CAmount> m_explicit_value;
+    std::vector<unsigned char> m_value_proof;
+    uint256 m_explicit_asset;
+    std::vector<unsigned char> m_asset_proof;
 
     bool IsNull() const;
     void FillSignatureData(SignatureData& sigdata) const;
@@ -472,6 +480,26 @@ struct PSBTInput
             if (!m_blind_issuance_inflation_keys_proof.empty()) {
                 SerializeToVector(s, CompactSizeWriter(PSBT_OUT_PROPRIETARY), PSBT_ELEMENTS_ID, CompactSizeWriter(PSBT_ELEMENTS_IN_ISSUANCE_BLIND_INFLATION_KEYS_PROOF));
                 s << m_blind_issuance_inflation_keys_proof;
+            }
+
+            // Explicit value and its proof
+            if (m_explicit_value.has_value()) {
+                SerializeToVector(s, CompactSizeWriter(PSBT_IN_PROPRIETARY), PSBT_ELEMENTS_ID, CompactSizeWriter(PSBT_ELEMENTS_IN_EXPLICIT_VALUE));
+                SerializeToVector(s, m_explicit_value.value());
+            }
+            if (!m_value_proof.empty()) {
+                SerializeToVector(s, CompactSizeWriter(PSBT_IN_PROPRIETARY), PSBT_ELEMENTS_ID, CompactSizeWriter(PSBT_ELEMENTS_IN_VALUE_PROOF));
+                s << m_value_proof;
+            }
+
+            // Explicit asset and its proof
+            if (!m_explicit_asset.IsNull()) {
+                SerializeToVector(s, CompactSizeWriter(PSBT_IN_PROPRIETARY), PSBT_ELEMENTS_ID, CompactSizeWriter(PSBT_ELEMENTS_IN_EXPLICIT_ASSET));
+                SerializeToVector(s, m_explicit_asset);
+            }
+            if (!m_asset_proof.empty()) {
+                SerializeToVector(s, CompactSizeWriter(PSBT_IN_PROPRIETARY), PSBT_ELEMENTS_ID, CompactSizeWriter(PSBT_ELEMENTS_IN_ASSET_PROOF));
+                s << m_asset_proof;
             }
         }
 
@@ -886,6 +914,48 @@ struct PSBTInput
                                 s >> m_blind_issuance_inflation_keys_proof;
                                 break;
                             }
+                            case PSBT_ELEMENTS_IN_EXPLICIT_VALUE:
+                            {
+                                if (!key_lookup.emplace(key).second) {
+                                    throw std::ios_base::failure("Duplicate Key, explicit value is already provided");
+                                } else if (key.size() != 1) {
+                                    throw std::ios_base::failure("Input explicit value is more than one byte type");
+                                }
+                                CAmount v;
+                                UnserializeFromVector(s, v);
+                                m_explicit_value = v;
+                                break;
+                            }
+                            case PSBT_ELEMENTS_IN_VALUE_PROOF:
+                            {
+                                if (!key_lookup.emplace(key).second) {
+                                    throw std::ios_base::failure("Duplicate Key, explicit value proof is already provided");
+                                } else if (key.size() != 1) {
+                                    throw std::ios_base::failure("Input explicit value proof is more than one byte type");
+                                }
+                                s >> m_value_proof;
+                                break;
+                            }
+                            case PSBT_ELEMENTS_IN_EXPLICIT_ASSET:
+                            {
+                                if (!key_lookup.emplace(key).second) {
+                                    throw std::ios_base::failure("Duplicate Key, explicit asset is already provided");
+                                } else if (key.size() != 1) {
+                                    throw std::ios_base::failure("Input explicit asset is more than one byte type");
+                                }
+                                UnserializeFromVector(s, m_explicit_asset);
+                                break;
+                            }
+                            case PSBT_ELEMENTS_IN_ASSET_PROOF:
+                            {
+                                if (!key_lookup.emplace(key).second) {
+                                    throw std::ios_base::failure("Duplicate Key, explicit asset proof is already provided");
+                                } else if (key.size() != 1) {
+                                    throw std::ios_base::failure("Input explicit asset proof is more than one byte type");
+                                }
+                                s >> m_value_proof;
+                                break;
+                            }
                             default:
                             {
                                 known = false;
@@ -935,6 +1005,12 @@ struct PSBTInput
             }
             if (!m_issuance_inflation_keys_commitment.IsNull() && m_issuance_inflation_keys_rangeproof.empty()) {
                 throw std::ios_base::failure("Issuance inflation keys commitment provided without inflation keys rangeproof");
+            }
+            if ((m_explicit_value.has_value() || !m_value_proof.empty()) && (!m_explicit_value.has_value() || m_value_proof.empty())) {
+                throw std::ios_base::failure("Input explicit value and value proof must be provided together");
+            }
+            if ((!m_explicit_asset.IsNull() || !m_asset_proof.empty()) && (!m_explicit_asset.IsNull() || m_asset_proof.empty())) {
+                throw std::ios_base::failure("Input explicit asset and asset proof must be provided together");
             }
         }
     }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1218,6 +1218,7 @@ static RPCHelpMan decodepsbt()
                                 {RPCResult::Type::STR_HEX, "value_proof", /*optional=*/true, "The explicit value proof for this input"},
                                 {RPCResult::Type::STR_HEX, "explicit_asset", /*optional=*/true, "The explicit asset for this input"},
                                 {RPCResult::Type::STR_HEX, "asset_proof", /*optional=*/true, "The explicit asset proof for this input"},
+                                {RPCResult::Type::BOOL, "blinded_issuance", /*optional=*/true, "Whether the issuance should be blinded prior to signing"},
                                 {RPCResult::Type::OBJ_DYN, "unknown", "The unknown global fields",
                                 {
                                     {RPCResult::Type::STR_HEX, "key", "(key-value pair) An unknown key-value pair"},
@@ -1611,6 +1612,10 @@ static RPCHelpMan decodepsbt()
         }
         if (!input.m_asset_proof.empty()) {
             in.pushKV("asset_proof", HexStr(input.m_asset_proof));
+        }
+
+        if (input.m_blinded_issuance.has_value()) {
+            in.pushKV("blinded_issuance", *input.m_blinded_issuance);
         }
 
         switch (VerifyBlindProofs(input)) {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1214,6 +1214,10 @@ static RPCHelpMan decodepsbt()
                                     {RPCResult::Type::STR_HEX, "", "hex-encoded witness data (if any)"},
                                 }},
                                 {RPCResult::Type::STR_HEX, "utxo_rangeproof", "The rangeproof for the UTXO"},
+                                {RPCResult::Type::NUM, "explicit_value", /*optional=*/true, "The explicit value for this input"},
+                                {RPCResult::Type::STR_HEX, "value_proof", /*optional=*/true, "The explicit value proof for this input"},
+                                {RPCResult::Type::STR_HEX, "explicit_asset", /*optional=*/true, "The explicit asset for this input"},
+                                {RPCResult::Type::STR_HEX, "asset_proof", /*optional=*/true, "The explicit asset proof for this input"},
                                 {RPCResult::Type::OBJ_DYN, "unknown", "The unknown global fields",
                                 {
                                     {RPCResult::Type::STR_HEX, "key", "(key-value pair) An unknown key-value pair"},
@@ -1595,6 +1599,41 @@ static RPCHelpMan decodepsbt()
         if (!input.m_utxo_rangeproof.empty()) {
             in.pushKV("utxo_rangeproof", HexStr(input.m_utxo_rangeproof));
         }
+
+        if (input.m_explicit_value.has_value()) {
+            in.pushKV("explicit_value", ValueFromAmount(*input.m_explicit_value));
+        }
+        if (!input.m_value_proof.empty()) {
+            in.pushKV("value_proof", HexStr(input.m_value_proof));
+        }
+        if (!input.m_explicit_asset.IsNull()) {
+            in.pushKV("explicit_asset", input.m_explicit_asset.GetHex());
+        }
+        if (!input.m_asset_proof.empty()) {
+            in.pushKV("asset_proof", HexStr(input.m_asset_proof));
+        }
+
+        switch (VerifyBlindProofs(input)) {
+        case BlindProofResult::OK:
+            // all good
+            break;
+        case BlindProofResult::NOT_FULLY_BLINDED:
+            in.pushKV("status", "ERROR: Proofs provided for unblinded input");
+            break;
+        case BlindProofResult::MISSING_VALUE_PROOF:
+            in.pushKV("status", "WARNING: has confidential and explicit values but no proof connecting them");
+            break;
+        case BlindProofResult::MISSING_ASSET_PROOF:
+            in.pushKV("status", "WARNING: has confidential and explicit assets but no proof connecting them");
+            break;
+        case BlindProofResult::INVALID_VALUE_PROOF:
+            in.pushKV("status", "ERROR: has invalid value proof, the value may be a lie!");
+            break;
+        case BlindProofResult::INVALID_ASSET_PROOF:
+            in.pushKV("status", "ERROR: has invalid asset proof, the asset may be a lie!");
+            break;
+        }
+
 
         // Proprietary
         if (!input.m_proprietary.empty()) {


### PR DESCRIPTION
Adds fields for explicit input value and assets, and their proofs. Also adds a flag to indicate whether an issuance should be blinded.

Closes #1153