### PR TITLE
Fix tests and build warnings

### DIFF
--- a/build_msvc/bitcoind/bitcoind.vcxproj
+++ b/build_msvc/bitcoind/bitcoind.vcxproj
@@ -57,9 +57,9 @@
   <Target Name="AfterBuild">
     <Copy SourceFiles="$(ConfigIniIn)" DestinationFiles="$(ConfigIniOut)" ></Copy>
     <ReplaceInFile FilePath="$(ConfigIniOut)"
-                   Replace="@PACKAGE_NAME@" By="Bitcoin Core"></ReplaceInFile>
+                   Replace="@PACKAGE_NAME@" By="Elements Core"></ReplaceInFile>
     <ReplaceInFile FilePath="$(ConfigIniOut)"
-                   Replace="@PACKAGE_BUGREPORT@" By="https://github.com/bitcoin/bitcoin/issues"></ReplaceInFile>
+                   Replace="@PACKAGE_BUGREPORT@" By="https://github.com/ElementsProject/elements/issues"></ReplaceInFile>
     <ReplaceInFile FilePath="$(ConfigIniOut)"
                    Replace="@abs_top_srcdir@" By="..\.." ToFullPath="true"></ReplaceInFile>
     <ReplaceInFile FilePath="$(ConfigIniOut)"

--- a/src/block_proof.cpp
+++ b/src/block_proof.cpp
@@ -43,7 +43,7 @@ static bool CheckProofGeneric(const CBlockHeader& block, const uint32_t max_bloc
         | SCRIPT_VERIFY_SIGPUSHONLY // Witness is push-only
         | SCRIPT_VERIFY_LOW_S // Stop easiest signature fiddling
         | SCRIPT_VERIFY_WITNESS // Witness and to enforce cleanstack
-        | (is_dyna ? 0 : SCRIPT_NO_SIGHASH_BYTE); // Non-dynafed blocks do not have sighash byte
+        | (is_dyna ? SCRIPT_VERIFY_NONE : SCRIPT_NO_SIGHASH_BYTE); // Non-dynafed blocks do not have sighash byte
     return GenericVerifyScript(scriptSig, witness, challenge, proof_flags, block);
 }
 

--- a/src/rpc/request.cpp
+++ b/src/rpc/request.cpp
@@ -139,7 +139,10 @@ static fs::path GetMainchainAuthCookieFile()
     if (gArgs.GetChainName() == "liquidv1") {
         cookie_file = ".cookie";
     }
-    return fsbridge::AbsPathJoin(GetMainchainDefaultDataDir(), fs::PathFromString(gArgs.GetArg("-mainchainrpccookiefile", cookie_file)));
+    fs::path cookie_path = fs::PathFromString(gArgs.GetArg("-mainchainrpccookiefile", cookie_file));
+    if (cookie_path.is_absolute())
+        return cookie_path;
+    return fsbridge::AbsPathJoin(GetMainchainDefaultDataDir(), cookie_path);
 }
 
 bool GetMainchainAuthCookie(std::string *cookie_out)

--- a/src/rpc/request.cpp
+++ b/src/rpc/request.cpp
@@ -151,7 +151,7 @@ bool GetMainchainAuthCookie(std::string *cookie_out)
     std::string cookie;
 
     std::filesystem::path filepath = GetMainchainAuthCookieFile();
-    file.open(filepath.string().c_str());
+    file.open(filepath);
     if (!file.is_open())
         return false;
     std::getline(file, cookie);

--- a/test/functional/feature_confidential_transactions.py
+++ b/test/functional/feature_confidential_transactions.py
@@ -25,6 +25,7 @@ from test_framework.util import (
 )
 import os
 import re
+import tempfile
 
 from test_framework.liquid_addr import (
     encode,
@@ -51,7 +52,7 @@ class CTTest (BitcoinTestFramework):
         self.skip_if_no_wallet()
 
     def test_wallet_recovery(self):
-        file_path = "/tmp/blind_details"
+        file_path = os.path.join(tempfile.gettempdir(), "blind_details")
         try:
             os.remove(file_path)
         except OSError:

--- a/test/functional/feature_discount_ct.py
+++ b/test/functional/feature_discount_ct.py
@@ -6,6 +6,7 @@
 from decimal import Decimal
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    assert_approx,
     assert_equal,
 )
 
@@ -80,10 +81,12 @@ class CTTest(BitcoinTestFramework):
         assert_equal(len(vout), 3)
         assert_equal(tx['fee']['bitcoin'], Decimal('-0.00000326'))
         assert_equal(decoded['vsize'], 326)
-        assert_equal(decoded['weight'], 1302)
+        # tx weight can be 1301 or 1302, accept both
+        assert_approx(decoded['weight'], 1301.5, 0.5)
         self.generate(node0, 1)
         tx = node1.getrawtransaction(txid, True)
-        assert_equal(tx['discountweight'], 1302)
+        # tx discountweight can be 1301 or 1302, accept both
+        assert_approx(tx['discountweight'], 1301.5, 0.5)
         assert_equal(tx['discountvsize'], 326)
 
         self.log.info("Send confidential tx to node 0")
@@ -98,10 +101,12 @@ class CTTest(BitcoinTestFramework):
         assert_equal(len(vout), 3)
         assert_equal(tx['fee']['bitcoin'], Decimal('-0.00002575'))
         assert_equal(decoded['vsize'], 2575)
-        assert_equal(decoded['weight'], 10300)
+        # tx weight can be 10299 or 10300, accept both
+        assert_approx(decoded['weight'], 10299.5, 0.5)
         self.generate(node0, 1)
         tx = node1.getrawtransaction(txid, True)
-        assert_equal(tx['discountweight'], 1302)
+        # tx discountweight can be 1301 or 1302, accept both
+        assert_approx(tx['discountweight'], 1301.5, 0.5)
         assert_equal(tx['discountvsize'], 326) # node1 has discountvsize
 
         self.log.info("Send explicit tx to node 1")
@@ -116,10 +121,12 @@ class CTTest(BitcoinTestFramework):
         assert_equal(len(vout), 3)
         assert_equal(tx['fee']['bitcoin'], Decimal('-0.00000326'))
         assert_equal(decoded['vsize'], 326)
-        assert_equal(decoded['weight'], 1302)
+        # tx weight can be 1301 or 1302, accept both
+        assert_approx(decoded['weight'], 1301.5, 0.5)
         self.generate(node0, 1)
         tx = node1.getrawtransaction(txid, True)
-        assert_equal(tx['discountweight'], 1302)
+        # tx weight can be 1301 or 1302, accept both
+        assert_approx(tx['discountweight'], 1301.5, 0.5)
         assert_equal(tx['discountvsize'], 326)
 
         self.log.info("Send confidential (undiscounted) tx to node 1")
@@ -134,10 +141,12 @@ class CTTest(BitcoinTestFramework):
         assert_equal(len(vout), 3)
         assert_equal(tx['fee']['bitcoin'], Decimal('-0.00002575'))
         assert_equal(decoded['vsize'], 2575)
-        assert_equal(decoded['weight'], 10300)
+        # tx weight can be 10299 or 10300, accept both
+        assert_approx(decoded['weight'], 10299.5, 0.5)
         self.generate(node0, 1)
         tx = node1.getrawtransaction(txid, True)
-        assert_equal(tx['discountweight'], 1302)
+        # tx discountweight can be 1301 or 1302, accept both
+        assert_approx(tx['discountweight'], 1301.5, 0.5)
         assert_equal(tx['discountvsize'], 326) # node1 has discountvsize
 
         self.log.info("Send confidential (discounted) tx to node 1")
@@ -161,8 +170,10 @@ class CTTest(BitcoinTestFramework):
             else:
                 assert_equal(decoded['fee'][bitcoin], Decimal('0.00000326'))
             assert_equal(decoded['vsize'], 2575)
-            assert_equal(decoded['weight'], 10300)
-            assert_equal(decoded['discountweight'], 1302)
+            # tx weight can be 10299 or 10300, accept both
+            assert_approx(decoded['weight'], 10299.5, 0.5)
+            # tx discountweight can be 1301 or 1302, accept both
+            assert_approx(decoded['discountweight'], 1301.5, 0.5)
             assert_equal(decoded['discountvsize'], 326)
 
         # node0 only has vsize
@@ -191,8 +202,10 @@ class CTTest(BitcoinTestFramework):
             else:
                 assert_equal(decoded['fee'][bitcoin], Decimal('0.00000033'))
             assert_equal(decoded['vsize'], 2575)
-            assert_equal(decoded['weight'], 10300)
-            assert_equal(decoded['discountweight'], 1302)
+            # tx weight can be 10299 or 10300, accept both
+            assert_approx(decoded['weight'], 10299.5, 0.5)
+            # tx discountweight can be 1301 or 1302, accept both
+            assert_approx(decoded['discountweight'], 1301.5, 0.5)
             assert_equal(decoded['discountvsize'], 326)
         # node0 only has vsize
         tx = node0.getrawtransaction(txid, True)

--- a/test/functional/feature_fedpeg.py
+++ b/test/functional/feature_fedpeg.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import time
+import os
 
 from test_framework.authproxy import JSONRPCException
 from test_framework.test_framework import BitcoinTestFramework
@@ -152,7 +153,7 @@ class FedPegTest(BitcoinTestFramework):
             else:
                 # Need to specify where to find parent cookie file
                 datadir = get_datadir_path(self.options.tmpdir, n)
-                extra_args.append('-mainchainrpccookiefile='+datadir+"/" + parent_chain + "/.cookie")
+                extra_args.append('-mainchainrpccookiefile='+os.path.join(datadir, parent_chain, ".cookie"))
 
             self.add_nodes(1, [extra_args], chain=["elementsregtest"])
             self.start_node(2+n)


### PR DESCRIPTION
In feature_discounct, the created tx can be of 2 different weights, we need to make sure we don't fail erroneously.

Newer gcc versions complain about mixing int and enum, so we need to do the 0 from the enum.

TSAN revealed an unlocked access to pindexBestHeader, so it's moved inside the lock

Fixes an issue in windows builds accessing the cookie file with special characters in the path.

Also addresses some issues seen in Win 64 native functional tests, doesn't fully fix the issues, but it's a step in the right direction.

Fixes: https://github.com/ElementsProject/elements/issues/1406 https://github.com/ElementsProject/elements/issues/1422