### PR TITLE
test: re-enable and fix script assets test 

### DIFF
--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -86,7 +86,7 @@ DOCKER_EXEC df -h
 
 if [ "$RUN_FUZZ_TESTS" = "true" ] || [ "$RUN_UNIT_TESTS" = "true" ] || [ "$RUN_UNIT_TESTS_SEQUENTIAL" = "true" ]; then
   if [ ! -d ${DIR_QA_ASSETS} ]; then
-    DOCKER_EXEC git clone --depth=1 https://github.com/bitcoin-core/qa-assets ${DIR_QA_ASSETS}
+    DOCKER_EXEC git clone --depth=1 https://github.com/ElementsProject/qa-assets ${DIR_QA_ASSETS}
   fi
 
   export DIR_FUZZ_IN=${DIR_QA_ASSETS}/fuzz_seed_corpus/

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -1684,7 +1684,7 @@ static void AssetTest(const UniValue& test)
     size_t idx = test["index"].get_int64();
     unsigned int test_flags = ParseScriptFlags(test["flags"].get_str());
     bool fin = test.exists("final") && test["final"].get_bool();
-    // ELEMENTS FIXME: update feature_taproot.py --dumptests to actually output these
+    // ELEMENTS: feature_taproot.py --dumptests outputs this field
     uint256 hash_genesis_block = test.exists("hash_genesis_block") ? uint256S(test["hash_genesis_block"].get_str()) : uint256{};
 
     if (test.exists("success")) {
@@ -1725,6 +1725,8 @@ BOOST_AUTO_TEST_CASE(script_assets_test)
 {
     // See src/test/fuzz/script_assets_test_minimizer.cpp for information on how to generate
     // the script_assets_test.json file used by this test.
+    // ELEMENTS: qa-assets repo can be cloned here https://github.com/ElementsProject/qa-assets
+    // then set DIR_UNIT_TEST_DATA env var to /path/to/qa-assets/unit_test_data when running this test
 
     const char* dir = std::getenv("DIR_UNIT_TEST_DATA");
     BOOST_WARN_MESSAGE(dir != nullptr, "Variable DIR_UNIT_TEST_DATA unset, skipping script_assets_test");
@@ -1744,12 +1746,11 @@ BOOST_AUTO_TEST_CASE(script_assets_test)
     BOOST_CHECK(tests.isArray());
     BOOST_CHECK(tests.size() > 0);
 
-/*
-    ELEMENTS: temporarily disabled until we implement the new Taproot sighash and upload new qa-assets
+    g_con_elementsmode = true;
     for (size_t i = 0; i < tests.size(); i++) {
         AssetTest(tests[i]);
     }
-*/
+    g_con_elementsmode = false;
     file.close();
 }
 

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -21,6 +21,7 @@ from test_framework.messages import (
     CTxOut,
     CTxOutValue,
     CTxOutWitness,
+    ser_uint256,
     uint256_from_str,
 )
 from test_framework.script import (
@@ -1179,12 +1180,15 @@ def dump_json_test(tx, input_utxos, idx, success, failure):
     # Determine flags to dump
     flags = LEGACY_FLAGS if spender.comment.startswith("legacy/") or spender.comment.startswith("inactive/") else TAPROOT_FLAGS
 
+    hash_genesis_block = bytearray(ser_uint256(g_genesis_hash))
+    hash_genesis_block.reverse()
     fields = [
         ("tx", tx.serialize().hex()),
         ("prevouts", [x.output.serialize().hex() for x in input_utxos]),
         ("index", idx),
         ("flags", flags),
-        ("comment", spender.comment)
+        ("comment", spender.comment),
+        ("hash_genesis_block", hash_genesis_block.hex())
     ]
 
     # The "final" field indicates that a spend should be always valid, even with more validation flags enabled


### PR DESCRIPTION
Fixes the `script_assets_test` by changing the `feature_taproot.py` functional test to include the genesis block hash when dumping the json tests. The asset tests were failing with the Taproot flag enabled, because the Elements Taphash calculation requires the genesis block hash. 

Requires the json file from https://github.com/ElementsProject/qa-assets/pull/1

Steps to run the test: 
- compile this branch with tests enabled 
- checkout my updated branch of the qa-assets repo in the PR above 
-  run the test `DIR_UNIT_TEST_DATA=/path/to/qa-assets/unit_test_data ./src/test/test_bitcoin -t script_tests/script_assets_test` 