### PR TITLE
Preserve blinding key when parsing taproot address.

### DIFF
--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -323,6 +323,7 @@ CTxDestination DecodeDestination(const std::string& str, const CChainParams& par
                 static_assert(WITNESS_V1_TAPROOT_SIZE == WitnessV1Taproot::size());
                 WitnessV1Taproot tap;
                 std::copy(data.begin(), data.end(), tap.begin());
+                tap.blinding_pubkey = blinding_pubkey;
                 return tap;
             }
 

--- a/test/functional/wallet_address_types.py
+++ b/test/functional/wallet_address_types.py
@@ -398,5 +398,13 @@ class AddressTypeTest(BitcoinTestFramework):
         info2 = self.nodes[0].getaddressinfo(self.nodes[0].getrawchangeaddress("blech32"))
         assert(len(info2["confidential_key"]) > 0)
 
+        # taproot (segwit v1) address parsing test
+        # We will use a hardcoded placeholder for now, until we can have the test use the wallet to generate one.
+        # This functions as a regression test for #1181.
+        tap_addr = "el1pqwp9ze75659cn5ad0hw25nt2kv7j882gudn636hnh4qvjcmjh6jq5ca0d4cgl009m5rn5w0n3k2cqa3ths2qf7s8q6x2xplwgvlfhg0atxwjah9089tf"
+        info3 = self.nodes[0].getaddressinfo(tap_addr)
+        assert_equal(tap_addr, info3["address"])
+        assert(len(info3["confidential_key"]) > 0)
+
 if __name__ == '__main__':
     AddressTypeTest().main()


### PR DESCRIPTION
Fixes #1181 . 