### PR TITLE
Continue receiving data for the current messages, even when we select…

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -313,6 +313,8 @@ public:
  */
 class TransportDeserializer {
 public:
+    // returns true if the current deserialization is empty
+    virtual bool IsEmpty() const = 0;
     // returns true if the current deserialization is complete
     virtual bool Complete() const = 0;
     // set the serialization context version
@@ -363,6 +365,10 @@ public:
         Reset();
     }
 
+    bool IsEmpty() const override
+    {
+        return (nHdrPos == 0);
+    }
     bool Complete() const override
     {
         if (!in_data)


### PR DESCRIPTION
https://github.com/ElementsProject/elements/issues/1233 was fixed upstream, but it's still happening in 23.x. This fix intends to be much more "surgical" since it's only selecting recv for incomplete messages. Upstream's fix always selects recv now.

Needs to be backported to 23.2.x too