### PR TITLE
[22.x] Restore full functionality to trim_headers (untrim)

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -5,6 +5,8 @@
 
 #include <chain.h>
 
+#include <validation.h> // pblocktree
+
 /**
  * CChain implementation
  */
@@ -46,6 +48,11 @@ CBlockLocator CChain::GetLocator(const CBlockIndex *pindex) const {
     }
 
     return CBlockLocator(vHave);
+}
+
+const CBlockIndex *CBlockIndex::untrim_to(CBlockIndex *pindexNew) const
+{
+    return pblocktree->RegenerateFullIndex(this, pindexNew);
 }
 
 const CBlockIndex *CChain::FindFork(const CBlockIndex *pindex) const {

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -50,6 +50,19 @@ CBlockLocator CChain::GetLocator(const CBlockIndex *pindex) const {
     return CBlockLocator(vHave);
 }
 
+void CBlockIndex::untrim() {
+    if (!trimmed())
+        return;
+    CBlockIndex tmp;
+    const CBlockIndex* pindexfull = untrim_to(&tmp);
+    assert(pindexfull!=this);
+    m_trimmed = false;
+    set_stored();
+    proof = pindexfull->proof;
+    m_dynafed_params = pindexfull->m_dynafed_params;
+    m_signblock_witness = pindexfull->m_signblock_witness;
+}
+
 const CBlockIndex *CBlockIndex::untrim_to(CBlockIndex *pindexNew) const
 {
     return pblocktree->RegenerateFullIndex(this, pindexNew);

--- a/src/chain.h
+++ b/src/chain.h
@@ -224,6 +224,8 @@ public:
     }
 
     void untrim();
+    const CBlockIndex *untrim_to(CBlockIndex *pindexNew) const;
+
     inline bool trimmed() const {
         return m_trimmed;
     }

--- a/src/dynafed.cpp
+++ b/src/dynafed.cpp
@@ -1,6 +1,7 @@
 
 #include <dynafed.h>
 #include <hash.h>
+#include <validation.h>
 
 bool NextBlockIsParameterTransition(const CBlockIndex* pindexPrev, const Consensus::Params& consensus, DynaFedParamEntry& winning_entry)
 {
@@ -15,6 +16,7 @@ bool NextBlockIsParameterTransition(const CBlockIndex* pindexPrev, const Consens
     for (int32_t height = next_height - 1; height >= (int32_t)(next_height - consensus.dynamic_epoch_length); --height) {
         const CBlockIndex* p_epoch_walk = pindexPrev->GetAncestor(height);
         assert(p_epoch_walk);
+        ForceUntrimHeader(p_epoch_walk);
         const DynaFedParamEntry& proposal = p_epoch_walk->dynafed_params().m_proposed;
         const uint256 proposal_root = proposal.CalculateRoot();
         vote_tally[proposal_root]++;
@@ -60,6 +62,7 @@ DynaFedParamEntry ComputeNextBlockFullCurrentParameters(const CBlockIndex* pinde
     // may be pre-dynafed params
     const CBlockIndex* p_epoch_start = pindexPrev->GetAncestor(epoch_start_height);
     assert(p_epoch_start);
+    ForceUntrimHeader(p_epoch_start);
     if (p_epoch_start->dynafed_params().IsNull()) {
         // We need to construct the "full" current parameters of pre-dynafed
         // consensus
@@ -93,6 +96,7 @@ DynaFedParamEntry ComputeNextBlockCurrentParameters(const CBlockIndex* pindexPre
 {
     assert(pindexPrev);
 
+    ForceUntrimHeader(pindexPrev);
     DynaFedParamEntry entry = ComputeNextBlockFullCurrentParameters(pindexPrev, consensus);
 
     uint32_t next_height = pindexPrev->nHeight+1;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -987,7 +987,7 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     }
 
     if (args.GetBoolArg("-trim_headers", false)) {
-        LogPrintf("Configured for header-trimming mode. This will reduce memory usage substantially, but we will be unable to serve as a full P2P peer, and certain header fields may be missing from JSON RPC output.\n");
+        LogPrintf("Configured for header-trimming mode. This will reduce memory usage substantially, but will increase IO usage when the headers need to be temporarily untrimmed.\n");
         fTrimHeaders = true;
         // This calculation is driven by GetValidFedpegScripts in pegins.cpp, which walks the chain
         //   back to current epoch start, and then an additional total_valid_epochs on top of that.
@@ -1711,7 +1711,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     // if pruning, unset the service bit and perform the initial blockstore prune
     // after any wallet rescanning has taken place.
-    if (fPruneMode || fTrimHeaders) {
+    if (fPruneMode) {
         LogPrintf("Unsetting NODE_NETWORK on prune mode\n");
         nLocalServices = ServiceFlags(nLocalServices & ~NODE_NETWORK);
         if (!fReindex) {
@@ -1721,11 +1721,6 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                 chainstate->PruneAndFlush();
             }
         }
-    }
-
-    if (fTrimHeaders) {
-        LogPrintf("Unsetting NODE_NETWORK_LIMITED on header trim mode\n");
-        nLocalServices = ServiceFlags(nLocalServices & ~NODE_NETWORK_LIMITED);
     }
 
     if (DeploymentEnabled(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT)) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -993,7 +993,7 @@ bool AppInitParameterInteraction(const ArgsManager& args)
         //   back to current epoch start, and then an additional total_valid_epochs on top of that.
         //   We add one epoch here for the current partial epoch, and then another one for good luck.
 
-        nMustKeepFullHeaders = (chainparams.GetConsensus().total_valid_epochs + 2) * epoch_length;
+        nMustKeepFullHeaders = chainparams.GetConsensus().total_valid_epochs * epoch_length;
         // This is the number of headers we can have in flight downloading at a time, beyond the
         //   set of blocks we've already validated. Capping this is necessary to keep memory usage
         //   bounded during IBD.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3183,12 +3183,13 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         for (; pindex; pindex = m_chainman.ActiveChain().Next(pindex))
         {
             if (pindex->trimmed()) {
-                // For simplicity, if any of the headers they're asking for are trimmed,
-                //   just drop the request.
-                LogPrint(BCLog::NET, "%s: ignoring getheaders from peer=%i which would return at least one trimmed header\n", __func__, pfrom.GetId());
-                return;
+                // Header is trimmed, reload from disk before sending
+                CBlockIndex tmpBlockIndexFull;
+                const CBlockIndex* pindexfull = pindex->untrim_to(&tmpBlockIndexFull);
+                vHeaders.push_back(pindexfull->GetBlockHeader());
+            } else {
+                vHeaders.push_back(pindex->GetBlockHeader());
             }
-            vHeaders.push_back(pindex->GetBlockHeader());
             if (--nLimit <= 0 || pindex->GetBlockHash() == hashStop)
                 break;
         }

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -408,17 +408,6 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus
     return true;
 }
 
-bool ReadBlockHeaderFromDisk(CBlockHeader& header, const CBlockIndex* pindex, const Consensus::Params& consensusParams)
-{
-    // Not very efficient: read a block and throw away all but the header.
-    CBlock tmp;
-    if (!ReadBlockFromDisk(tmp, pindex, consensusParams)) {
-        return false;
-    }
-    header = tmp.GetBlockHeader();
-    return true;
-}
-
 bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start)
 {
     FlatFilePos hpos = pos;

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -79,7 +79,6 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus
 bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start);
 bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const CBlockIndex* pindex, const CMessageHeader::MessageStartChars& message_start);
 // ELEMENTS:
-bool ReadBlockHeaderFromDisk(class CBlockHeader& header, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
 
 bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex);
 bool WriteUndoDataForBlock(const CBlockUndo& blockundo, BlockValidationState& state, CBlockIndex* pindex, const CChainParams& chainparams);

--- a/src/pegins.cpp
+++ b/src/pegins.cpp
@@ -26,6 +26,8 @@
 // ELEMENTS
 //
 
+#include <validation.h>
+
 namespace {
 static secp256k1_context* secp256k1_ctx_validation;
 
@@ -487,6 +489,7 @@ std::vector<std::pair<CScript, CScript>> GetValidFedpegScripts(const CBlockIndex
             break;
         }
 
+        ForceUntrimHeader(p_epoch_start);
         if (!p_epoch_start->dynafed_params().IsNull()) {
             fedpegscripts.push_back(std::make_pair(p_epoch_start->dynafed_params().m_current.m_fedpeg_program, p_epoch_start->dynafed_params().m_current.m_fedpegscript));
         } else {

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -221,13 +221,9 @@ static bool rest_headers(const std::any& context,
     case RetFormat::BINARY: {
         CDataStream ssHeader(SER_NETWORK, PROTOCOL_VERSION);
         for (const CBlockIndex *pindex : headers) {
-            if (pindex->trimmed()) {
-                CBlockHeader tmp;
-                ReadBlockHeaderFromDisk(tmp, pindex, Params().GetConsensus());
-                ssHeader << tmp;
-            } else {
-                ssHeader << pindex->GetBlockHeader();
-            }
+            CBlockIndex tmpBlockIndexFull;
+            const CBlockIndex* pindexfull = pindex->untrim_to(&tmpBlockIndexFull);
+            ssHeader << pindexfull->GetBlockHeader();
         }
 
         std::string binaryHeader = ssHeader.str();
@@ -239,14 +235,9 @@ static bool rest_headers(const std::any& context,
     case RetFormat::HEX: {
         CDataStream ssHeader(SER_NETWORK, PROTOCOL_VERSION);
         for (const CBlockIndex *pindex : headers) {
-            if (pindex->trimmed()) {
-                CBlockHeader tmp;
-                ReadBlockHeaderFromDisk(tmp, pindex, Params().GetConsensus());
-                ssHeader << tmp;
-
-            } else {
-                ssHeader << pindex->GetBlockHeader();
-            }
+            CBlockIndex tmpBlockIndexFull;
+            const CBlockIndex* pindexfull = pindex->untrim_to(&tmpBlockIndexFull);
+            ssHeader << pindexfull->GetBlockHeader();
         }
 
         std::string strHex = HexStr(ssHeader) + "\n";

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -226,15 +226,18 @@ CBlockIndex* ParseHashOrHeight(const UniValue& param, ChainstateManager& chainma
     }
 }
 
-UniValue blockheaderToJSON(const CBlockIndex* tip, const CBlockIndex* blockindex)
+UniValue blockheaderToJSON(const CBlockIndex* tip, const CBlockIndex* blockindex_)
 {
     // Serialize passed information without accessing chain state of the active chain!
     AssertLockNotHeld(cs_main); // For performance reasons
 
+    CBlockIndex tmpBlockIndexFull;
+    const CBlockIndex* blockindex = blockindex_->untrim_to(&tmpBlockIndexFull);
+
     UniValue result(UniValue::VOBJ);
     result.pushKV("hash", blockindex->GetBlockHash().GetHex());
     const CBlockIndex* pnext;
-    int confirmations = ComputeNextBlockAndDepth(tip, blockindex, pnext);
+    int confirmations = ComputeNextBlockAndDepth(tip, blockindex_, pnext);
     result.pushKV("confirmations", confirmations);
     result.pushKV("height", blockindex->nHeight);
     result.pushKV("version", blockindex->nVersion);
@@ -271,7 +274,7 @@ UniValue blockheaderToJSON(const CBlockIndex* tip, const CBlockIndex* blockindex
         }
     }
     result.pushKV("nTx", (uint64_t)blockindex->nTx);
-    if (blockindex->pprev)
+    if (blockindex_->pprev)
         result.pushKV("previousblockhash", blockindex->pprev->GetBlockHash().GetHex());
     if (pnext)
         result.pushKV("nextblockhash", pnext->GetBlockHash().GetHex());
@@ -966,7 +969,7 @@ static RPCHelpMan getblockheader()
     if (!request.params[1].isNull())
         fVerbose = request.params[1].get_bool();
 
-    const CBlockIndex* pblockindex;
+    CBlockIndex* pblockindex;
     const CBlockIndex* tip;
     {
         ChainstateManager& chainman = EnsureAnyChainman(request.context);
@@ -982,13 +985,9 @@ static RPCHelpMan getblockheader()
     if (!fVerbose)
     {
         CDataStream ssBlock(SER_NETWORK, PROTOCOL_VERSION);
-        if (pblockindex->trimmed()) {
-            CBlockHeader tmp;
-            ReadBlockHeaderFromDisk(tmp, pblockindex, Params().GetConsensus());
-            ssBlock << tmp;
-        } else {
-            ssBlock << pblockindex->GetBlockHeader();
-        }
+        CBlockIndex tmpBlockIndexFull;
+        const CBlockIndex* pblockindexfull = pblockindex->untrim_to(&tmpBlockIndexFull);
+        ssBlock << pblockindexfull->GetBlockHeader();
         std::string strHex = HexStr(ssBlock);
         return strHex;
     }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -373,6 +373,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
                 pindexNew->nStatus        = diskindex.nStatus;
                 pindexNew->nTx            = diskindex.nTx;
 
+                pindexNew->set_stored();
                 n_total++;
                 if (diskindex.nHeight >= trimBelowHeight) {
                     n_untrimmed++;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -373,24 +373,26 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
                 pindexNew->nStatus        = diskindex.nStatus;
                 pindexNew->nTx            = diskindex.nTx;
 
+                pindexNew->proof               = diskindex.proof;
+                pindexNew->m_dynafed_params    = diskindex.m_dynafed_params;
+                pindexNew->m_signblock_witness = diskindex.m_signblock_witness;
+
+                assert(!(g_signed_blocks && diskindex.m_dynafed_params.value().IsNull() && diskindex.proof.value().IsNull()));
+
                 pindexNew->set_stored();
                 n_total++;
+
+                const uint256 block_hash = pindexNew->GetBlockHash();
+                // Only validate one of every 1000 block header for sanity check
+                if (pindexNew->nHeight % 1000 == 0 &&
+                        block_hash != consensusParams.hashGenesisBlock &&
+                        !CheckProof(pindexNew->GetBlockHeader(), consensusParams)) {
+                    return error("%s: CheckProof: %s, %s", __func__, block_hash.ToString(), pindexNew->ToString());
+                }
                 if (diskindex.nHeight >= trimBelowHeight) {
                     n_untrimmed++;
-                    pindexNew->proof               = diskindex.proof;
-                    pindexNew->m_dynafed_params    = diskindex.m_dynafed_params;
-                    pindexNew->m_signblock_witness = diskindex.m_signblock_witness;
-
-                    const uint256 block_hash = pindexNew->GetBlockHash();
-                    // Only validate one of every 1000 block header for sanity check
-                    if (pindexNew->nHeight % 1000 == 0 &&
-                            block_hash != consensusParams.hashGenesisBlock &&
-                            !CheckProof(pindexNew->GetBlockHeader(), consensusParams)) {
-                        return error("%s: CheckProof: %s, %s", __func__, block_hash.ToString(), pindexNew->ToString());
-                    }
                 } else {
-                    pindexNew->m_trimmed = true;
-                    pindexNew->m_trimmed_dynafed_block = !diskindex.m_dynafed_params.value().IsNull();
+                    pindexNew->trim();
                 }
 
                 pcursor->Next();

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -308,41 +308,6 @@ bool CBlockTreeDB::WritePAKList(const std::vector<std::vector<unsigned char> >& 
         return Write(std::make_pair(DB_PAK, uint256S("1")), offline_list) && Write(std::make_pair(DB_PAK, uint256S("2")), online_list) && Write(std::make_pair(DB_PAK, uint256S("3")), reject);
 }
 
-/** Note that we only get a conservative (lower) estimate of the max header height here,
- * obtained by sampling the first 10,000 headers on disk (which are in random order) and
- * taking the highest block we see. */
-bool CBlockTreeDB::WalkBlockIndexGutsForMaxHeight(int* nHeight) {
-    std::unique_ptr<CDBIterator> pcursor(NewIterator());
-    *nHeight = 0;
-    int i = 0;
-    pcursor->Seek(std::make_pair(DB_BLOCK_INDEX, uint256()));
-    while (pcursor->Valid()) {
-        if (ShutdownRequested()) return false;
-        std::pair<uint8_t, uint256> key;
-        if (pcursor->GetKey(key) && key.first == DB_BLOCK_INDEX) {
-            i++;
-            if (i > 10'000) {
-                // Under the (accurate) assumption that the headers on disk are effectively in random height order,
-                //   we have a good-enough (conservative) estimate of the max height very quickly, and don't need to
-                //   waste more time. Shortcutting like this will cause us to keep a few extra headers, which is fine.
-                break;
-            }
-            CDiskBlockIndex diskindex;
-            if (pcursor->GetValue(diskindex)) {
-                if (diskindex.nHeight > *nHeight) {
-                    *nHeight = diskindex.nHeight;
-                }
-                pcursor->Next();
-            } else {
-                return error("%s: failed to read value", __func__);
-            }
-        } else {
-            break;
-        }
-    }
-    return true;
-}
-
 const CBlockIndex *CBlockTreeDB::RegenerateFullIndex(const CBlockIndex *pindexTrimmed, CBlockIndex *pindexNew) const
 {
     if(!pindexTrimmed->trimmed()) {

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -87,6 +87,7 @@ public:
     bool ReadFlag(const std::string &name, bool &fValue);
     bool LoadBlockIndexGuts(const Consensus::Params& consensusParams, std::function<CBlockIndex*(const uint256&)> insertBlockIndex, int trimBelowHeight);
     // ELEMENTS:
+    const CBlockIndex* RegenerateFullIndex(const CBlockIndex *pindexTrimmed, CBlockIndex *pindexNew) const;
     bool WalkBlockIndexGutsForMaxHeight(int* nHeight);
     bool ReadPAKList(std::vector<std::vector<unsigned char> >& offline_list, std::vector<std::vector<unsigned char> >& online_list, bool& reject);
     bool WritePAKList(const std::vector<std::vector<unsigned char> >& offline_list, const std::vector<std::vector<unsigned char> >& online_list, bool reject);

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -88,7 +88,6 @@ public:
     bool LoadBlockIndexGuts(const Consensus::Params& consensusParams, std::function<CBlockIndex*(const uint256&)> insertBlockIndex, int trimBelowHeight);
     // ELEMENTS:
     const CBlockIndex* RegenerateFullIndex(const CBlockIndex *pindexTrimmed, CBlockIndex *pindexNew) const;
-    bool WalkBlockIndexGutsForMaxHeight(int* nHeight);
     bool ReadPAKList(std::vector<std::vector<unsigned char> >& offline_list, std::vector<std::vector<unsigned char> >& online_list, bool& reject);
     bool WritePAKList(const std::vector<std::vector<unsigned char> >& offline_list, const std::vector<std::vector<unsigned char> >& online_list, bool reject);
 };

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2360,7 +2360,7 @@ bool CChainState::FlushStateToDisk(
                     (*it)->set_stored();
                 }
 
-                if (fTrimHeaders) {
+                if (fTrimHeaders && !ShutdownRequested()) {
                     LogPrintf("Flushing block index, trimming headers, setTrimmableBlockIndex.size(): %d\n", setTrimmableBlockIndex.size());
                     int trim_height = m_chain.Height() - nMustKeepFullHeaders;
                     int min_height = std::numeric_limits<int>::max();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2355,6 +2355,11 @@ bool CChainState::FlushStateToDisk(
                     return AbortNode(state, "Failed to write to block index database");
                 }
 
+                // This should be done inside WriteBatchSync, but CBlockIndex is const there
+                for (std::set<CBlockIndex*>::iterator it = setTrimmableBlockIndex.begin(); it != setTrimmableBlockIndex.end(); it++) {
+                    (*it)->set_stored();
+                }
+
                 if (fTrimHeaders) {
                     LogPrintf("Flushing block index, trimming headers, setTrimmableBlockIndex.size(): %d\n", setTrimmableBlockIndex.size());
                     int trim_height = m_chain.Height() - nMustKeepFullHeaders;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4161,15 +4161,7 @@ bool BlockManager::LoadBlockIndex(
 {
     int trim_below_height = 0;
     if (fTrimHeaders) {
-        int max_height = 0;
-        if (!blocktree.WalkBlockIndexGutsForMaxHeight(&max_height)) {
-            LogPrintf("LoadBlockIndex: Failed to WalkBlockIndexGutsForMaxHeight.\n");
-            return false;
-        }
-
-        int must_keep_headers = (consensus_params.total_valid_epochs + 2) * consensus_params.dynamic_epoch_length;
-        int extra_headers_buffer = consensus_params.dynamic_epoch_length * 2; // XXX arbitrary
-        trim_below_height = max_height - must_keep_headers - extra_headers_buffer;
+        trim_below_height = std::numeric_limits<int>::max();
     }
     if (!blocktree.LoadBlockIndexGuts(consensus_params, [this](const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return this->InsertBlockIndex(hash); }, trim_below_height))
         return false;
@@ -4218,6 +4210,9 @@ bool BlockManager::LoadBlockIndex(
             pindexBestHeader = pindex;
     }
 
+    if (pindexBestHeader) {
+        ForceUntrimHeader(pindexBestHeader);
+    }
     return true;
 }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -1068,4 +1068,5 @@ bool LoadMempool(CTxMemPool& pool, CChainState& active_chainstate, FopenFn mocka
  */
 const AssumeutxoData* ExpectedAssumeutxo(const int height, const CChainParams& params);
 
+void ForceUntrimHeader(const CBlockIndex *pindex_);
 #endif // BITCOIN_VALIDATION_H


### PR DESCRIPTION
Currently, trim_headers has certain limitations wrt the way it behaves in P2P protocol and in certain RPC calls. This PR brings back the full functionality and fixes a corruption issue when combined with pruning.

This is the 22.x version of https://github.com/ElementsProject/elements/pull/1270