### PR TITLE
various bugfixes for new fuzz test vectors

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -469,7 +469,7 @@ public:
     bool RemoveDynaFedMaskOnSerialize(bool for_read) {
         if (for_read) {
             bool is_dyna = nVersion < 0;
-            nVersion = ~CBlockHeader::DYNAFED_HF_MASK & nVersion;
+            nVersion = (int32_t) (~CBlockHeader::DYNAFED_HF_MASK & (uint32_t)nVersion);
             return is_dyna;
         } else {
             return is_dynafed_block();

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -46,7 +46,7 @@ struct CTxMemPoolModifiedEntry {
         nSigOpCostWithAncestors = entry->GetSigOpCostWithAncestors();
     }
 
-    int64_t GetModifiedFee() const { return iter->GetModifiedFee(); }
+    CAmount GetModifiedFee() const { return iter->GetModifiedFee(); }
     uint64_t GetSizeWithAncestors() const { return nSizeWithAncestors; }
     uint64_t GetDiscountSizeWithAncestors() const { return discountSizeWithAncestors; }
     CAmount GetModFeesWithAncestors() const { return nModFeesWithAncestors; }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1527,6 +1527,10 @@ static RPCHelpMan getcompactsketch()
     CDataStream ssBlock(block_bytes, SER_NETWORK, PROTOCOL_VERSION);
     ssBlock >> block;
 
+    if (block.vtx.empty()) {
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Cannot obtain sketch of empty block.");
+    }
+
     CBlockHeaderAndShortTxIDs cmpctblock(block, true);
 
     CDataStream ssCompactBlock(SER_NETWORK, PROTOCOL_VERSION);

--- a/src/test/fuzz/witness_program.cpp
+++ b/src/test/fuzz/witness_program.cpp
@@ -45,7 +45,7 @@ FUZZ_TARGET_INIT(witness_program, initialize_witness_program)
 
         CScriptWitness witness;
         int fuzz_control;
-        int flags;
+        unsigned flags;
         ds >> fuzz_control;
         ds >> witness.stack;
         ds >> flags;

--- a/src/test/fuzz/witness_program.cpp
+++ b/src/test/fuzz/witness_program.cpp
@@ -64,7 +64,7 @@ FUZZ_TARGET_INIT(witness_program, initialize_witness_program)
 
         if (fuzz_control & 1) {
             unsigned char hash_program[32];
-            CSHA256().Write(&program[0], program.size()).Finalize(hash_program);
+            CSHA256().Write(program.data(), program.size()).Finalize(hash_program);
             CScript scriptPubKey = CScript{} << OP_0 << std::vector<unsigned char>(hash_program, hash_program + sizeof(hash_program));
             witness.stack.push_back(program);
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -98,7 +98,7 @@ CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& tx, CAmount fee,
       discountSizeWithAncestors{GetDiscountTxSize()},
       setPeginsSpent(_setPeginsSpent) {}
 
-void CTxMemPoolEntry::UpdateFeeDelta(int64_t newFeeDelta)
+void CTxMemPoolEntry::UpdateFeeDelta(CAmount newFeeDelta)
 {
     nModFeesWithDescendants += newFeeDelta - feeDelta;
     nModFeesWithAncestors += newFeeDelta - feeDelta;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -60,16 +60,6 @@ struct update_ancestor_state
         int64_t discountSize;
 };
 
-struct update_fee_delta
-{
-    explicit update_fee_delta(int64_t _feeDelta) : feeDelta(_feeDelta) { }
-
-    void operator() (CTxMemPoolEntry &e) { e.UpdateFeeDelta(feeDelta); }
-
-private:
-    int64_t feeDelta;
-};
-
 bool TestLockPointValidity(CChain& active_chain, const LockPoints& lp)
 {
     AssertLockHeld(cs_main);
@@ -520,7 +510,7 @@ void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, setEntries &setAnces
     CAmount delta{0};
     ApplyDelta(entry.GetTx().GetHash(), delta);
     if (delta) {
-            mapTx.modify(newit, update_fee_delta(delta));
+        mapTx.modify(newit, [&delta](CTxMemPoolEntry& e) { e.UpdateFeeDelta(delta); });
     }
 
     // Update cachedInnerUsage to include contained transaction's usage.
@@ -1027,7 +1017,7 @@ void CTxMemPool::PrioritiseTransaction(const uint256& hash, const CAmount& nFeeD
         delta += nFeeDelta;
         txiter it = mapTx.find(hash);
         if (it != mapTx.end()) {
-            mapTx.modify(it, update_fee_delta(delta));
+            mapTx.modify(it, [&delta](CTxMemPoolEntry& e) { e.UpdateFeeDelta(delta); });
             // Now update all ancestors' modified fees with descendants
             setEntries setAncestors;
             uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -102,7 +102,7 @@ private:
     const unsigned int entryHeight; //!< Chain height when entering the mempool
     const bool spendsCoinbase;      //!< keep track of transactions that spend a coinbase
     const int64_t sigOpCost;        //!< Total sigop cost
-    int64_t feeDelta{0};            //!< Used for determining the priority of the transaction for mining in a block
+    CAmount feeDelta{0};            //!< Used for determining the priority of the transaction for mining in a block
     LockPoints lockPoints;     //!< Track the height and time at which tx was final
 
     // Information about descendants of this transaction that are in the
@@ -135,7 +135,7 @@ public:
     std::chrono::seconds GetTime() const { return std::chrono::seconds{nTime}; }
     unsigned int GetHeight() const { return entryHeight; }
     int64_t GetSigOpCost() const { return sigOpCost; }
-    int64_t GetModifiedFee() const { return nFee + feeDelta; }
+    CAmount GetModifiedFee() const { return nFee + feeDelta; }
     size_t DynamicMemoryUsage() const { return nUsageSize; }
     const LockPoints& GetLockPoints() const { return lockPoints; }
 
@@ -144,8 +144,8 @@ public:
     // Adjusts the ancestor state
     void UpdateAncestorState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount, int64_t modifySigOps, int64_t discountSize);
     // Updates the fee delta used for mining priority score, and the
-    // modified fees with descendants.
-    void UpdateFeeDelta(int64_t feeDelta);
+    // modified fees with descendants/ancestors.
+    void UpdateFeeDelta(CAmount newFeeDelta);
     // Update the LockPoints after a reorg
     void UpdateLockPoints(const LockPoints& lp);
 

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -81,3 +81,5 @@ implicit-integer-sign-change:primitives/confidential.cpp
 implicit-integer-sign-change:primitives/confidential.h
 shift-base:simplicity/sha256.c
 unsigned-integer-overflow:simplicity/sha256.c
+# See comment in simplicity/primitive/elements/env.c line 303
+unsigned-integer-overflow:simplicity/primitive/elements/env.c


### PR DESCRIPTION
Mostly straightforward stuff in here, except that we needed to backport https://github.com/bitcoin/bitcoin/pull/23418, which in turn required https://github.com/bitcoin/bitcoin/pull/24625.

This does not fix the PSET RPC-related crash but it does fix various ubsan lints (and a couple actual crashes) for other parts of the codebase.