### PR TITLE
Fix VerifySchnorr bug in 23.x

### DIFF
--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -208,7 +208,7 @@ bool XOnlyPubKey::VerifySchnorr(const Span<const unsigned char> msg, Span<const 
     assert(sigbytes.size() == 64);
     secp256k1_xonly_pubkey pubkey;
     if (!secp256k1_xonly_pubkey_parse(secp256k1_context_verify, &pubkey, m_keydata.data())) return false;
-    return secp256k1_schnorrsig_verify(secp256k1_context_verify, sigbytes.data(), msg.begin(), 32, &pubkey);
+    return secp256k1_schnorrsig_verify(secp256k1_context_verify, sigbytes.data(), msg.data(), msg.size(), &pubkey);
 }
 
 // ELEMENTS: this is preserved from an old version of the Taproot code for use in OP_TWEAKVERIFY


### PR DESCRIPTION
Fixes issue which was causing validation to fail on block `2a70e30a3b975b53a0598139f6f490ff0865a47d0028a55ddc04451270d228d0` in liquidtestnet.

This bug was introduced in the merge of https://github.com/bitcoin/bitcoin/pull/22448 
https://github.com/bitcoin/bitcoin/pull/22448 in https://github.com/ElementsProject/elements/commit/09333e2aca97bc819aed26eb2835df7cf604c38d.

It is not yet clear why only a testnet block was affected, and no production blocks were affected.
