### PR TITLE
lint: fix codespell and python utf8 encoding lint issues (redux)

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2023,7 +2023,7 @@ void PeerManagerImpl::ProcessHeadersMessage(CNode& pfrom, const Peer& peer,
             if ((nodestate->pindexBestKnownBlock == nullptr) ||
                 (nodestate->pindexBestKnownBlock->nHeight < m_chainman.ActiveHeight())) {
                 // Our notion of what blocks a peer has available is based on its pindexBestKnownBlock,
-                // which is based on headers recieved from it. If we don't have one, or it's too old,
+                // which is based on headers received from it. If we don't have one, or it's too old,
                 // then we can never get blocks from this peer until we accept headers from it first.
                 LogPrint(BCLog::NET, "NOT discarding headers from peer=%d, to update its block availability. (current best header %d, active chain height %d)\n", pfrom.GetId(), pindexBestHeader->nHeight, m_chainman.ActiveHeight());
             } else {

--- a/test/lint/lint-python-utf8-encoding.sh
+++ b/test/lint/lint-python-utf8-encoding.sh
@@ -9,7 +9,7 @@
 
 export LC_ALL=C
 EXIT_CODE=0
-OUTPUT=$(git grep " open(" -- "*.py" ":(exclude)src/crc32c/" | grep -vE "encoding=.(ascii|utf8|utf-8)." | grep -vE "open\([^,]*, ['\"][^'\"]*b[^'\"]*['\"]")
+OUTPUT=$(git grep " open(" -- "*.py" ":(exclude)src/crc32c/" ":(exclude)src/secp256k1/" | grep -vE "encoding=.(ascii|utf8|utf-8)." | grep -vE "open\([^,]*, ['\"][^'\"]*b[^'\"]*['\"]")
 if [[ ${OUTPUT} != "" ]]; then
     echo "Python's open(...) seems to be used to open text files without explicitly"
     echo "specifying encoding=\"utf8\":"

--- a/test/lint/lint-spelling.ignore-words.txt
+++ b/test/lint/lint-spelling.ignore-words.txt
@@ -17,3 +17,5 @@ useable
 mut
 wit
 te
+ligh
+atack


### PR DESCRIPTION
These commits fixes a few linting issues for codespell, and excludes `src/secp256k1/` from the python utf8 linter. 

The linters run cleanly on the master branch with these commits applied. However, on the `elements-22.x` branch there are 2 other lints in `doc/release-notes.md` that can be fixed by this diff: 

```diff
diff --git a/doc/release-notes.md b/doc/release-notes.md
index 972c91aa6f..f94437a884 100644
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -744,7 +744,7 @@ A detailed list of changes in this version follows. To keep the list to a manage
 - bitcoin/bitcoin#21185 fuzz: Remove expensive and redundant muhash from crypto fuzz target (MarcoFalke)
 - bitcoin/bitcoin#21200 Speed up `rpc_blockchain.py` by removing miniwallet.generate() (MarcoFalke)
 - bitcoin/bitcoin#21211 Move `P2WSH_OP_TRUE` to shared test library (MarcoFalke)
-- bitcoin/bitcoin#21228 Avoid comparision of integers with different signs (jonasschnelli)
+- bitcoin/bitcoin#21228 Avoid comparison of integers with different signs (jonasschnelli)
 - bitcoin/bitcoin#21230 Fix `NODE_NETWORK_LIMITED_MIN_BLOCKS` disconnection (MarcoFalke)
 - bitcoin/bitcoin#21252 Add missing wait for sync to `feature_blockfilterindex_prune` (MarcoFalke)
 - bitcoin/bitcoin#21254 Avoid connecting to real network when running tests (MarcoFalke)
@@ -992,7 +992,7 @@ A detailed list of changes in this version follows. To keep the list to a manage
 - bitcoin/bitcoin#21481 Tell howto install clang-format on Debian/Ubuntu (wodry)
 - bitcoin/bitcoin#21567 Fix various misleading comments (glozow)
 - bitcoin/bitcoin#21661 Fix name of script guix-build (Emzy)
-- bitcoin/bitcoin#21672 Remove boostrap info from `GUIX_COMMON_FLAGS` doc (fanquake)
+- bitcoin/bitcoin#21672 Remove bootstrap info from `GUIX_COMMON_FLAGS` doc (fanquake)
 - bitcoin/bitcoin#21688 Note on SDK for macOS depends cross-compile (jarolrod)
 - bitcoin/bitcoin#21709 Update reduce-memory.md and bitcoin.conf -maxconnections info (jonatack)
 - bitcoin/bitcoin#21710 update helps for addnode rpc and -addnode/-maxconnections config options (jonatack)

```