### PR TITLE
fix: simplicity activation when dynafed is active

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -215,7 +215,7 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 709632; // Approximately November 12th, 2021
 
         // Simplicity
-        consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].bit = 24;
+        consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].bit = 21;
         consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].min_activation_height = 0; // No activation delay
@@ -361,7 +361,7 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay
 
         // Simplicity
-        consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].bit = 24;
+        consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].bit = 21;
         consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].min_activation_height = 0; // No activation delay
@@ -527,7 +527,7 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay
 
         // Simplicity
-        consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].bit = 24;
+        consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].bit = 21;
         consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].min_activation_height = 0; // No activation delay
@@ -626,7 +626,7 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nThreshold = 128;
 
         // Simplicity
-        consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].bit = 24;
+        consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].bit = 21;
         consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].min_activation_height = 0; // No activation delay
@@ -1288,7 +1288,7 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nThreshold = 10080; // ...of 100% signalling
 
         // Simplicity
-        consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].bit = 24;
+        consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].bit = 21;
         consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_SIMPLICITY].min_activation_height = 0; // No activation delay

--- a/test/functional/feature_elements_simplicity_activation.py
+++ b/test/functional/feature_elements_simplicity_activation.py
@@ -18,6 +18,7 @@ class SimplicityActivationTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
+        self.extra_args = [["-evbparams=dynafed:0:::"]]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
@@ -36,8 +37,8 @@ class SimplicityActivationTest(BitcoinTestFramework):
             if n < 143:
                 assert_equal (decode["versionHex"], "20000000")
             elif n < 431:
-                # TESTDUMMY deployment: 144 blocks active, 144 blocks locked in
-                assert_equal (decode["versionHex"], "30000000")
+                # TESTDUMMY and DYNAFED deployment: 144 blocks active, 144 blocks locked in
+                assert_equal (decode["versionHex"], "32000000")
             else:
                 assert_equal (decode["versionHex"], "20000000")
 
@@ -103,15 +104,15 @@ class SimplicityActivationTest(BitcoinTestFramework):
             if n < 143:
                 assert_equal (decode["versionHex"], "20000000")
             elif n < 431:
-                # TESTDUMMY deployment: 144 blocks active, 144 blocks locked in
-                assert_equal (decode["versionHex"], "30000000")
+                # TESTDUMMY and DYNAFED deployment: 144 blocks active, 144 blocks locked in
+                assert_equal (decode["versionHex"], "32000000")
             else:
                 assert_equal (decode["versionHex"], "20000000")
 
         # Test activation starting from height 1000
         # Note that for Simplicity this is an illogical combination (Simplicity without
         # Taproot) but for purposes of this test it's fine.
-        self.restart_node(0, ["-evbparams=simplicity:500:::"])
+        self.restart_node(0, ["-evbparams=dynafed:0:::", "-evbparams=simplicity:500:::"])
         self.nodes[0].invalidateblock(self.nodes[0].getblockhash(1))
         self.test_activation(self.nodes[0], 500)
 

--- a/test/functional/feature_elements_simplicity_activation.py
+++ b/test/functional/feature_elements_simplicity_activation.py
@@ -53,7 +53,7 @@ class SimplicityActivationTest(BitcoinTestFramework):
         blocks = self.generatetoaddress(rpc, 127, rpc.getnewaddress())
         for n, block in enumerate(blocks):
             decode = rpc.getblockheader(block)
-            assert_equal (decode["versionHex"], "21000000")
+            assert_equal (decode["versionHex"], "20200000")
         assert_equal(rpc.getdeploymentinfo()["deployments"]["simplicity"]["bip9"]["status"], "started")
 
         # Fail to signal on the 128th block. Since the threshold for Simplicity is
@@ -61,7 +61,7 @@ class SimplicityActivationTest(BitcoinTestFramework):
         # 144 (the default), as we have overridden the period for Simplicity. On
         # the main Liquid chain it is overridden to be one week of signalling.
         block = rpc.getnewblockhex()
-        block = block[:7] + "0" + block[8:] # turn off Simplicity signal
+        block = block[:4] + "0" + block[5:] # turn off Simplicity signal
         rpc.submitblock(block)
         assert_equal(rpc.getdeploymentinfo()["deployments"]["simplicity"]["bip9"]["status"], "started")
 
@@ -69,22 +69,22 @@ class SimplicityActivationTest(BitcoinTestFramework):
         blocks = self.generatetoaddress(rpc, 127, rpc.getnewaddress())
         for n, block in enumerate(blocks):
             decode = rpc.getblockheader(block)
-            assert_equal (decode["versionHex"], "21000000")
+            assert_equal (decode["versionHex"], "20200000")
         assert_equal(rpc.getdeploymentinfo()["deployments"]["simplicity"]["bip9"]["status"], "started")
         # The 128th block then switches from "started" to "locked_in"
         blocks = self.generatetoaddress(rpc, 1, rpc.getnewaddress())
         assert_equal(rpc.getdeploymentinfo()["deployments"]["simplicity"]["bip9"]["status"], "started")
         assert_equal(rpc.getdeploymentinfo()["deployments"]["simplicity"]["bip9"]["status_next"], "locked_in")
-        assert_equal(rpc.getblockheader(blocks[0])["versionHex"], "21000000")
+        assert_equal(rpc.getblockheader(blocks[0])["versionHex"], "20200000")
 
         # Run through another 128 blocks, which will go from "locked in" to "active" regardless of signalling
         blocks = self.generatetoaddress(rpc, 127, rpc.getnewaddress())
         for n, block in enumerate(blocks):
             decode = rpc.getblockheader(block)
-            assert_equal (decode["versionHex"], "21000000")
+            assert_equal (decode["versionHex"], "20200000")
         assert_equal(rpc.getdeploymentinfo()["deployments"]["simplicity"]["bip9"]["status"], "locked_in")
         block = rpc.getnewblockhex()
-        block = block[:7] + "0" + block[8:] # turn off Simplicity signal
+        block = block[:4] + "0" + block[5:] # turn off Simplicity signal
         rpc.submitblock(block)
         assert_equal(rpc.getdeploymentinfo()["deployments"]["simplicity"]["bip9"]["status"], "locked_in")
         assert_equal(rpc.getdeploymentinfo()["deployments"]["simplicity"]["bip9"]["status_next"], "active")


### PR DESCRIPTION
When DynaFed is active, trying to activate Simplicity with version bit 24 causes [`ContextualCheckDynaFedHeader`](https://github.com/ElementsProject/elements/blob/b63f7ab9b5e710fcd4e87f92c1981ea5f9c71bd1/src/validation.cpp#L3709) to fail with `CreateNewBlock: TestBlockValidity failed: invalid-dyna-fed, dynamic block header has unknown HF extension bits set`. 
