### PR TITLE
Fix some functional tests when bdb is not available

### DIFF
--- a/test/functional/example_elements_code_tutorial.py
+++ b/test/functional/example_elements_code_tutorial.py
@@ -25,6 +25,7 @@ class WalletTest(BitcoinTestFramework):
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
+        self.skip_if_no_bdb()
 
     def run_test(self):
         self.generate(self.nodes[0], COINBASE_MATURITY + 1)

--- a/test/functional/feature_discount_ct.py
+++ b/test/functional/feature_discount_ct.py
@@ -36,6 +36,7 @@ class CTTest(BitcoinTestFramework):
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
+        self.skip_if_no_bdb()
 
     def run_test(self):
         feerate = 1.0

--- a/test/functional/feature_discount_ct_ordering.py
+++ b/test/functional/feature_discount_ct_ordering.py
@@ -33,6 +33,7 @@ class CTTest(BitcoinTestFramework):
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
+        self.skip_if_no_bdb()
 
     def run_test(self):
 

--- a/test/functional/feature_taphash_pegins_issuances.py
+++ b/test/functional/feature_taphash_pegins_issuances.py
@@ -41,6 +41,7 @@ class TapHashPeginTest(BitcoinTestFramework):
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
+        self.skip_if_no_bdb()
 
     def setup_network(self, split=False):
         self.setup_nodes()

--- a/test/functional/feature_tapscript_opcodes.py
+++ b/test/functional/feature_tapscript_opcodes.py
@@ -45,6 +45,7 @@ class TapHashPeginTest(BitcoinTestFramework):
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
+        self.skip_if_no_bdb()
 
     def setup_network(self, split=False):
         self.setup_nodes()

--- a/test/functional/feature_trim_headers.py
+++ b/test/functional/feature_trim_headers.py
@@ -39,6 +39,7 @@ def make_signblockscript(num_nodes, required_signers, keys):
 class TrimHeadersTest(BitcoinTestFramework):
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
+        self.skip_if_no_bdb()
 
     # Dynamically generate N keys to be used for block signing.
     def init_keys(self, num_keys):

--- a/test/functional/wallet_elements_21million.py
+++ b/test/functional/wallet_elements_21million.py
@@ -50,8 +50,8 @@ class WalletTest(BitcoinTestFramework):
         assert_equal(self.nodes[1].getbalance()[asset], 22_000_000)
 
         # unload/load wallet
-        self.nodes[1].unloadwallet("")
-        self.nodes[1].loadwallet("")
+        self.nodes[1].unloadwallet(self.default_wallet_name)
+        self.nodes[1].loadwallet(self.default_wallet_name)
         assert_equal(self.nodes[1].getbalance()[asset], 22_000_000)
 
         # send more than 45 million of that asset
@@ -62,8 +62,8 @@ class WalletTest(BitcoinTestFramework):
         assert_equal(self.nodes[2].getbalance()[asset], 46_000_000)
 
         # unload/load wallet
-        self.nodes[2].unloadwallet("")
-        self.nodes[2].loadwallet("")
+        self.nodes[2].unloadwallet(self.default_wallet_name)
+        self.nodes[2].loadwallet(self.default_wallet_name)
         assert_equal(self.nodes[2].getbalance()[asset], 46_000_000)
 
         # send some policy asset to node 1 for fees
@@ -86,8 +86,8 @@ class WalletTest(BitcoinTestFramework):
         assert_equal(self.nodes[2].getbalance()[asset], 200_000_000)
 
         # unload/load wallet
-        self.nodes[2].unloadwallet("")
-        self.nodes[2].loadwallet("")
+        self.nodes[2].unloadwallet(self.default_wallet_name)
+        self.nodes[2].loadwallet(self.default_wallet_name)
         assert_equal(self.nodes[2].getbalance()[asset], 200_000_000)
 
 if __name__ == '__main__':

--- a/test/functional/wallet_elements_regression_1263.py
+++ b/test/functional/wallet_elements_regression_1263.py
@@ -19,6 +19,7 @@ class RegressionTest(BitcoinTestFramework):
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
+        self.skip_if_no_bdb()
 
     def run_test(self):
         self.log.info("Start in Bitcoin regtest mode")


### PR DESCRIPTION
Several tests are failing in the mac native builds because they only have descriptor wallets, peg-ins/peg-outs/initialfreecoins are not available yet for descriptor wallets so we need to disable them.

Also the 21M test fails in descriptor wallets but for different reasons, the wallets have different names