### PR TITLE
Small fixes in preparation for trim_headers version 2

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -217,11 +217,11 @@ public:
         m_signblock_witness = std::nullopt;
     }
 
-    bool trimmed() const {
+    inline bool trimmed() const {
         return m_trimmed;
     }
 
-    void assert_untrimmed() const {
+    inline void assert_untrimmed() const {
         assert(!m_trimmed);
     }
 

--- a/src/chain.h
+++ b/src/chain.h
@@ -230,7 +230,7 @@ public:
         return proof.value();
     }
 
-    const bool dynafed_block() const {
+    bool dynafed_block() const {
         if (m_trimmed) {
             return m_trimmed_dynafed_block;
         }

--- a/src/chain.h
+++ b/src/chain.h
@@ -417,12 +417,12 @@ public:
             nVersion = ~CBlockHeader::DYNAFED_HF_MASK & nVersion;
             return is_dyna;
         } else {
-            return !dynafed_params().IsNull();
+            return is_dynafed_block();
         }
     }
     bool RemoveDynaFedMaskOnSerialize(bool for_read) const {
         assert(!for_read);
-        return !dynafed_params().IsNull();
+        return is_dynafed_block();
     }
 
     SERIALIZE_METHODS(CDiskBlockIndex, obj)
@@ -445,7 +445,7 @@ public:
             READWRITE(obj.nVersion);
         } else {
             int32_t nVersion = obj.nVersion;
-            if (!obj.dynafed_params().IsNull()) {
+            if (obj.is_dynafed_block()) {
                 nVersion |= CBlockHeader::DYNAFED_HF_MASK;
             }
             READWRITE(nVersion);

--- a/src/chain.h
+++ b/src/chain.h
@@ -450,7 +450,7 @@ public:
             }
             READWRITE(nVersion);
         }
-        bool is_dyna = obj.RemoveDynaFedMaskOnSerialize(ser_action.ForRead());;
+        bool is_dyna = obj.RemoveDynaFedMaskOnSerialize(ser_action.ForRead());
 
         READWRITE(obj.hashPrev);
         READWRITE(obj.hashMerkleRoot);

--- a/src/chain.h
+++ b/src/chain.h
@@ -230,7 +230,7 @@ public:
         return proof.value();
     }
 
-    bool dynafed_block() const {
+    bool is_dynafed_block() const {
         if (m_trimmed) {
             return m_trimmed_dynafed_block;
         }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -986,7 +986,7 @@ bool AppInitParameterInteraction(const ArgsManager& args)
         epoch_length = 20160;
     }
 
-    if (args.IsArgSet("-trim_headers")) {
+    if (args.GetBoolArg("-trim_headers", false)) {
         LogPrintf("Configured for header-trimming mode. This will reduce memory usage substantially, but we will be unable to serve as a full P2P peer, and certain header fields may be missing from JSON RPC output.\n");
         fTrimHeaders = true;
         // This calculation is driven by GetValidFedpegScripts in pegins.cpp, which walks the chain

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -248,7 +248,7 @@ UniValue blockheaderToJSON(const CBlockIndex* tip, const CBlockIndex* blockindex
         result.pushKV("difficulty", GetDifficulty(blockindex));
         result.pushKV("chainwork", blockindex->nChainWork.GetHex());
     } else {
-        if (!blockindex->dynafed_block()) {
+        if (!blockindex->is_dynafed_block()) {
             if (blockindex->trimmed()) {
                 result.pushKV("signblock_witness_asm", "<trimmed>");
                 result.pushKV("signblock_witness_hex", "<trimmed>");


### PR DESCRIPTION
Preparing for the new version of trim headers, both in 22 and 23, there are a few commits that don't create conflicts and that it would be easier to have before branching.