### PR TITLE
RPC: Avoid assert by keeping a flag to identify trimmed dynafed blocks

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -200,6 +200,7 @@ protected:
     std::optional<CScriptWitness> m_signblock_witness{};
 
     bool m_trimmed{false};
+    bool m_trimmed_dynafed_block{false};
 
     friend class CBlockTreeDB;
 
@@ -210,6 +211,7 @@ public:
     void trim() {
         assert_untrimmed();
         m_trimmed = true;
+        m_trimmed_dynafed_block = !m_dynafed_params.value().IsNull();
         proof = std::nullopt;
         m_dynafed_params = std::nullopt;
         m_signblock_witness = std::nullopt;
@@ -226,6 +228,13 @@ public:
     const CProof& get_proof() const {
         assert_untrimmed();
         return proof.value();
+    }
+
+    const bool dynafed_block() const {
+        if (m_trimmed) {
+            return m_trimmed_dynafed_block;
+        }
+        return !m_dynafed_params.value().IsNull();
     }
 
     const DynaFedParams& dynafed_params() const {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -248,7 +248,7 @@ UniValue blockheaderToJSON(const CBlockIndex* tip, const CBlockIndex* blockindex
         result.pushKV("difficulty", GetDifficulty(blockindex));
         result.pushKV("chainwork", blockindex->nChainWork.GetHex());
     } else {
-        if (blockindex->dynafed_params().IsNull()) {
+        if (!blockindex->dynafed_block()) {
             if (blockindex->trimmed()) {
                 result.pushKV("signblock_witness_asm", "<trimmed>");
                 result.pushKV("signblock_witness_hex", "<trimmed>");

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -280,13 +280,7 @@ UniValue blockheaderToJSON(const CBlockIndex* tip, const CBlockIndex* blockindex
 
 UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIndex* blockindex, bool txDetails)
 {
-    UniValue result;
-    if (blockindex->trimmed()) {
-        CBlockIndex tmp = CBlockIndex(block.GetBlockHeader());
-        result = blockheaderToJSON(tip, &tmp);
-    } else {
-        result = blockheaderToJSON(tip, blockindex);
-    }
+    UniValue result = blockheaderToJSON(tip, blockindex);
 
     result.pushKV("strippedsize", (int)::GetSerializeSize(block, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS));
     result.pushKV("size", (int)::GetSerializeSize(block, PROTOCOL_VERSION));

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -389,6 +389,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
                     }
                 } else {
                     pindexNew->m_trimmed = true;
+                    pindexNew->m_trimmed_dynafed_block = !diskindex.m_dynafed_params.value().IsNull();
                 }
 
                 pcursor->Next();


### PR DESCRIPTION
This MR fixes 2 crashes:
1) assert in blockheaderToJSON when checking for dynafed block on a trimmed header
2) crash in blocktoJSON/blockheaderToJSON due to loaded block being incomplete.

Fixes: https://github.com/ElementsProject/elements/issues/1224