### PR TITLE
Re-enable qa-assets unit tests

### DIFF
--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -86,7 +86,7 @@ DOCKER_EXEC df -h
 
 if [ "$RUN_FUZZ_TESTS" = "true" ] || [ "$RUN_UNIT_TESTS" = "true" ] || [ "$RUN_UNIT_TESTS_SEQUENTIAL" = "true" ]; then
   if [ ! -d ${DIR_QA_ASSETS} ]; then
-    DOCKER_EXEC git clone --depth=1 https://github.com/bitcoin-core/qa-assets ${DIR_QA_ASSETS}
+    DOCKER_EXEC git clone --depth=1 https://github.com/ElementsProject/qa-assets ${DIR_QA_ASSETS}
   fi
 
   export DIR_FUZZ_IN=${DIR_QA_ASSETS}/fuzz_seed_corpus/

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -1744,12 +1744,10 @@ BOOST_AUTO_TEST_CASE(script_assets_test)
     BOOST_CHECK(tests.isArray());
     BOOST_CHECK(tests.size() > 0);
 
-/*
     ELEMENTS: temporarily disabled until we implement the new Taproot sighash and upload new qa-assets
     for (size_t i = 0; i < tests.size(); i++) {
         AssetTest(tests[i]);
     }
-*/
     file.close();
 }
 


### PR DESCRIPTION
I can't test this locally yet (had some nix issues). Should be able to soon. But throwing this over the fence.