### PR TITLE
rpc: decodepsbt: fix check for blind_reissuance_amount_proof output

### DIFF
--- a/src/blindpsbt.cpp
+++ b/src/blindpsbt.cpp
@@ -175,6 +175,10 @@ static bool CreateBlindAssetProof(std::vector<unsigned char>& assetproof, const 
 
 bool VerifyBlindValueProof(CAmount value, const CConfidentialValue& conf_value, const std::vector<unsigned char>& proof, const CConfidentialAsset& conf_asset)
 {
+    if (conf_value.IsNull() || conf_asset.IsNull()) {
+        return false;
+    }
+
     secp256k1_pedersen_commitment value_commit;
     if (secp256k1_pedersen_commitment_parse(secp256k1_blind_context, &value_commit, conf_value.vchCommitment.data()) == 0) {
         return false;

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1530,7 +1530,7 @@ static RPCHelpMan decodepsbt()
         }
 
         // Issuance blind inflation keys value proof
-        if (!input.m_blind_issuance_value_proof.empty()) {
+        if (!input.m_blind_issuance_inflation_keys_proof.empty()) {
             in.pushKV("blind_reissuance_amount_proof", HexStr(input.m_blind_issuance_inflation_keys_proof));
         }
 


### PR DESCRIPTION
Also make sure value rangeproof generation fails if its asset commitment isn't provided.