### PR TITLE
fix: segfault on getpeginaddress rpc when not in elements mode

### DIFF
--- a/src/wallet/rpc/elements.cpp
+++ b/src/wallet/rpc/elements.cpp
@@ -197,6 +197,13 @@ RPCHelpMan getpeginaddress()
 
     // Get P2CH deposit address on mainchain from most recent fedpegscript.
     const auto& fedpegscripts = GetValidFedpegScripts(pwallet->chain().getTip(), Params().GetConsensus(), true /* nextblock_validation */);
+    if (fedpegscripts.empty()) {
+        std::string message = "No valid fedpegscripts.";
+        if (!g_con_elementsmode) {
+            message += " Not running in Elements mode, check your 'chain' param.";
+        }
+        throw JSONRPCError(RPC_INTERNAL_ERROR, message);
+    }
     CTxDestination mainchain_dest(WitnessV0ScriptHash(calculate_contract(fedpegscripts.front().second, dest_script)));
     // P2SH-wrapped is the only valid choice for non-dynafed chains but still an
     // option for dynafed-enabled ones as well

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -122,6 +122,7 @@ BASE_SCRIPTS = [
     'feature_block.py',
     'rpc_fundrawtransaction.py --legacy-wallet',
     'rpc_fundrawtransaction.py --descriptors',
+    'wallet_elements_regression_1263.py',
     'p2p_compactblocks.py',
     'p2p_compactblocks_blocksonly.py',
     'feature_segwit.py --legacy-wallet',

--- a/test/functional/wallet_elements_regression_1263.py
+++ b/test/functional/wallet_elements_regression_1263.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test getpeginaddress when started with Bitcoin chain params.
+
+This doesn't make sense and should fail gracefully, but is causing a segfault.
+This functional test should catch any regression to this fix.
+"""
+
+from test_framework.util import assert_raises_rpc_error
+from test_framework.test_framework import BitcoinTestFramework
+
+class RegressionTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.chain = "regtest"
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        self.log.info("Start in Bitcoin regtest mode")
+        self.nodes[0].createwallet("pegin")
+        rpc = self.nodes[0].get_wallet_rpc("pegin")
+
+        self.log.info("Call getpeginaddress")
+        assert_raises_rpc_error(-32603, "No valid fedpegscripts. Not running in Elements mode, check your 'chain' param.", rpc.getpeginaddress)
+
+if __name__ == '__main__':
+    RegressionTest().main()


### PR DESCRIPTION
Fixes https://github.com/ElementsProject/elements/issues/1263

When not running in Elements mode, GetValidFedpegScripts returns an empty vector. Subsequently `calculate_contract` is called with `fedpegscripts.front().second` which is a null reference. This reference is passed into `MatchLiquidWatchman` which tries to dereference the null reference and causes a segfault.

This fix throws an exception in `getpeginaddress` if fedpegscripts is empty, returning an error to the RPC caller. It also adds a functional regression test.