### PR TITLE
pset: fix NULL pointer dereference when deserializing malformed PSETs over RPC

### DIFF
--- a/src/psbt.h
+++ b/src/psbt.h
@@ -901,12 +901,16 @@ struct PSBTInput
                                     Sidechain::Bitcoin::CTransactionRef tx;
                                     OverrideStream<Stream> os(&s, s.GetType(), s.GetVersion());
                                     UnserializeFromVector(os, tx);
-                                    m_peg_in_tx = tx;
+                                    if (tx) {
+                                        m_peg_in_tx = tx;
+                                    }
                                 } else {
                                     CTransactionRef tx;
                                     OverrideStream<Stream> os(&s, s.GetType(), s.GetVersion());
                                     UnserializeFromVector(os, tx);
-                                    m_peg_in_tx = tx;
+                                    if (tx) {
+                                        m_peg_in_tx = tx;
+                                    }
                                 }
                                 break;
                             }

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -1091,9 +1091,9 @@ struct PSBTInput
                                 } else if (subkey_len != 1) {
                                     throw std::ios_base::failure("Input issuance needs blinded flag is more than one byte type");
                                 }
-                                bool b;
+                                uint8_t b;
                                 UnserializeFromVector(s, b);
-                                m_blinded_issuance = b;
+                                m_blinded_issuance = !!b;
                                 break;
                             }
                             default:


### PR DESCRIPTION
I mentioned in one of my fuzz seed PRs that I couldn't provide seeds for the `psbt_input_deserialize` target because they were crashing.

This PR fixes the crash. I will PR to the fuzz seeds repo shortly.