### PR TITLE
Fix Assert crash in win64 native builds

### DIFF
--- a/src/primitives/confidential.h
+++ b/src/primitives/confidential.h
@@ -149,7 +149,7 @@ public:
             return -1;
         }
 
-        assert(IsExplicit());;
+        assert(IsExplicit());
         return ReadBE64(&vchCommitment[1]);
     }
     void SetToAmount(CAmount nAmount);

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -1446,6 +1446,8 @@ static bool CreateTransactionInternal(
             return false;
         }
         txNew = tx_blinded; // sigh, `fillBlindDetails` may have modified txNew
+        // Update the change position to the new tx
+        change_position = txNew.vout.begin() + nChangePosInOut;
 
         int ret = BlindTransaction(blind_details->i_amount_blinds, blind_details->i_asset_blinds, blind_details->i_assets, blind_details->i_amounts, blind_details->o_amount_blinds, blind_details->o_asset_blinds, blind_details->o_pubkeys, issuance_asset_keys, issuance_token_keys, tx_blinded);
         assert(ret != -1);


### PR DESCRIPTION
Not sure why this is not affecting linux builds too, but when `fillBlindDetails` adds the `OP_RETURN`, `change_position` still points to the old tx, we should update it to the new one.

Fixes 4 previously failing tests in win64.
```
feature_confidential_transactions.py --legacy-wallet
feature_issuance.py --legacy-wallet
wallet_basic.py --legacy-wallet
wallet_watchonly.py --legacy-wallet
```