### PR TITLE
feat: reduce default dust relay fee

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -55,7 +55,7 @@ static const unsigned int MAX_STANDARD_SCRIPTSIG_SIZE = 1650;
  * standard and should be done with care and ideally rarely. It makes sense to
  * only increase the dust limit after prior releases were already not creating
  * outputs below the new threshold */
-static const unsigned int DUST_RELAY_TX_FEE = 3000;
+static const unsigned int DUST_RELAY_TX_FEE = 100;
 /**
  * Standard script verification flags that standard transactions will comply
  * with. However scripts violating these flags may still be present in valid


### PR DESCRIPTION
This PR reduces `DUST_RELAY_TX_FEE` to `100`, matching [`DEFAULT_MIN_RELAY_TX_FEE`](https://github.com/ElementsProject/elements/blob/master/src/validation.h#L59), allowing elements wallet to create transactions with amounts as low as 17 sats, see https://github.com/ElementsProject/ELIPs/pull/24#issuecomment-2709819278.