### PR TITLE
Add more CPUs to the fuzzer test

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -159,7 +159,7 @@ task:
   << : *GLOBAL_TASK_TEMPLATE
   container:
     image: ubuntu:focal
-    cpu: 4  # Increase CPU and memory to avoid timeout
+    cpu: 8  # Increase CPU and memory to avoid timeout
     memory: 16G
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV


### PR DESCRIPTION
Currently fuzzer test fails due to the 120 minute timeout, add some CPUs to avoid that