### PR TITLE
A couple miscellaneous fixes for fuzztests

### DIFF
--- a/src/primitives/confidential.h
+++ b/src/primitives/confidential.h
@@ -135,6 +135,11 @@ public:
     CConfidentialValue() { SetNull(); }
     CConfidentialValue(CAmount nAmount) { SetToAmount(nAmount); }
 
+    template <typename Stream>
+    inline void Unserialize(Stream& s) {
+        CConfidentialCommitment::Unserialize(s);
+    }
+
     /* An explicit value is called an amount. The first byte indicates it is
      * an explicit value, and the remaining 8 bytes is the value serialized as
      * a 64-bit big-endian integer. */

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -295,6 +295,9 @@ public:
             s >> nAsset;
             s >> nValue;
             s >> nNonce;
+            if (nAsset.IsNull() || nValue.IsNull()) {
+                throw std::ios_base::failure("Confidential values may not be null");
+            }
         } else {
             CAmount value;
             s >> value;

--- a/src/test/fuzz/rbf.cpp
+++ b/src/test/fuzz/rbf.cpp
@@ -15,7 +15,13 @@
 #include <string>
 #include <vector>
 
-FUZZ_TARGET(rbf)
+void initialize_rbf(void) {
+    // ELEMENTS: our mempool needs Params() to be set for multiple reasons -- to check
+    //  the discount CT rate, to figure out pegin policy, etc
+    SelectParams(CBaseChainParams::LIQUID1);
+}
+
+FUZZ_TARGET_INIT(rbf, initialize_rbf)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     SetMockTime(ConsumeTime(fuzzed_data_provider));


### PR DESCRIPTION
I ran all the non-Simplicity fuzztests for 100 CPU-hours and found 3 crashes. Two are minor things which are fixed here. Another was in deserializing PSBTs, which needs more investigation, so I did not address.