### PR TITLE
test: fix tests broken by change to getpeginaddress

### DIFF
--- a/test/functional/rpc_tweakfedpeg.py
+++ b/test/functional/rpc_tweakfedpeg.py
@@ -38,12 +38,14 @@ class TweakFedpegTest(BitcoinTestFramework):
     def run_test(self):
         # Test that OP_TRUE mainchain_addr/claim_script never changes
         assert_equal(self.nodes[0].getsidechaininfo()["fedpegscript"], OP_TRUE_SCRIPT)
+        self.generate(self.nodes[0], 1, sync_fun=self.no_op) # just to get node out of ibd
         pegin_addr = self.nodes[0].getpeginaddress()
         for _ in range(5):
             assert_equal(pegin_addr["mainchain_address"], self.nodes[0].getpeginaddress()["mainchain_address"])
             assert_equal(self.nodes[0].tweakfedpegscript(pegin_addr["claim_script"])["script"], OP_TRUE_SCRIPT)
 
         # Test that OP_CMS has all keys change and matches elements-0.14 example
+        self.generate(self.nodes[1], 1, sync_fun=self.no_op)
         pegin_addr = self.nodes[1].getpeginaddress()
         assert_equal(self.nodes[1].getsidechaininfo()["fedpegscript"], OP_CMS_SCRIPT)
         nontweak_decoded = self.nodes[1].decodescript(OP_CMS_SCRIPT)["asm"]
@@ -61,6 +63,7 @@ class TweakFedpegTest(BitcoinTestFramework):
                 "522102f5bc6bc407187d06854005c366b84b411534757f4503587cf335645a620f896a2102fd90164e4e7d53417e4eacfa3f86fd39fe40594791758739e8af31eeea4e79c552ae")
 
         # Test Liquid-style fedpegscript with CSV emergency keys(which don't get tweaked!)
+        self.generate(self.nodes[2], 1, sync_fun=self.no_op)
         pegin_addr = self.nodes[2].getpeginaddress()
         assert_equal(self.nodes[2].getsidechaininfo()["fedpegscript"], LIQUID_SCRIPT)
         nontweak_decoded = self.nodes[2].decodescript(LIQUID_SCRIPT)["asm"]
@@ -86,7 +89,7 @@ class TweakFedpegTest(BitcoinTestFramework):
         # Advance to dynamic federations activation, which has pubkeys
         # after OP_ELSE get tweaked except the exact liquidv1 template to
         # maintain compatibility
-        self.generate(self.nodes[2], 433, sync_fun=self.no_op)
+        self.generate(self.nodes[2], 432, sync_fun=self.no_op)
         assert_equal(self.nodes[2].getdeploymentinfo()['deployments']['dynafed']['bip9']['status'], 'active')
         assert_equal(self.nodes[2].tweakfedpegscript(claim_script)["script"], liquid_tweaked)
 

--- a/test/functional/wallet_elements_regression_1263.py
+++ b/test/functional/wallet_elements_regression_1263.py
@@ -24,6 +24,7 @@ class RegressionTest(BitcoinTestFramework):
         self.log.info("Start in Bitcoin regtest mode")
         self.nodes[0].createwallet("pegin")
         rpc = self.nodes[0].get_wallet_rpc("pegin")
+        self.generatetoaddress(self.nodes[0], 1, rpc.getnewaddress())
 
         self.log.info("Call getpeginaddress")
         assert_raises_rpc_error(-32603, "No valid fedpegscripts. Not running in Elements mode, check your 'chain' param.", rpc.getpeginaddress)


### PR DESCRIPTION
Fixes 2 functional tests failing since PR #1327 which changed getpeginaddress to only be valid when IsInitialBlockDownload is false

<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
