### PR TITLE
fix: getnewaddress - don't blind bech32 addresses

### DIFF
--- a/test/functional/feature_confidential_transactions.py
+++ b/test/functional/feature_confidential_transactions.py
@@ -164,13 +164,13 @@ class CTTest (BitcoinTestFramework):
         self.test_wallet_recovery()
 
         print("Test blech32 python roundtrip")
-        # blech/bech are aliased, both are blech32
-        for addrtype in ["bech32", "blech32"]:
-            addr_to_rt = self.nodes[0].getnewaddress("", addrtype)
-            hrp = addr_to_rt[:2]
-            assert_equal(hrp, "el")
-            (witver, witprog) = decode(hrp, addr_to_rt)
-            assert_equal(encode(hrp, witver, witprog), addr_to_rt)
+        # test only blech32, since getnewaddress for bech32 was changed to return an unblinded address
+        addr_to_rt = self.nodes[0].getnewaddress("", "blech32")
+        hrp = addr_to_rt[:2]
+        assert_equal(hrp, "el")
+
+        (witver, witprog) = decode(hrp, addr_to_rt)
+        assert_equal(encode(hrp, witver, witprog), addr_to_rt)
 
         # Test that "blech32" gives a blinded segwit address.
         blech32_addr = self.nodes[0].getnewaddress("", "blech32")

--- a/test/functional/feature_sighash_rangeproof.py
+++ b/test/functional/feature_sighash_rangeproof.py
@@ -130,7 +130,7 @@ class SighashRangeproofTest(BitcoinTestFramework):
                 struct.pack("<B", len(signature)) + signature
                 + struct.pack("<B", len(pubkey.get_bytes())) + pubkey.get_bytes()
             )
-        elif address_type == "bech32" or address_type == "p2sh-segwit":
+        elif address_type == "blech32" or address_type == "p2sh-segwit":
             assert signed_tx.wit.vtxinwit[0].scriptWitness.stack[1] == pubkey.get_bytes()
             pubkeyhash = hash160(pubkey.get_bytes())
             script = get_p2pkh_script(pubkeyhash)
@@ -217,7 +217,7 @@ class SighashRangeproofTest(BitcoinTestFramework):
 
     def run_test(self):
         util.node_fastmerkle = self.nodes[0]
-        ADDRESS_TYPES = ["legacy", "bech32", "p2sh-segwit"]
+        ADDRESS_TYPES = ["legacy", "blech32", "p2sh-segwit"]
 
         # Different test scenarios.
         # - before activation, using the flag is non-standard
@@ -280,4 +280,3 @@ class SighashRangeproofTest(BitcoinTestFramework):
 
 if __name__ == '__main__':
     SighashRangeproofTest().main()
-

--- a/test/functional/rpc_signrawtransaction.py
+++ b/test/functional/rpc_signrawtransaction.py
@@ -357,7 +357,7 @@ class SignRawTransactionsTest(BitcoinTestFramework):
         4) The signature of signrawtransactionwithwallet by inputs and
            the signature of signrawtransactionwithwallet by utxos are equal.
         5) The signed transaction can broadcast."""
-        utxo_address = self.nodes[2].getnewaddress('', 'bech32')
+        utxo_address = self.nodes[2].getnewaddress('', 'blech32')
         utxo_address_info = self.nodes[2].getaddressinfo(utxo_address)
         uc_addr = utxo_address_info['unconfidential']
         utxo_address_privkey = self.nodes[2].dumpprivkey(uc_addr)


### PR DESCRIPTION
fixes #1245 - `getnewaddress` will now return an unblinded bech32 address even when `-blindedaddresses=1` in config 

