### PR TITLE
KnapsackSolver fix

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -924,7 +924,7 @@ static RPCHelpMan sendrawtransaction()
         //   will always be blinded and not explicit. In the former case, we
         //   error out because the transaction is not blinded properly.
         if (!out.nNonce.IsNull() && out.nValue.IsExplicit()) {
-            throw JSONRPCError(RPC_TRANSACTION_ERROR, "Transaction output has nonce, but is not blinded. Did you forget to call blindrawtranssaction, or rawblindrawtransaction?");
+            throw JSONRPCError(RPC_TRANSACTION_ERROR, "Transaction output has nonce, but is not blinded. Did you forget to call blindrawtransaction, or rawblindrawtransaction?");
         }
     }
 

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -299,7 +299,13 @@ bool KnapsackSolver(const CAmountMap& mapTargetValue, std::vector<OutputGroup>& 
     }
 
     // Perform the standard Knapsack solver for the policy asset
-    CAmount policy_target = non_policy_effective_value + mapTargetValue.at(::policyAsset);
+    /*
+    NOTE:
+    CInputCoin::effective_value is a negative value so non_policy_effective_value
+    will be negative. Therefor, it should be substracted from the policy output
+    amount, not added.
+    */
+    CAmount policy_target = mapTargetValue.at(::policyAsset) - non_policy_effective_value;
     if (policy_target > 0) {
         inner_groups.clear();
         inner_coinsret.clear();

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -301,9 +301,7 @@ bool KnapsackSolver(const CAmountMap& mapTargetValue, std::vector<OutputGroup>& 
     // Perform the standard Knapsack solver for the policy asset
     /*
     NOTE:
-    CInputCoin::effective_value is a negative value so non_policy_effective_value
-    will be negative. Therefor, it should be substracted from the policy output
-    amount, not added.
+    CInputCoin::effective_value is negative for non-policy assets, so the sum non_policy_effective_value is negative. Therefore, it is subtracted in order to increase policy_target by the fees required.
     */
     CAmount policy_target = mapTargetValue.at(::policyAsset) - non_policy_effective_value;
     if (policy_target > 0) {

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -1446,7 +1446,12 @@ bool CWallet::CreateTransactionInternal(
 
     // The only time that fee_needed should be less than the amount available for fees (in change_and_fee - change_amount) is when
     // we are subtracting the fee from the outputs. If this occurs at any other time, it is a bug.
-    assert(coin_selection_params.m_subtract_fee_outputs || fee_needed <= map_change_and_fee.at(policyAsset) - change_amount);
+    if (!coin_selection_params.m_subtract_fee_outputs && fee_needed > map_change_and_fee.at(policyAsset) - change_amount) {
+        WalletLogPrintf("ERROR: not enough coins to cover for fee (needed: %d, total: %d, change: %d)\n",
+            fee_needed, map_change_and_fee.at(policyAsset), change_amount);
+        error = _("Could not cover fee");
+        return false;
+    }
 
     // Update nFeeRet in case fee_needed changed due to dropping the change output
     if (fee_needed <= map_change_and_fee.at(policyAsset) - change_amount) {

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -110,6 +110,7 @@ BASE_SCRIPTS = [
     'feature_progress.py',
     'rpc_getnewblockhex.py',
     'wallet_elements_regression_1172.py',
+    'wallet_elements_regression_1259.py',
     # Longest test should go first, to favor running tests in parallel
     'wallet_hd.py --legacy-wallet',
     'wallet_hd.py --descriptors',

--- a/test/functional/wallet_elements_regression_1259.py
+++ b/test/functional/wallet_elements_regression_1259.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Tests that fundrawtransaction correcly handles the case of sending many
+inputs of an issued asset, with no policy asset recipient.
+
+See: https://github.com/ElementsProject/elements/issues/1259
+
+This test issues an asset and creates many utxos, which are then used as inputs in
+a consolidation transaction created with the various raw transaction calls.
+"""
+from decimal import Decimal
+
+from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+)
+
+class WalletTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 3
+        self.extra_args = [[
+            "-blindedaddresses=1",
+            "-initialfreecoins=2100000000000000",
+            "-con_blocksubsidy=0",
+            "-con_connect_genesis_outputs=1",
+            "-txindex=1",
+        ]] * self.num_nodes
+        self.extra_args[0].append("-anyonecanspendaremine=1")
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        self.nodes[0].generate(COINBASE_MATURITY + 1)
+        self.sync_all()
+
+        self.log.info(f"Send some policy asset to node 1")
+        self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 10)
+        self.nodes[0].generate(1)
+
+        self.log.info(f"Issuing an asset from node 0")
+        issuance = self.nodes[0].issueasset(1000, 1, True)
+        self.nodes[0].generate(1)
+        asset = issuance["asset"]
+        self.log.info(f"Asset ID is {asset}")
+
+        # create many outputs of the new asset on node 1
+        num_utxos = 45
+        value = 10
+        fee_rate = 10
+        self.log.info(f"Sending {num_utxos} utxos of asset to node 1")
+        for i in range(num_utxos):
+            self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), value, "", "", False, False, None, None, None, asset, False, fee_rate, True)
+            self.nodes[0].generate(1)
+
+        # create a raw tx on node 1 consolidating the asset utxos
+        self.log.info(f"Create the raw consolidation transaction")
+        hex = self.nodes[1].createrawtransaction([], [{ 'asset': asset, self.nodes[2].getnewaddress(): num_utxos * value }])
+
+        # fund the raw tx
+        self.log.info(f"Fund the raw transaction")
+        raw_tx = self.nodes[1].fundrawtransaction(hex, True)
+
+        # blind and sign the tx
+        self.log.info(f"Blind and sign the raw transaction")
+        hex = self.nodes[1].blindrawtransaction(raw_tx['hex'])
+        signed_tx = self.nodes[1].signrawtransactionwithwallet(hex)
+        assert_equal(signed_tx['complete'], True)
+
+        # decode tx
+        tx = self.nodes[1].decoderawtransaction(signed_tx['hex'])
+
+        assert_equal(len(tx['vin']), num_utxos + 1)
+        assert_equal(len(tx['vout']), 3)
+        assert_equal(tx['fee'], {'b2e15d0d7a0c94e4e2ce0fe6e8691b9e451377f6e46e8045a86f7c4b5d4f0f23': Decimal('0.00112380')}) # fee output
+
+        # send and mine the tx
+        self.log.info(f"Send the raw transaction")
+        self.nodes[1].sendrawtransaction(signed_tx['hex'])
+        self.nodes[1].generate(1)
+        self.sync_all()
+        balance = self.nodes[2].getbalance()
+        assert_equal(balance[asset], Decimal(num_utxos * value))
+
+
+if __name__ == '__main__':
+    WalletTest().main()


### PR DESCRIPTION
- KnapsackSolver applies non_policy_effective_value incorrectly to policy output amount. This leads to a negative expected fee in lots of inputs with few outputs scenarios (e.g. utxo consolidations). Fixed that and added a comment.

- Without this fix, an assert on policy change amount vs fee paid will trigger (spend.cpp:1449). I consider asserts too aggressive a check for these kinds of condition (this will crash elements unless an explicit handler for SIGSEVs is registered). I took to liberty of replacing the assert with a log event and graceful failure (returning false).

- No new tests was added to cover for this issue,  functional tests pass.