### PR TITLE
simplicity: activate on first week of unanimous signalling after block 3333333

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1291,7 +1291,7 @@ public:
 
         // Simplicity
         consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].bit = 21;
-        consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
+        consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].nStartTime = 3333333; // April 14, 2025
         consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].min_activation_height = 0; // No activation delay
         consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].nPeriod = 10080; // one week...


### PR DESCRIPTION
This patch simply starts signalling for Simplicity in any blocksigner that has it enabled. Once we have one week (10080 blocks) of unanimous signalling, then it activates.