### PR TITLE
discount: fix init doc for acceptdiscountct and override for creatediscountct

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -896,7 +896,7 @@ protected:
         consensus.fedpegScript = StrHexToScriptWithDefault(args.GetArg("-fedpegscript", ""), default_script);
         consensus.start_p2wsh_script = args.GetIntArg("-con_start_p2wsh_script", consensus.start_p2wsh_script);
         create_discount_ct = args.GetBoolArg("-creatediscountct", false);
-        accept_discount_ct = args.GetBoolArg("-acceptdiscountct", create_discount_ct);
+        accept_discount_ct = args.GetBoolArg("-acceptdiscountct", false) || create_discount_ct;
 
         // Calculate pegged Bitcoin asset
         std::vector<unsigned char> commit = CommitToArguments(consensus, strNetworkID);
@@ -1129,7 +1129,7 @@ public:
 
         multi_data_permitted = true;
         create_discount_ct = args.GetBoolArg("-creatediscountct", false);
-        accept_discount_ct = args.GetBoolArg("-acceptdiscountct", false);
+        accept_discount_ct = args.GetBoolArg("-acceptdiscountct", false) || create_discount_ct;
 
         parentGenesisBlockHash = uint256S("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
         const bool parent_genesis_is_null = parentGenesisBlockHash == uint256();
@@ -1479,7 +1479,7 @@ public:
 
         multi_data_permitted = args.GetBoolArg("-multi_data_permitted", multi_data_permitted);
         create_discount_ct = args.GetBoolArg("-creatediscountct", create_discount_ct);
-        accept_discount_ct = args.GetBoolArg("-acceptdiscountct", accept_discount_ct || create_discount_ct);
+        accept_discount_ct = args.GetBoolArg("-acceptdiscountct", accept_discount_ct) || create_discount_ct;
 
         if (args.IsArgSet("-parentgenesisblockhash")) {
             parentGenesisBlockHash = uint256S(args.GetArg("-parentgenesisblockhash", ""));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -640,7 +640,7 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-initialreissuancetokens=<n>", "The amount of reissuance tokens created in the genesis block. (default: 0)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-ct_bits", strprintf("The default number of hiding bits in a rangeproof. Will be exceeded to cover amounts exceeding the maximum hiding value. (default: %d)", 52), ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-ct_exponent", strprintf("The hiding exponent. (default: %s)", 0), ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
-    argsman.AddArg("-acceptdiscountct", "Accept discounted fees for Confidential Transactions (default: true for liquidv1, false for other chains)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
+    argsman.AddArg("-acceptdiscountct", "Accept discounted fees for Confidential Transactions (default: false)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-creatediscountct", "Create Confidential Transactions with discounted fees (default: false). Setting this to true will also set 'acceptdiscountct' to true.", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
 
 #if defined(USE_SYSCALL_SANDBOX)

--- a/test/functional/feature_discount_ct.py
+++ b/test/functional/feature_discount_ct.py
@@ -26,7 +26,8 @@ class CTTest(BitcoinTestFramework):
             # node 1 accepts but does not create discounted CTs
             args + ["-acceptdiscountct=1", "-creatediscountct=0"],
             # node 2 both accepts and creates discounted CTs
-            args + ["-acceptdiscountct=1", "-creatediscountct=1"],
+            # check that 'create' overrides 'accept'
+            args + ["-acceptdiscountct=0", "-creatediscountct=1"],
         ]
 
     def skip_test_if_missing_module(self):


### PR DESCRIPTION
The default for acceptdiscountct in liquidv1 was changed to false in #1317 without the corresponding doc being updated. 

Also fixes that creatediscountct should override the acceptdiscountct setting.  