### PR TITLE
Ensure that arm-macos environments have sufficient QT thread stack

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -579,6 +579,10 @@ RPCConsole::RPCConsole(interfaces::Node& node, const PlatformStyle *_platformSty
     clear();
 
     GUIUtil::handleCloseWindowShortcut(this);
+#if defined(Q_OS_MAC) && defined(__aarch64__)
+    // MacOS default is apparently 0x80000, too small for MacOS arm; use linux-like size instead
+    thread.setStackSize(0x800000);
+#endif
 }
 
 RPCConsole::~RPCConsole()


### PR DESCRIPTION
Issuing assets via the elements-qt console interface on MacOS arm platforms causes the process to crash.  This appears to be because the secondary threads on MacOS default to a 512k stack (per https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Multithreading/CreatingThreads/CreatingThreads.html via https://stackoverflow.com/a/23609290 ) -- this in comparison to linux threads that apparently have 8M of stack.

This change forces the QT-related threads to have an 8M stack.