### PR TITLE
pubkey: fix VerifySchnorr bug which is causing testnet validation failure

### DIFF
--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -208,7 +208,7 @@ bool XOnlyPubKey::VerifySchnorr(const Span<const unsigned char> msg, Span<const 
     assert(sigbytes.size() == 64);
     secp256k1_xonly_pubkey pubkey;
     if (!secp256k1_xonly_pubkey_parse(secp256k1_context_verify, &pubkey, m_keydata.data())) return false;
-    return secp256k1_schnorrsig_verify(secp256k1_context_verify, sigbytes.data(), msg.begin(), 32, &pubkey);
+    return secp256k1_schnorrsig_verify(secp256k1_context_verify, sigbytes.data(), msg.data(), msg.size(), &pubkey);
 }
 
 // ELEMENTS: this is preserved from an old version of the Taproot code for use in OP_TWEAKVERIFY

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -33,6 +33,8 @@
 
 #include <univalue.h>
 
+using namespace std;
+
 // Uncomment if you want to output updated JSON tests.
 // #define UPDATE_JSON_TESTS
 
@@ -1756,6 +1758,7 @@ BOOST_AUTO_TEST_CASE(script_assets_test)
     file.close();
 }
 
+// ELEMENTS: TODO: Some of these test vectors need updating
 BOOST_AUTO_TEST_CASE(bip341_keypath_test_vectors)
 {
     UniValue tests;
@@ -1777,9 +1780,14 @@ BOOST_AUTO_TEST_CASE(bip341_keypath_test_vectors)
 
         PrecomputedTransactionData txdata;
         txdata.Init(tx, std::vector<CTxOut>{utxos}, true);
+        // ELEMENTS: add a txout witness for each output
+        for (u_int i = 0; i < (u_int)utxos.size(); i++) {
+            tx.witness.vtxoutwit.emplace_back(CTxOutWitness());
+        }
 
         BOOST_CHECK(txdata.m_bip341_taproot_ready);
-        // BOOST_CHECK_EQUAL(HexStr(txdata.m_spent_amounts_single_hash), vec["intermediary"]["hashAmounts"].get_str());
+        // ELEMENTS: FIXME
+        //BOOST_CHECK_EQUAL(HexStr(txdata.m_spent_amounts_single_hash), vec["intermediary"]["hashAmounts"].get_str());
         BOOST_CHECK_EQUAL(HexStr(txdata.m_outputs_single_hash), vec["intermediary"]["hashOutputs"].get_str());
         BOOST_CHECK_EQUAL(HexStr(txdata.m_prevouts_single_hash), vec["intermediary"]["hashPrevouts"].get_str());
         BOOST_CHECK_EQUAL(HexStr(txdata.m_spent_scripts_single_hash), vec["intermediary"]["hashScriptPubkeys"].get_str());
@@ -1809,22 +1817,24 @@ BOOST_AUTO_TEST_CASE(bip341_keypath_test_vectors)
             provider.keys[key.GetPubKey().GetID()] = key;
             MutableTransactionSignatureCreator creator(&tx, txinpos, utxos[txinpos].nValue, &txdata, hashtype);
             std::vector<unsigned char> signature;
+            BOOST_CHECK(creator.CreateSchnorrSig(provider, signature, pubkey, nullptr, &merkle_root, SigVersion::TAPROOT));
             // ELEMENTS: FIXME
-            // BOOST_CHECK(creator.CreateSchnorrSig(provider, signature, pubkey, nullptr, &merkle_root, SigVersion::TAPROOT));
-            // BOOST_CHECK_EQUAL(HexStr(signature), input["expected"]["witness"][0].get_str());
+            //BOOST_CHECK_EQUAL(HexStr(signature), input["expected"]["witness"][0].get_str());
 
             // We can't observe the tweak used inside the signing logic, so verify by recomputing it.
-            // BOOST_CHECK_EQUAL(HexStr(pubkey.ComputeTapTweakHash(merkle_root.IsNull() ? nullptr : &merkle_root)), input["intermediary"]["tweak"].get_str());
+            // ELEMENTS: FIXME
+            //BOOST_CHECK_EQUAL(HexStr(pubkey.ComputeTapTweakHash(merkle_root.IsNull() ? nullptr : &merkle_root)), input["intermediary"]["tweak"].get_str());
 
             // We can't observe the sighash used inside the signing logic, so verify by recomputing it.
             ScriptExecutionData sed;
             sed.m_annex_init = true;
             sed.m_annex_present = false;
-            // uint256 sighash;
-            // BOOST_CHECK(SignatureHashSchnorr(sighash, sed, tx, txinpos, hashtype, SigVersion::TAPROOT, txdata, MissingDataBehavior::FAIL));
+            uint256 sighash;
+            BOOST_CHECK(SignatureHashSchnorr(sighash, sed, tx, txinpos, hashtype, SigVersion::TAPROOT, txdata, MissingDataBehavior::FAIL));
             // BOOST_CHECK_EQUAL(HexStr(sighash), input["intermediary"]["sigHash"].get_str());
 
             // To verify the sigmsg, hash the expected sigmsg, and compare it with the (expected) sighash.
+            // ELEMENTS: FIXME
             //BOOST_CHECK_EQUAL(HexStr((CHashWriter(HASHER_TAPSIGHASH_ELEMENTS) << Span{ParseHex(input["intermediary"]["sigMsg"].get_str())}).GetSHA256()), input["intermediary"]["sigHash"].get_str());
         }
 

--- a/test/functional/feature_tapscript_opcodes.py
+++ b/test/functional/feature_tapscript_opcodes.py
@@ -582,9 +582,6 @@ class TapHashPeginTest(BitcoinTestFramework):
             self.tapscript_satisfy_test(CScript([msg, pub, OP_CHECKSIGFROMSTACK]), inputs = [sig], fail=fail)
 
         csfs_test("e168c349d0d2499caf3a6d71734c743d517f94f8571fa52c04285b68deec1936")
-        # Elements: FIXME this test fails
-        # with test_framework.authproxy.JSONRPCException: non-mandatory-script-verify-flag (Invalid Schnorr signature) (-26)
-        # csfs_test("Hello World!".encode('utf-8').hex())
         csfs_test("Hello World!".encode('utf-8').hex(), fail="Invalid Schnorr signature", mutute_sig=True)
         msg = bytes.fromhex("e168c349d0d2499caf3a6d71734c743d517f94f8571fa52c04285b68deec1936")
         pub = bytes.fromhex("3f67e97da0df6931189cfb0072447da22707897bd5de04936a277ed7e00b35b3")

--- a/test/functional/feature_tapscript_opcodes.py
+++ b/test/functional/feature_tapscript_opcodes.py
@@ -258,7 +258,7 @@ class TapHashPeginTest(BitcoinTestFramework):
     def run_test(self):
         self.generate(self.nodes[0], 101)
         self.wait_until(lambda: self.nodes[0].getblockcount() == 101, timeout=5)
-        # spend the initialfreecoins to node0, to fix bad-txns-inputs-missingorspent error when creating the first taproot utxo
+        # ELEMENTS: spend the initialfreecoins to node0, to fix bad-txns-inputs-missingorspent error when creating the first taproot utxo
         self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 50)
         self.generate(self.nodes[0], 1)
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -208,9 +208,8 @@ BASE_SCRIPTS = [
     'rpc_signrawtransaction.py --descriptors',
     'rpc_rawtransaction.py --legacy-wallet',
     'rpc_rawtransaction.py --descriptors',
-    # ELEMENTS: FIXME failing tests
-    # 'wallet_groups.py --legacy-wallet',
-    # 'wallet_groups.py --descriptors',
+    'wallet_groups.py --legacy-wallet',
+    'wallet_groups.py --descriptors',
     'wallet_transactiontime_rescan.py --descriptors',
     'wallet_transactiontime_rescan.py --legacy-wallet',
     'p2p_addrv2_relay.py',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -145,7 +145,7 @@ BASE_SCRIPTS = [
     'wallet_signer.py --descriptors',
     # ELEMENTS: FIXME failing tests
     # 'feature_taphash_pegins_issuances.py',
-    # 'feature_tapscript_opcodes.py',
+    'feature_tapscript_opcodes.py',
     # vv Tests less than 60s vv
     'p2p_sendheaders.py',
     'wallet_importmulti.py --legacy-wallet',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -131,8 +131,7 @@ BASE_SCRIPTS = [
     'feature_segwit.py --descriptors',
     # vv Tests less than 2m vv
     'wallet_basic.py --legacy-wallet',
-    # ELEMENTS: FIXME
-    # 'wallet_basic.py --descriptors',
+    'wallet_basic.py --descriptors',
     'wallet_labels.py --legacy-wallet',
     'wallet_labels.py --descriptors',
     'p2p_segwit.py',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -140,8 +140,7 @@ BASE_SCRIPTS = [
     'mempool_updatefromblock.py',
     'wallet_dump.py --legacy-wallet',
     'feature_taproot.py --previous_release',
-    # ELEMENTS: FIXME taproot test needs to be updated
-    # 'feature_taproot.py',
+    'feature_taproot.py',
     'rpc_signer.py',
     'wallet_signer.py --descriptors',
     # ELEMENTS: FIXME failing tests

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -143,8 +143,7 @@ BASE_SCRIPTS = [
     'feature_taproot.py',
     'rpc_signer.py',
     'wallet_signer.py --descriptors',
-    # ELEMENTS: FIXME failing tests
-    # 'feature_taphash_pegins_issuances.py',
+    'feature_taphash_pegins_issuances.py',
     'feature_tapscript_opcodes.py',
     # vv Tests less than 60s vv
     'p2p_sendheaders.py',

--- a/test/functional/wallet_groups.py
+++ b/test/functional/wallet_groups.py
@@ -49,6 +49,7 @@ class WalletGroupTest(BitcoinTestFramework):
 
         # For each node, send 0.2 coins back to 0;
         # - node[1] should pick one 0.5 UTXO and leave the rest
+        # ELEMENTS: since SRD was added, node[1] sometimes picks a 1.0 UTXO
         # - node[2] should pick one (1.0 + 0.5) UTXO group corresponding to a
         #   given address, and leave the rest
         self.log.info("Test sending transactions picks one UTXO group and leaves the rest")
@@ -61,7 +62,12 @@ class WalletGroupTest(BitcoinTestFramework):
         v = [vout["value"] for vout in tx1["vout"] if vout["scriptPubKey"]["type"] != "fee"]
         v.sort()
         assert_approx(v[0], vexp=0.2, vspan=0.0001)
-        assert_approx(v[1], vexp=0.3, vspan=0.0001)
+        # ELEMENTS
+        try:
+            assert_approx(v[1], vexp=0.3, vspan=0.0001)
+        except AssertionError:
+            assert_approx(v[1], vexp=0.8, vspan=0.0001)
+
 
         txid2 = self.nodes[2].sendtoaddress(self.nodes[0].getnewaddress(), 0.2)
         tx2 = self.nodes[2].getrawtransaction(txid2, True)

--- a/test/functional/wallet_groups.py
+++ b/test/functional/wallet_groups.py
@@ -60,11 +60,6 @@ class WalletGroupTest(BitcoinTestFramework):
         # one output should be 0.2, the other should be ~0.3
         v = [vout["value"] for vout in tx1["vout"] if vout["scriptPubKey"]["type"] != "fee"]
         v.sort()
-        # JAMES/BYRON DELETE ME
-        #print(self.nodes[1].listunspent())
-        print("vin amount = {}".format(self.nodes[0].gettxout(tx1["vin"][0]["txid"], tx1["vin"][0]["vout"], True)["value"]))
-        print("vout amounts = {}".format(v))
-        # END JAMES?BYRON
         assert_approx(v[0], vexp=0.2, vspan=0.0001)
         assert_approx(v[1], vexp=0.3, vspan=0.0001)
 
@@ -114,10 +109,10 @@ class WalletGroupTest(BitcoinTestFramework):
         assert_equal(input_addrs[0], input_addrs[1])
         # Node 2 enforces avoidpartialspends so needs no checking here
 
-        tx4_ungrouped_fee = 2820
-        tx4_grouped_fee = 4160
-        tx5_6_ungrouped_fee = 5520
-        tx5_6_grouped_fee = 8240
+        tx4_ungrouped_fee = 5140
+        tx4_grouped_fee = 6520
+        tx5_6_ungrouped_fee = 7880
+        tx5_6_grouped_fee = 10620
 
         self.log.info("Test wallet option maxapsfee")
         addr_aps = self.nodes[3].getnewaddress()


### PR DESCRIPTION
Fixes issue which was causing validation to fail on block 2a70e30a3b975b53a0598139f6f490ff0865a47d0028a55ddc04451270d228d0 in liquidtestnet.

This bug was introduced in the merge of https://github.com/bitcoin/bitcoin/pull/22448 in https://github.com/ElementsProject/elements/commit/09333e2aca97bc819aed26eb2835df7cf604c38d.

It is not yet clear why only a testnet block is affected by this issue, and why the production liquid chain syncs fully.

Subsequent commits in this PR contain fixes for various failing functional tests. 