### PR TITLE
simplicity: enable coverage in configure.ac

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -208,6 +208,7 @@ LCOV_FILTER_PATTERN = \
 	-p "src/univalue" \
 	-p "src/crypto/ctaes" \
 	-p "src/secp256k1" \
+	-p "src/simplicity/secp256k1" \
 	-p "depends"
 
 DIR_FUZZ_SEED_CORPUS ?= qa-assets/fuzz_seed_corpus

--- a/configure.ac
+++ b/configure.ac
@@ -810,7 +810,7 @@ if test x$use_lcov = xyes; then
 
   AX_CHECK_LINK_FLAG([[--coverage]], [LDFLAGS="$LDFLAGS --coverage"],
     [AC_MSG_ERROR("lcov testing requested but --coverage linker flag does not work")])
-  AX_CHECK_COMPILE_FLAG([--coverage],[CXXFLAGS="$CXXFLAGS --coverage"],
+  AX_CHECK_COMPILE_FLAG([--coverage],[CXXFLAGS="$CXXFLAGS --coverage";CFLAGS="$CFLAGS --coverage"],
     [AC_MSG_ERROR("lcov testing requested but --coverage flag does not work")])
   CXXFLAGS="$CXXFLAGS -Og"
 fi


### PR DESCRIPTION
- enables coverage for the simplicity build when elements is built with `--enable-lcov` 
- filters `src/simplicity/secp256k1` from results (since `src/secp256k1` is also filtered by upstream)  

example output: 

qa-assets from https://github.com/uncomputable/asset-gen thanks @uncomputable 

configured with: `./configure --enable-lcov --with-incompatible-bdb --with-seccomp=no` 

built with: `DIR_UNIT_TEST_DATA=/path/to/qa-assets/unit_test_data make -j15 cov` 

uploaded results here: https://simplicity-coverage.netlify.app/ 

![image](https://github.com/ElementsProject/elements/assets/351403/57391357-94c6-4440-b046-53cee708766b)


