### PR TITLE
Improve elements memory usage

### DIFF
--- a/src/block_proof.cpp
+++ b/src/block_proof.cpp
@@ -13,7 +13,7 @@
 bool CheckChallenge(const CBlockHeader& block, const CBlockIndex& indexLast, const Consensus::Params& params)
 {
     if (g_signed_blocks) {
-        return block.proof.challenge == indexLast.proof.challenge;
+        return block.proof.challenge == indexLast.get_proof().challenge;
     } else {
         return block.nBits == GetNextWorkRequired(&indexLast, &block, params);
     }

--- a/src/chain.h
+++ b/src/chain.h
@@ -446,11 +446,14 @@ public:
         READWRITE(obj.hashPrev);
         READWRITE(obj.hashMerkleRoot);
         READWRITE(obj.nTime);
+
+        // Allocate objects in the optional<> fields when reading, since READWRITE will not do this
+        SER_READ(obj, obj.m_dynafed_params = DynaFedParams());
+        SER_READ(obj, obj.m_signblock_witness = CScriptWitness());
+        SER_READ(obj, obj.proof = CProof());
+
         // For compatibility with elements 0.14 based chains
         if (g_signed_blocks) {
-            SER_READ(obj, obj.m_dynafed_params = DynaFedParams());
-            SER_READ(obj, obj.m_signblock_witness = CScriptWitness());
-            SER_READ(obj, obj.proof = CProof());
             if (is_dyna) {
                 READWRITE(obj.m_dynafed_params.value());
                 READWRITE(obj.m_signblock_witness.value().stack);

--- a/src/dynafed.cpp
+++ b/src/dynafed.cpp
@@ -15,7 +15,7 @@ bool NextBlockIsParameterTransition(const CBlockIndex* pindexPrev, const Consens
     for (int32_t height = next_height - 1; height >= (int32_t)(next_height - consensus.dynamic_epoch_length); --height) {
         const CBlockIndex* p_epoch_walk = pindexPrev->GetAncestor(height);
         assert(p_epoch_walk);
-        const DynaFedParamEntry& proposal = p_epoch_walk->dynafed_params.m_proposed;
+        const DynaFedParamEntry& proposal = p_epoch_walk->dynafed_params().m_proposed;
         const uint256 proposal_root = proposal.CalculateRoot();
         vote_tally[proposal_root]++;
         // Short-circuit once 4/5 threshold is reached
@@ -56,13 +56,13 @@ DynaFedParamEntry ComputeNextBlockFullCurrentParameters(const CBlockIndex* pinde
     // may be pre-dynafed params
     const CBlockIndex* p_epoch_start = pindexPrev->GetAncestor(epoch_start_height);
     assert(p_epoch_start);
-    if (p_epoch_start->dynafed_params.IsNull()) {
+    if (p_epoch_start->dynafed_params().IsNull()) {
         // We need to construct the "full" current parameters of pre-dynafed
         // consensus
 
         // Convert signblockscript to P2WSH
         uint256 signblock_witness_program;
-        CSHA256().Write(p_epoch_start->proof.challenge.data(), p_epoch_start->proof.challenge.size()).Finalize(signblock_witness_program.begin());
+        CSHA256().Write(p_epoch_start->get_proof().challenge.data(), p_epoch_start->get_proof().challenge.size()).Finalize(signblock_witness_program.begin());
         CScript p2wsh_signblock_script = CScript() << OP_0 << ToByteVector(signblock_witness_program);
 
         // Make P2SH-P2WSH-ness of non-dynafed fedpegscript explicit
@@ -75,7 +75,7 @@ DynaFedParamEntry ComputeNextBlockFullCurrentParameters(const CBlockIndex* pinde
         // Put them in winning proposal
         winning_proposal = DynaFedParamEntry(p2wsh_signblock_script, consensus.max_block_signature_size, sh_wsh_fedpeg_program, consensus.fedpegScript, consensus.first_extension_space);
     } else {
-        winning_proposal = p_epoch_start->dynafed_params.m_current;
+        winning_proposal = p_epoch_start->dynafed_params().m_current;
     }
     return winning_proposal;
 }
@@ -93,7 +93,7 @@ DynaFedParamEntry ComputeNextBlockCurrentParameters(const CBlockIndex* pindexPre
 
     // Return appropriate format based on epoch age or if we *just* activated
     // dynafed via BIP9
-    if (epoch_age == 0 || pindexPrev->dynafed_params.IsNull()) {
+    if (epoch_age == 0 || pindexPrev->dynafed_params().IsNull()) {
         return entry;
     } else {
         return DynaFedParamEntry(entry.m_signblockscript, entry.m_signblock_witness_limit, entry.CalculateExtraRoot());

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -425,7 +425,7 @@ void SetupServerArgs(ArgsManager& argsman)
     hidden_args.emplace_back("-sysperms");
 #endif
     argsman.AddArg("-txindex", strprintf("Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)", DEFAULT_TXINDEX), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    argsman.AddArg("-trim_headers", strprintf("Trim old headers in memory, removing blocksigning and dynafed-related fields. Saves memory, but blocks us from serving blocks or headers to peers, and removes trimmed fields from some JSON RPC outputs. (default: false)"), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-trim_headers", strprintf("Trim old headers in memory (by default older than 2 epochs), removing blocksigning and dynafed-related fields. Saves memory, but blocks us from serving blocks or headers to peers, and removes trimmed fields from some JSON RPC outputs. (default: false)"), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-blockfilterindex=<type>",
                  strprintf("Maintain an index of compact filters by block (default: %s, values: %s).", DEFAULT_BLOCKFILTERINDEX, ListBlockFilterTypes()) +
                  " If <type> is not supplied or if <type> = 1, indexes for all known types are enabled.",

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -29,7 +29,7 @@
 
 void ResetChallenge(CBlockHeader& block, const CBlockIndex& indexLast, const Consensus::Params& params)
 {
-    block.proof.challenge = indexLast.proof.challenge;
+    block.proof.challenge = indexLast.get_proof().challenge;
 }
 
 void ResetProof(CBlockHeader& block)

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2018,18 +2018,26 @@ void PeerManagerImpl::ProcessHeadersMessage(CNode& pfrom, const Peer& peer,
         uint64_t headers_ahead = pindexBestHeader->nHeight - m_chainman.ActiveHeight();
         bool too_far_ahead = fTrimHeaders && (headers_ahead >= nHeaderDownloadBuffer);
         if (too_far_ahead) {
-            LogPrint(BCLog::NET, "Discarding received headers and pausing header sync from peer=%d, because we are too far ahead of block sync (%d > %d, %d new headers received)\n", pfrom.GetId(), pindexBestHeader->nHeight, m_chainman.ActiveHeight(), nCount);
             LOCK(cs_main);
             CNodeState *nodestate = State(pfrom.GetId());
-            if (nodestate->fSyncStarted) {
-                // Cancel sync from this node, so we don't penalize it later.
-                // This will cause us to automatically start syncing from a different node (or restart syncing from the same node) later,
-                //   if we still need to sync headers.
-                nSyncStarted--;
-                nodestate->fSyncStarted = false;
-                nodestate->m_headers_sync_timeout = 0us;
+            if ((nodestate->pindexBestKnownBlock == nullptr) ||
+                (nodestate->pindexBestKnownBlock->nHeight < m_chainman.ActiveHeight())) {
+                // Our notion of what blocks a peer has available is based on its pindexBestKnownBlock,
+                // which is based on headers recieved from it. If we don't have one, or it's too old,
+                // then we can never get blocks from this peer until we accept headers from it first.
+                LogPrint(BCLog::NET, "NOT discarding headers from peer=%d, to update its block availability. (current best header %d, active chain height %d)\n", pfrom.GetId(), pindexBestHeader->nHeight, m_chainman.ActiveHeight());
+            } else {
+                LogPrint(BCLog::NET, "Discarding received headers and pausing header sync from peer=%d, because we are too far ahead of block sync. (%d > %d)\n", pfrom.GetId(), pindexBestHeader->nHeight, m_chainman.ActiveHeight());
+                if (nodestate->fSyncStarted) {
+                    // Cancel sync from this node, so we don't penalize it later.
+                    // This will cause us to automatically start syncing from a different node (or restart syncing from the same node) later,
+                    //   if we still need to sync headers.
+                    nSyncStarted--;
+                    nodestate->fSyncStarted = false;
+                    nodestate->m_headers_sync_timeout = 0us;
+                }
+                return;
             }
-            return;
         }
     }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -910,6 +910,10 @@ bool PeerManagerImpl::TipMayBeStale()
 
 bool PeerManagerImpl::CanDirectFetch()
 {
+    if(!m_chainman.ActiveChain().Tip()) {
+        LogPrint(BCLog::NET, "Startup crash avoided\n");
+        return false;
+    }
     return m_chainman.ActiveChain().Tip()->GetBlockTime() > GetAdjustedTime() - m_chainparams.GetConsensus().nPowTargetSpacing * 20;
 }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -911,7 +911,7 @@ bool PeerManagerImpl::TipMayBeStale()
 bool PeerManagerImpl::CanDirectFetch()
 {
     if(!m_chainman.ActiveChain().Tip()) {
-        LogPrint(BCLog::NET, "Startup crash avoided\n");
+        LogPrint(BCLog::NET, "Tried to call CanDirectFetch with no currently-active chain.\n");
         return false;
     }
     return m_chainman.ActiveChain().Tip()->GetBlockTime() > GetAdjustedTime() - m_chainparams.GetConsensus().nPowTargetSpacing * 20;

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -412,6 +412,17 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus
     return true;
 }
 
+bool ReadBlockHeaderFromDisk(CBlockHeader& header, const CBlockIndex* pindex, const Consensus::Params& consensusParams)
+{
+    // Not very efficient: read a block and throw away all but the header.
+    CBlock tmp;
+    if (!ReadBlockFromDisk(tmp, pindex, consensusParams)) {
+        return false;
+    }
+    header = tmp.GetBlockHeader();
+    return true;
+}
+
 bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start)
 {
     FlatFilePos hpos = pos;

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -25,6 +25,9 @@ std::atomic_bool fReindex(false);
 bool fHavePruned = false;
 bool fPruneMode = false;
 uint64_t nPruneTarget = 0;
+bool fTrimHeaders = false;
+uint64_t nMustKeepFullHeaders = std::numeric_limits<uint64_t>::max();
+uint64_t nHeaderDownloadBuffer = std::numeric_limits<uint64_t>::max();
 
 // TODO make namespace {
 RecursiveMutex cs_LastBlockFile;

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -44,6 +44,13 @@ extern bool fHavePruned;
 extern bool fPruneMode;
 /** Number of MiB of block files that we're trying to stay below. */
 extern uint64_t nPruneTarget;
+/** True if we're running in -trim_headers mode. */
+extern bool fTrimHeaders;
+/** Minimum number of full untrimmed headers to keep, for blocks we have. */
+extern uint64_t nMustKeepFullHeaders;
+/** Target number of headers to download beyond the blocks we have. */
+// XXX: this currently only operates when in header trim mode, but it's really independent of that.
+extern uint64_t nHeaderDownloadBuffer;
 
 //! Check whether the block associated with this index entry is pruned or not.
 bool IsBlockPruned(const CBlockIndex* pblockindex);

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -49,7 +49,7 @@ extern bool fTrimHeaders;
 /** Minimum number of full untrimmed headers to keep, for blocks we have. */
 extern uint64_t nMustKeepFullHeaders;
 /** Target number of headers to download beyond the blocks we have. */
-// XXX: this currently only operates when in header trim mode, but it's really independent of that.
+// NOTE: this currently only operates when in header trim mode, but it's really independent of that.
 extern uint64_t nHeaderDownloadBuffer;
 
 //! Check whether the block associated with this index entry is pruned or not.
@@ -78,6 +78,8 @@ bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::P
 bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
 bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start);
 bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const CBlockIndex* pindex, const CMessageHeader::MessageStartChars& message_start);
+// ELEMENTS:
+bool ReadBlockHeaderFromDisk(class CBlockHeader& header, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
 
 bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex);
 bool WriteUndoDataForBlock(const CBlockUndo& blockundo, BlockValidationState& state, CBlockIndex* pindex, const CChainParams& chainparams);

--- a/src/pegins.cpp
+++ b/src/pegins.cpp
@@ -487,8 +487,8 @@ std::vector<std::pair<CScript, CScript>> GetValidFedpegScripts(const CBlockIndex
             break;
         }
 
-        if (!p_epoch_start->dynafed_params.IsNull()) {
-            fedpegscripts.push_back(std::make_pair(p_epoch_start->dynafed_params.m_current.m_fedpeg_program, p_epoch_start->dynafed_params.m_current.m_fedpegscript));
+        if (!p_epoch_start->dynafed_params().IsNull()) {
+            fedpegscripts.push_back(std::make_pair(p_epoch_start->dynafed_params().m_current.m_fedpeg_program, p_epoch_start->dynafed_params().m_current.m_fedpegscript));
         } else {
             fedpegscripts.push_back(std::make_pair(GetScriptForDestination(ScriptHash(GetScriptForDestination(WitnessV0ScriptHash(params.fedpegScript)))), params.fedpegScript));
         }

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -221,7 +221,14 @@ static bool rest_headers(const std::any& context,
     case RetFormat::BINARY: {
         CDataStream ssHeader(SER_NETWORK, PROTOCOL_VERSION);
         for (const CBlockIndex *pindex : headers) {
-            ssHeader << pindex->GetBlockHeader();
+            if (pindex->trimmed()) {
+                CBlockHeader tmp;
+                ReadBlockHeaderFromDisk(tmp, pindex, Params().GetConsensus());
+                ssHeader << tmp;
+
+            } else {
+                ssHeader << pindex->GetBlockHeader();
+            }
         }
 
         std::string binaryHeader = ssHeader.str();
@@ -233,8 +240,14 @@ static bool rest_headers(const std::any& context,
     case RetFormat::HEX: {
         CDataStream ssHeader(SER_NETWORK, PROTOCOL_VERSION);
         for (const CBlockIndex *pindex : headers) {
-            ssHeader << pindex->GetBlockHeader();
-        }
+            if (pindex->trimmed()) {
+                CBlockHeader tmp;
+                ReadBlockHeaderFromDisk(tmp, pindex, Params().GetConsensus());
+                ssHeader << tmp;
+
+            } else {
+                ssHeader << pindex->GetBlockHeader();
+            }        }
 
         std::string strHex = HexStr(ssHeader) + "\n";
         req->WriteHeader("Content-Type", "text/plain");

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -225,7 +225,6 @@ static bool rest_headers(const std::any& context,
                 CBlockHeader tmp;
                 ReadBlockHeaderFromDisk(tmp, pindex, Params().GetConsensus());
                 ssHeader << tmp;
-
             } else {
                 ssHeader << pindex->GetBlockHeader();
             }
@@ -247,7 +246,8 @@ static bool rest_headers(const std::any& context,
 
             } else {
                 ssHeader << pindex->GetBlockHeader();
-            }        }
+            }
+        }
 
         std::string strHex = HexStr(ssHeader) + "\n";
         req->WriteHeader("Content-Type", "text/plain");

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -249,12 +249,25 @@ UniValue blockheaderToJSON(const CBlockIndex* tip, const CBlockIndex* blockindex
         result.pushKV("chainwork", blockindex->nChainWork.GetHex());
     } else {
         if (blockindex->dynafed_params().IsNull()) {
-            result.pushKV("signblock_witness_asm", ScriptToAsmStr(blockindex->get_proof().solution));
-            result.pushKV("signblock_witness_hex", HexStr(blockindex->get_proof().solution));
-            result.pushKV("signblock_challenge", HexStr(blockindex->get_proof().challenge));
+            if (blockindex->trimmed()) {
+                result.pushKV("signblock_witness_asm", "<trimmed>");
+                result.pushKV("signblock_witness_hex", "<trimmed>");
+                result.pushKV("signblock_challenge", "<trimmed>");
+                result.pushKV("warning", "Fields missing due to -trim_headers flag.");
+            } else {
+                result.pushKV("signblock_witness_asm", ScriptToAsmStr(blockindex->get_proof().solution));
+                result.pushKV("signblock_witness_hex", HexStr(blockindex->get_proof().solution));
+                result.pushKV("signblock_challenge", HexStr(blockindex->get_proof().challenge));
+            }
         } else {
-            result.pushKV("signblock_witness_hex", EncodeHexScriptWitness(blockindex->signblock_witness()));
-            result.pushKV("dynamic_parameters", dynaParamsToJSON(blockindex->dynafed_params()));
+            if (blockindex->trimmed()) {
+                result.pushKV("signblock_witness_hex", "<trimmed>");
+                result.pushKV("dynamic_parameters", "<trimmed>");
+                result.pushKV("warning", "Fields missing due to -trim_headers flag.");
+            } else {
+                result.pushKV("signblock_witness_hex", EncodeHexScriptWitness(blockindex->signblock_witness()));
+                result.pushKV("dynamic_parameters", dynaParamsToJSON(blockindex->dynafed_params()));
+            }
         }
     }
     result.pushKV("nTx", (uint64_t)blockindex->nTx);
@@ -267,7 +280,13 @@ UniValue blockheaderToJSON(const CBlockIndex* tip, const CBlockIndex* blockindex
 
 UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIndex* blockindex, bool txDetails)
 {
-    UniValue result = blockheaderToJSON(tip, blockindex);
+    UniValue result;
+    if (blockindex->trimmed()) {
+        CBlockIndex tmp = CBlockIndex(block.GetBlockHeader());  // XXX: lifetimes?
+        result = blockheaderToJSON(tip, &tmp);
+    } else {
+        result = blockheaderToJSON(tip, blockindex);
+    }
 
     result.pushKV("strippedsize", (int)::GetSerializeSize(block, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS));
     result.pushKV("size", (int)::GetSerializeSize(block, PROTOCOL_VERSION));
@@ -969,7 +988,13 @@ static RPCHelpMan getblockheader()
     if (!fVerbose)
     {
         CDataStream ssBlock(SER_NETWORK, PROTOCOL_VERSION);
-        ssBlock << pblockindex->GetBlockHeader();
+        if (pblockindex->trimmed()) {
+            CBlockHeader tmp;
+            ReadBlockHeaderFromDisk(tmp, pblockindex, Params().GetConsensus());
+            ssBlock << tmp;
+        } else {
+            ssBlock << pblockindex->GetBlockHeader();
+        }
         std::string strHex = HexStr(ssBlock);
         return strHex;
     }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -248,13 +248,13 @@ UniValue blockheaderToJSON(const CBlockIndex* tip, const CBlockIndex* blockindex
         result.pushKV("difficulty", GetDifficulty(blockindex));
         result.pushKV("chainwork", blockindex->nChainWork.GetHex());
     } else {
-        if (blockindex->dynafed_params.IsNull()) {
-            result.pushKV("signblock_witness_asm", ScriptToAsmStr(blockindex->proof.solution));
-            result.pushKV("signblock_witness_hex", HexStr(blockindex->proof.solution));
-            result.pushKV("signblock_challenge", HexStr(blockindex->proof.challenge));
+        if (blockindex->dynafed_params().IsNull()) {
+            result.pushKV("signblock_witness_asm", ScriptToAsmStr(blockindex->get_proof().solution));
+            result.pushKV("signblock_witness_hex", HexStr(blockindex->get_proof().solution));
+            result.pushKV("signblock_challenge", HexStr(blockindex->get_proof().challenge));
         } else {
-            result.pushKV("signblock_witness_hex", EncodeHexScriptWitness(blockindex->m_signblock_witness));
-            result.pushKV("dynamic_parameters", dynaParamsToJSON(blockindex->dynafed_params));
+            result.pushKV("signblock_witness_hex", EncodeHexScriptWitness(blockindex->signblock_witness()));
+            result.pushKV("dynamic_parameters", dynaParamsToJSON(blockindex->dynafed_params()));
         }
     }
     result.pushKV("nTx", (uint64_t)blockindex->nTx);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -282,7 +282,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIn
 {
     UniValue result;
     if (blockindex->trimmed()) {
-        CBlockIndex tmp = CBlockIndex(block.GetBlockHeader());  // XXX: lifetimes?
+        CBlockIndex tmp = CBlockIndex(block.GetBlockHeader());
         result = blockheaderToJSON(tip, &tmp);
     } else {
         result = blockheaderToJSON(tip, blockindex);

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -339,7 +339,7 @@ bool CBlockTreeDB::WalkBlockIndexGutsForMaxHeight(int* nHeight) {
     return true;
 }
 
-bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, std::function<CBlockIndex*(const uint256&)> insertBlockIndex, int trim_below_height)
+bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, std::function<CBlockIndex*(const uint256&)> insertBlockIndex, int trimBelowHeight)
 {
     std::unique_ptr<CDBIterator> pcursor(NewIterator());
 
@@ -371,10 +371,10 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
                 pindexNew->nTx            = diskindex.nTx;
 
                 n_total++;
-                if (diskindex.nHeight >= trim_below_height) {
+                if (diskindex.nHeight >= trimBelowHeight) {
                     n_untrimmed++;
-                    pindexNew->proof          = diskindex.proof;
-                    pindexNew->m_dynafed_params       = diskindex.m_dynafed_params;
+                    pindexNew->proof               = diskindex.proof;
+                    pindexNew->m_dynafed_params    = diskindex.m_dynafed_params;
                     pindexNew->m_signblock_witness = diskindex.m_signblock_witness;
 
                     const uint256 block_hash = pindexNew->GetBlockHash();

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -307,6 +307,9 @@ bool CBlockTreeDB::WritePAKList(const std::vector<std::vector<unsigned char> >& 
         return Write(std::make_pair(DB_PAK, uint256S("1")), offline_list) && Write(std::make_pair(DB_PAK, uint256S("2")), online_list) && Write(std::make_pair(DB_PAK, uint256S("3")), reject);
 }
 
+/** Note that we only get a conservative (lower) estimate of the max header height here,
+ * obtained by sampling the first 10,000 headers on disk (which are in random order) and
+ * taking the highest block we see. */
 bool CBlockTreeDB::WalkBlockIndexGutsForMaxHeight(int* nHeight) {
     std::unique_ptr<CDBIterator> pcursor(NewIterator());
     *nHeight = 0;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -318,7 +318,7 @@ bool CBlockTreeDB::WalkBlockIndexGutsForMaxHeight(int* nHeight) {
         if (pcursor->GetKey(key) && key.first == DB_BLOCK_INDEX) {
             i++;
             if (i > 10'000) {
-                // Under the (accurate) assumption hat the headers on disk are effectively in random height order,
+                // Under the (accurate) assumption that the headers on disk are effectively in random height order,
                 //   we have a good-enough (conservative) estimate of the max height very quickly, and don't need to
                 //   waste more time. Shortcutting like this will cause us to keep a few extra headers, which is fine.
                 break;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -335,7 +335,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
                 pindexNew->proof          = diskindex.proof;
                 pindexNew->nStatus        = diskindex.nStatus;
                 pindexNew->nTx            = diskindex.nTx;
-                pindexNew->dynafed_params       = diskindex.dynafed_params;
+                pindexNew->m_dynafed_params       = diskindex.m_dynafed_params;
                 pindexNew->m_signblock_witness = diskindex.m_signblock_witness;
 
                 const uint256 block_hash = pindexNew->GetBlockHash();

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -85,7 +85,7 @@ public:
     void ReadReindexing(bool &fReindexing);
     bool WriteFlag(const std::string &name, bool fValue);
     bool ReadFlag(const std::string &name, bool &fValue);
-    bool LoadBlockIndexGuts(const Consensus::Params& consensusParams, std::function<CBlockIndex*(const uint256&)> insertBlockIndex, int trim_below_height);
+    bool LoadBlockIndexGuts(const Consensus::Params& consensusParams, std::function<CBlockIndex*(const uint256&)> insertBlockIndex, int trimBelowHeight);
     // ELEMENTS:
     bool WalkBlockIndexGutsForMaxHeight(int* nHeight);
     bool ReadPAKList(std::vector<std::vector<unsigned char> >& offline_list, std::vector<std::vector<unsigned char> >& online_list, bool& reject);

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -85,8 +85,9 @@ public:
     void ReadReindexing(bool &fReindexing);
     bool WriteFlag(const std::string &name, bool fValue);
     bool ReadFlag(const std::string &name, bool &fValue);
-    bool LoadBlockIndexGuts(const Consensus::Params& consensusParams, std::function<CBlockIndex*(const uint256&)> insertBlockIndex);
+    bool LoadBlockIndexGuts(const Consensus::Params& consensusParams, std::function<CBlockIndex*(const uint256&)> insertBlockIndex, int trim_below_height);
     // ELEMENTS:
+    bool WalkBlockIndexGutsForMaxHeight(int* nHeight);
     bool ReadPAKList(std::vector<std::vector<unsigned char> >& offline_list, std::vector<std::vector<unsigned char> >& online_list, bool& reject);
     bool WritePAKList(const std::vector<std::vector<unsigned char> >& offline_list, const std::vector<std::vector<unsigned char> >& online_list, bool reject);
 };

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2464,13 +2464,13 @@ void CChainState::UpdateTip(const CBlockIndex* pindexNew)
       !warning_messages.empty() ? strprintf(" warning='%s'", warning_messages.original) : "");
 
     // Do some logging if dynafed parameters changed.
-    if (pindexNew->pprev && !pindexNew->dynafed_params.IsNull()) {
+    if (pindexNew->pprev && !pindexNew->dynafed_params().IsNull()) {
         int height = pindexNew->nHeight;
         uint256 hash = pindexNew->GetBlockHash();
-        uint256 root = pindexNew->dynafed_params.m_current.CalculateRoot();
-        if (pindexNew->pprev->dynafed_params.IsNull()) {
+        uint256 root = pindexNew->dynafed_params().m_current.CalculateRoot();
+        if (pindexNew->pprev->dynafed_params().IsNull()) {
             LogPrintf("Dynafed activated in block %d:%s: %s\n", height, hash.GetHex(), root.GetHex());
-        } else if (root != pindexNew->pprev->dynafed_params.m_current.CalculateRoot()) {
+        } else if (root != pindexNew->pprev->dynafed_params().m_current.CalculateRoot()) {
             LogPrintf("New dynafed parameters activated in block %d:%s: %s\n", height, hash.GetHex(), root.GetHex());
         }
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4141,7 +4141,7 @@ bool BlockManager::LoadBlockIndex(
     if (fTrimHeaders) {
         int max_height = 0;
         if (!blocktree.WalkBlockIndexGutsForMaxHeight(&max_height)) {
-            LogPrintf("LoadBlockIndex: Somehow failed to WalkBlockIndexGutsForMaxHeight.\n");
+            LogPrintf("LoadBlockIndex: Failed to WalkBlockIndexGutsForMaxHeight.\n");
             return false;
         }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -649,6 +649,7 @@ public:
     //! @returns A reference to the in-memory cache of the UTXO set.
     CCoinsViewCache& CoinsTip() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
+        assert(m_coins_views);
         assert(m_coins_views->m_cacheview);
         return *m_coins_views->m_cacheview.get();
     }

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -40,9 +40,11 @@ export LC_ALL=C
 KNOWN_VIOLATIONS=(
     "src/bitcoin-tx.cpp.*stoul"
     "src/bitcoin-tx.cpp.*trim_right"
+    "src/chain.h.*trim"
     "src/dbwrapper.cpp.*stoul"
     "src/dbwrapper.cpp:.*vsnprintf"
     "src/httprpc.cpp.*trim"
+    "src/init.cpp.*trim"
     "src/node/blockstorage.cpp:.*atoi"
     "src/qt/rpcconsole.cpp:.*atoi"
     "src/rest.cpp:.*strtol"


### PR DESCRIPTION
Adds a `-trim_headers` flag, which punts some of the largest header fields out of `CBlockIndex`, the struct used for keeping the in-memory copies of the headers of the whole chain. We keep several dynafed periods worth of headers fully in memory, so that we can be assured of being able to validate new blocks; additionally, during IBD we keep a window of headers in-memory past where we have blocks validated (but restrict the size of the window, so that memory usage does not balloon too much.)

If the chain is not configured for dynafed, the default value for the dynafed period is very large, so my guess is this code will do basically nothing in that case (it will have a window of headers to keep which is larger than the entire chain), but I haven't tested that.

Turning the flag on while in the middle of IBD may trip an assert during startup, as we try to load the index (due to having way more headers than blocks on disk, such that we try to trim away headers we still need for validation.) This should have no ill effects once the node is restarted without the flag, but this should probably be better documented.

RPCs and REST endpoints which need a trimmed header will load it from the block file on disk, in a fairly wasteful way (loading the entire block each time.) RPCs which print a trimmed header in JSON will omit the missing fields instead (replacing them with a placeholder.) This could also be better documented.

A node operating in trimmed mode will act as a "light" or SPV node to the P2P network, since it can't provide full headers to other nodes. So this mode is not appropriate for "infrastructure" nodes which need to provide support for IBD or block/transaction propagation. (I am fairly convinced that, with the current on-disk structures being set up the way they are, the performance impact of trying to go to disk for this would be prohibitive. I haven't tried it, though.)

The memory usage reduction I see with this, downloading the entire Liquid v1 chain, is something like 2x. There are definitely further improvements that could be made.