### PR TITLE
testmempoolaccept: feed genesis hash into sighash computation

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1172,7 +1172,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::
     }
 
     for (Workspace& ws : workspaces) {
-        PrecomputedTransactionData txdata;
+        PrecomputedTransactionData txdata(args.m_chainparams.HashGenesisBlock());
         if (!PolicyScriptChecks(args, ws, txdata)) {
             // Exit early to avoid doing pointless work. Update the failed tx result; the rest are unfinished.
             package_state.Invalid(PackageValidationResult::PCKG_TX, "transaction failed");


### PR DESCRIPTION
I cannot test this because of #1238 and #1237 as well as the lack of functionality in the PSBT RPCs, inability to inform the wallet about a UTXO without broadcasting the transaction it comes from, etc etc.