### PR TITLE
fix: size estimation for pegin transactions

### DIFF
--- a/src/wallet/rpc/elements.cpp
+++ b/src/wallet/rpc/elements.cpp
@@ -850,7 +850,7 @@ static UniValue createrawpegin(const JSONRPCRequest& request, T_tx_ref& txBTCRef
 
     // Estimate fee for transaction, decrement fee output(including witness data)
     unsigned int nBytes = GetVirtualTransactionSize(CTransaction(mtx)) +
-        (1+1+72+1+33/WITNESS_SCALE_FACTOR);
+        (1+1+72+1+33)/WITNESS_SCALE_FACTOR;
     CCoinControl coin_control;
     FeeCalculation feeCalc;
     CAmount nFeeNeeded = GetMinimumFee(*pwallet, nBytes, coin_control, &feeCalc);


### PR DESCRIPTION
Fixes the size estimation for pegin transactions, the witness scale factor was only being applied to the pubkey and not the rest of the witness data. 

The overestimation is ~56 bytes 

```
>>> (1+1+72+1+33/4)
83.25
>>> (1+1+72+1+33)/4
27.0
>>> 83.25 - 27.0
56.25
``` 

