### PR TITLE
ci: fix macos failing functional tests 

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -124,7 +124,7 @@ BASE_SCRIPTS = [
     'feature_block.py',
     'rpc_fundrawtransaction.py --legacy-wallet',
     'rpc_fundrawtransaction.py --descriptors',
-    'wallet_elements_regression_1263.py',
+    'wallet_elements_regression_1263.py --legacy-wallet',
     'p2p_compactblocks.py',
     'p2p_compactblocks_blocksonly.py',
     'feature_segwit.py --legacy-wallet',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -88,7 +88,7 @@ EXTENDED_SCRIPTS = [
 BASE_SCRIPTS = [
     # Scripts that are run by default.
     # vv First elements tests vv
-    'example_elements_code_tutorial.py',
+    'example_elements_code_tutorial.py --legacy-wallet',
     'feature_fedpeg.py --legacy-wallet',
     'feature_fedpeg.py --pre_transition --legacy-wallet',
     'feature_fedpeg.py --post_transition --legacy-wallet',


### PR DESCRIPTION
The macOS 13 CI job in elements-23.x defaults to descriptor wallets, so `example_elements_code_tutorial.py` fails with "insufficient funds". 

Fixed by running the test with legacy wallet. 