### PR TITLE
Correct testproposedblock help

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1716,7 +1716,7 @@ static RPCHelpMan testproposedblock()
                 "\nChecks a block proposal for validity, and that it extends chaintip\n",
                 {
                     {"blockhex", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The hex-encoded block from getnewblockhex"},
-                    {"acceptnonstd", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED_NAMED_ARG, "If set false, returns error if block contains non-standard transaction. Default is set via `-acceptnonstdtxn`. If PAK enforcement is set, block commitment mismatches with configuration PAK lists are rejected as well."},
+                    {"acceptnonstd", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED_NAMED_ARG, "If set false, returns error if block contains non-standard transaction. Default is set via `-acceptnonstdtxn`."},
                 },
                 RPCResult{RPCResult::Type::NONE, "", ""},
                 RPCExamples{


### PR DESCRIPTION
The help message for `testproposedblock` erroneously indicates that some checking will be done against the PAK list.  There are no [longer any] such checks.