### PR TITLE
Encapsulate Simplicity's mallocTransaction inside SimplicityTxData co…

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -2669,7 +2669,7 @@ void PrecomputedTransactionData::Init(const T& txTo, std::vector<CTxOut>&& spent
         simplicityRawTx.version = txTo.nVersion;
         simplicityRawTx.lockTime = txTo.nLockTime;
 
-        m_simplicity_tx_data = SimplicityTransactionUniquePtr(simplicity_elements_mallocTransaction(&simplicityRawTx));
+        m_simplicity_tx_data = SimplicityTxData(&simplicityRawTx);
 
         m_bip341_taproot_ready = true;
     }


### PR DESCRIPTION
This PR is in between #1424 and #1425.  This PR is optional.  

The primary benefit is moving `simplicity_elements_mallocTransaction` into a structure's constructor, and hiding the `SimplicityTransactionDeleter` class.

The `unique_ptr` operations that we use are delegated.

This code is pushing the boundaries of my rusty C++ programming abilities, and it would be good to get a more expert review on it.