### PR TITLE
Avoid double free in simplicity pointer when copying PrecomputedTransactionData

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -2669,7 +2669,7 @@ void PrecomputedTransactionData::Init(const T& txTo, std::vector<CTxOut>&& spent
         simplicityRawTx.version = txTo.nVersion;
         simplicityRawTx.lockTime = txTo.nLockTime;
 
-        m_simplicity_tx_data = simplicity_elements_mallocTransaction(&simplicityRawTx);
+        m_simplicity_tx_data_ptr = std::make_unique<SimplicityTxData>(&simplicityRawTx);
 
         m_bip341_taproot_ready = true;
     }
@@ -3119,9 +3119,10 @@ bool GenericTransactionSignatureChecker<T>::CheckSimplicity(const valtype& progr
     simplicity_err error;
     tapEnv* simplicityTapEnv = simplicity_elements_mallocTapEnv(&simplicityRawTap);
 
-    assert(txdata->m_simplicity_tx_data);
+    assert(txdata->m_simplicity_tx_data_ptr);
+    assert(txdata->m_simplicity_tx_data_ptr->m_simplicity_tx_data);
     assert(simplicityTapEnv);
-    if (!simplicity_elements_execSimplicity(&error, 0, txdata->m_simplicity_tx_data, nIn, simplicityTapEnv, txdata->m_hash_genesis_block.data(), budget, 0, program.data(), program.size(), witness.data(), witness.size())) {
+    if (!simplicity_elements_execSimplicity(&error, 0, txdata->m_simplicity_tx_data_ptr->m_simplicity_tx_data, nIn, simplicityTapEnv, txdata->m_hash_genesis_block.data(), budget, 0, program.data(), program.size(), witness.data(), witness.size())) {
         assert(!"simplicity_elements_execSimplicity internal error");
     }
     simplicity_elements_freeTapEnv(simplicityTapEnv);

--- a/src/test/fuzz/simplicity.cpp
+++ b/src/test/fuzz/simplicity.cpp
@@ -204,13 +204,14 @@ FUZZ_TARGET_INIT(simplicity, initialize_simplicity)
     PrecomputedTransactionData txdata{GENESIS_HASH};
     std::vector<CTxOut> spent_outs_copy{spent_outs};
     txdata.Init(mtx, std::move(spent_outs_copy));
-    assert(txdata.m_simplicity_tx_data != NULL);
+    assert(txdata.m_simplicity_tx_data_ptr);
+    assert(txdata.m_simplicity_tx_data_ptr->m_simplicity_tx_data);
 
     // 4. Main test
     unsigned char imr_out[32];
     unsigned char *imr = mtx.vin[0].prevout.hash.data()[2] & 2 ? imr_out : NULL;
 
-    const transaction* tx = txdata.m_simplicity_tx_data;
+    const transaction* tx = txdata.m_simplicity_tx_data_ptr->m_simplicity_tx_data;
     tapEnv* taproot = simplicity_elements_mallocTapEnv(&simplicityRawTap);
     simplicity_elements_execSimplicity(&error, imr, tx, nIn, taproot, GENESIS_HASH.data(), budget, amr, prog_bytes.data(), prog_bytes.size(), wit_bytes.data(), wit_bytes.size());
 

--- a/src/test/fuzz/simplicity_tx.cpp
+++ b/src/test/fuzz/simplicity_tx.cpp
@@ -217,7 +217,8 @@ FUZZ_TARGET_INIT(simplicity_tx, initialize_simplicity_tx)
         // that we will allocate Simplicity data. The check for whether to do this is very
         // lax: is this a 34-byte scriptPubKey that starts with OP_1 and does it have a
         // nonempty witness.
-        assert(txdata.m_simplicity_tx_data != NULL);
+        assert(txdata.m_simplicity_tx_data_ptr);
+        assert(txdata.m_simplicity_tx_data_ptr->m_simplicity_tx_data);
     }
 
     const CTransaction tx{mtx};


### PR DESCRIPTION
Fixes the following tests
```
feature_block_v4.py                                 | ✓ Passed  | 3 s
feature_fedpeg.py --legacy-wallet                   | ✓ Passed  | 78 s
feature_fedpeg.py --post_transition --legacy-wallet | ✓ Passed  | 74 s
feature_fedpeg.py --pre_transition --legacy-wallet  | ✓ Passed  | 80 s
feature_nulldummy.py --descriptors                  | ✓ Passed  | 4 s
feature_nulldummy.py --legacy-wallet                | ✓ Passed  | 5 s
feature_sighash_rangeproof.py --legacy-wallet       | ✓ Passed  | 143 s
rpc_fundrawtransaction.py --descriptors             | ✓ Passed  | 971 s
rpc_fundrawtransaction.py --legacy-wallet           | ✓ Passed  | 985 s
rpc_psbt.py --descriptors                           | ✓ Passed  | 216 s
rpc_psbt.py --legacy-wallet                         | ✓ Passed  | 239 s
wallet_bumpfee.py --descriptors                     | ✓ Passed  | 160 s
wallet_bumpfee.py --legacy-wallet                   | ✓ Passed  | 106 s
wallet_keypool.py --descriptors                     | ✓ Passed  | 17 s
wallet_keypool.py --legacy-wallet                   | ✓ Passed  | 10 s
wallet_multisig_descriptor_psbt.py                  | ✓ Passed  | 19 s
wallet_send.py --descriptors                        | ✓ Passed  | 37 s
wallet_send.py --legacy-wallet                      | ✓ Passed  | 36 s
wallet_taproot.py                                   | ✓ Passed  | 150 s
wallet_timelock.py                                  | ✓ Passed  | 2 s
wallet_watchonly.py --usecli --legacy-wallet        | ✓ Passed  | 6 s
```

There are still 2 failing tests, `feature_fee_estimation` fails in all arches and the problem is the test itself, needs to be fixed for elements. `feature_trim_headers` needs some backports from 23.x, but it is working in the release branches

