### PR TITLE
Fix: Issueasset tx with blind parameter false is not accepted after t…

### DIFF
--- a/src/confidential_validation.cpp
+++ b/src/confidential_validation.cpp
@@ -102,7 +102,7 @@ static bool VerifyIssuanceAmount(secp256k1_pedersen_commitment& value_commit, se
 
     // Build value commitment
     if (value.IsExplicit()) {
-        if (asset == consensus_params.pegged_asset && !MoneyRange(value.GetAmount()) || value.GetAmount() <= 0) {
+        if ((asset == consensus_params.pegged_asset && !MoneyRange(value.GetAmount())) || value.GetAmount() <= 0) {
             return false;
         }
         if (!rangeproof.empty()) {

--- a/src/confidential_validation.h
+++ b/src/confidential_validation.h
@@ -3,6 +3,7 @@
 #define BITCOIN_CONFIDENTIAL_VALIDATION_H
 
 #include <consensus/amount.h>
+#include <consensus/params.h>
 #include <asset.h>
 #include <coins.h>
 #include <primitives/confidential.h>
@@ -89,7 +90,7 @@ public:
 
 ScriptError QueueCheck(std::vector<CCheck*>* queue, CCheck* check);
 
-bool VerifyAmounts(const std::vector<CTxOut>& inputs, const CTransaction& tx, std::vector<CCheck*>* pvChecks, const bool cacheStore);
+bool VerifyAmounts(const std::vector<CTxOut>& inputs, const CTransaction& tx, const Consensus::Params& consensusParams, std::vector<CCheck*>* pvChecks, const bool cacheStore);
 
 bool VerifyCoinbaseAmount(const CTransaction& tx, const CAmountMap& mapFees);
 

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -192,7 +192,7 @@ int64_t GetTransactionSigOpCost(const CTransaction& tx, const CCoinsViewCache& i
     return nSigOps;
 }
 
-bool Consensus::CheckTxInputs(const CTransaction& tx, TxValidationState& state, const CCoinsViewCache& inputs, int nSpendHeight, CAmountMap& fee_map, std::set<std::pair<uint256, COutPoint>>& setPeginsSpent, std::vector<CCheck*> *pvChecks, const bool cacheStore, bool fScriptChecks, const std::vector<std::pair<CScript, CScript>>& fedpegscripts)
+bool Consensus::CheckTxInputs(const CTransaction& tx, TxValidationState& state, const CCoinsViewCache& inputs, const Consensus::Params& consensusParams, int nSpendHeight, CAmountMap& fee_map, std::set<std::pair<uint256, COutPoint>>& setPeginsSpent, std::vector<CCheck*> *pvChecks, const bool cacheStore, bool fScriptChecks, const std::vector<std::pair<CScript, CScript>>& fedpegscripts)
 {
     // are the actual inputs available?
     if (!inputs.HaveInputs(tx)) {
@@ -250,7 +250,7 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, TxValidationState& state, 
         }
 
         // Verify that amounts add up.
-        if (fScriptChecks && !VerifyAmounts(spent_inputs, tx, pvChecks, cacheStore)) {
+        if (fScriptChecks && !VerifyAmounts(spent_inputs, tx, consensusParams, pvChecks, cacheStore)) {
             return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-in-ne-out", "value in != value out");
         }
         fee_map += GetFeeMap(tx);

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -28,7 +28,7 @@ namespace Consensus {
  * @param[out] fee_map Set to the transaction fee if successful.
  * Preconditions: tx.IsCoinBase() is false.
  */
-[[nodiscard] ]bool CheckTxInputs(const CTransaction& tx, TxValidationState& state, const CCoinsViewCache& inputs, int nSpendHeight, CAmountMap& fee_map, std::set<std::pair<uint256, COutPoint>>& setPeginsSpent, std::vector<CCheck*> *pvChecks, const bool cacheStore, bool fScriptChecks, const std::vector<std::pair<CScript, CScript>>& fedpegscripts);
+    [[nodiscard] ]bool CheckTxInputs(const CTransaction& tx, TxValidationState& state, const CCoinsViewCache& inputs, const Consensus::Params& consensusParams, int nSpendHeight, CAmountMap& fee_map, std::set<std::pair<uint256, COutPoint>>& setPeginsSpent, std::vector<CCheck*> *pvChecks, const bool cacheStore, bool fScriptChecks, const std::vector<std::pair<CScript, CScript>>& fedpegscripts);
 } // namespace Consensus
 
 /** Auxiliary functions for transaction validation (ideally should not be exposed) */

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -50,6 +50,7 @@ void initialize_coins_view()
 FUZZ_TARGET_INIT(coins_view, initialize_coins_view)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    const Consensus::Params& consensus_params = Params().GetConsensus();
     CCoinsView backend_coins_view;
     CCoinsViewCache coins_view_cache{&backend_coins_view};
     COutPoint random_out_point;
@@ -252,7 +253,7 @@ FUZZ_TARGET_INIT(coins_view, initialize_coins_view)
                 }
                 std::vector<std::pair<CScript, CScript>> fedpegscripts; // ELEMENTS: we ought to populate this and have a more useful fuzztest
                 std::set<std::pair<uint256, COutPoint> > setPeginsSpent;
-                if (Consensus::CheckTxInputs(transaction, state, coins_view_cache, fuzzed_data_provider.ConsumeIntegralInRange<int>(0, std::numeric_limits<int>::max()), tx_fee_map, setPeginsSpent, NULL, false, true, fedpegscripts)) {
+                if (Consensus::CheckTxInputs(transaction, state, coins_view_cache, consensus_params, fuzzed_data_provider.ConsumeIntegralInRange<int>(0, std::numeric_limits<int>::max()), tx_fee_map, setPeginsSpent, NULL, false, true, fedpegscripts)) {
                     assert(MoneyRange(tx_fee_map));
                 }
             },

--- a/src/test/pegin_witness_tests.cpp
+++ b/src/test/pegin_witness_tests.cpp
@@ -52,6 +52,8 @@ BOOST_AUTO_TEST_CASE(witness_valid)
 
     std::string err;
 
+    const Consensus::Params& consensusParams = Params().GetConsensus();
+
     std::vector<unsigned char> fedpegscript_bytes = ParseHex(fedpegscript_str);
     CScript fedpegscript(fedpegscript_bytes.begin(), fedpegscript_bytes.end());
     // Test sample was generated as "legacy" with p2sh-p2wsh fedpegscript
@@ -123,7 +125,7 @@ BOOST_AUTO_TEST_CASE(witness_valid)
     CCoinsViewCache coins(&coinsDummy);
     // Get the latest block index to look up fedpegscripts
     // For these tests, should be genesis-block-hardcoded consensus.fedpegscript
-    BOOST_CHECK(Consensus::CheckTxInputs(tx, state, coins, 0, fee_map, setPeginsSpent, NULL, false, true, fedpegscripts));
+    BOOST_CHECK(Consensus::CheckTxInputs(tx, state, coins, consensusParams, 0, fee_map, setPeginsSpent, NULL, false, true, fedpegscripts));
     BOOST_CHECK(setPeginsSpent.size() == 1);
     setPeginsSpent.clear();
 
@@ -131,7 +133,7 @@ BOOST_AUTO_TEST_CASE(witness_valid)
     CMutableTransaction mtxn(tx);
     mtxn.witness.vtxinwit[0].m_pegin_witness.SetNull();
     CTransaction tx2(mtxn);
-    BOOST_CHECK(!Consensus::CheckTxInputs(tx2, state, coins, 0, fee_map, setPeginsSpent, NULL, false, true, fedpegscripts));
+    BOOST_CHECK(!Consensus::CheckTxInputs(tx2, state, coins, consensusParams, 0, fee_map, setPeginsSpent, NULL, false, true, fedpegscripts));
     BOOST_CHECK(setPeginsSpent.empty());
 
     // Invalidate peg-in (and spending) authorization by pegin marker.
@@ -140,7 +142,7 @@ BOOST_AUTO_TEST_CASE(witness_valid)
     CMutableTransaction mtxn2(tx);
     mtxn2.vin[0].m_is_pegin = false;
     CTransaction tx3(mtxn2);
-    BOOST_CHECK(!Consensus::CheckTxInputs(tx3, state, coins, 0, fee_map, setPeginsSpent, NULL, false, true, fedpegscripts));
+    BOOST_CHECK(!Consensus::CheckTxInputs(tx3, state, coins, consensusParams, 0, fee_map, setPeginsSpent, NULL, false, true, fedpegscripts));
     BOOST_CHECK(setPeginsSpent.empty());
 
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -895,7 +895,7 @@ void CTxMemPool::check(const CBlockIndex* active_chain_tip, const CCoinsViewCach
         const auto& fedpegscripts = GetValidFedpegScripts(active_chain_tip, Params().GetConsensus(), true /* nextblock_validation */);
         bool cacheStore = true;
         bool fScriptChecks = true;
-        assert(Consensus::CheckTxInputs(tx, dummy_state, mempoolDuplicate, spendheight, fee_map, setPeginsSpent, nullptr, cacheStore, fScriptChecks, fedpegscripts));
+        assert(Consensus::CheckTxInputs(tx, dummy_state, mempoolDuplicate, Params().GetConsensus(), spendheight, fee_map, setPeginsSpent, nullptr, cacheStore, fScriptChecks, fedpegscripts));
         for (const auto& input: tx.vin) mempoolDuplicate.SpendCoin(input.prevout);
         AddCoins(mempoolDuplicate, tx, std::numeric_limits<int>::max());
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -855,7 +855,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
     // The mempool holds txs for the next block, so pass height+1 to CheckTxInputs
     CAmountMap fee_map;
-    if (!Consensus::CheckTxInputs(tx, state, m_view, m_active_chainstate.m_chain.Height() + 1, fee_map, setPeginsSpent, NULL, true, true, fedpegscripts)) {
+    if (!Consensus::CheckTxInputs(tx, state, m_view, chainparams.GetConsensus(), m_active_chainstate.m_chain.Height() + 1, fee_map, setPeginsSpent, NULL, true, true, fedpegscripts)) {
         return false; // state filled in by CheckTxInputs
     }
 
@@ -2348,7 +2348,7 @@ bool CChainState::ConnectBlock(const CBlock& block, BlockValidationState& state,
             std::vector<CCheck*> vChecks;
             bool fCacheResults = fJustCheck; /* Don't cache results if we're actually connecting blocks (still consult the cache, though) */
             TxValidationState tx_state;
-            if (!Consensus::CheckTxInputs(tx, tx_state, view, pindex->nHeight, fee_map,
+            if (!Consensus::CheckTxInputs(tx, tx_state, view, m_params.GetConsensus(), pindex->nHeight, fee_map,
                         setPeginsSpent == NULL ? setPeginsSpentDummy : *setPeginsSpent,
                         g_parallel_script_checks ? &vChecks : NULL, fCacheResults, fScriptChecks, fedpegscripts)) {
                 // Any transaction validation failure in ConnectBlock is a block consensus failure

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2164,7 +2164,7 @@ TransactionError CWallet::SignPSBT(PartiallySignedTransaction& psbtx, bool& comp
         }
 
         CTransaction tx_tmp(tx);
-        if (!VerifyAmounts(inputs_utxos, tx_tmp, nullptr, false)) {
+        if (!VerifyAmounts(inputs_utxos, tx_tmp, Params().GetConsensus(), nullptr, false)) {
             return TransactionError::VALUE_IMBALANCE;
         }
     }

--- a/test/functional/wallet_elements_21million.py
+++ b/test/functional/wallet_elements_21million.py
@@ -42,6 +42,17 @@ class WalletTest(BitcoinTestFramework):
         self.generate(self.nodes[0], 1)
         assert_equal(self.nodes[0].getbalance()[asset], 200_000_000)
 
+        self.log.info("Issue more than 21 million of a unblinded non-policy asset")
+        issuance = self.nodes[0].issueasset(300_000_000, 100, False)
+        unblinded_asset = issuance['asset']
+        self.generate(self.nodes[0], 1)
+        assert_equal(self.nodes[0].getbalance()[unblinded_asset], 300_000_000)
+
+        self.log.info("Reissue more than 21 million of a unblinded non-policy asset")
+        self.nodes[0].reissueasset(unblinded_asset, 200_000_000)
+        self.generate(self.nodes[0], 1)
+        assert_equal(self.nodes[0].getbalance()[unblinded_asset], 500_000_000)
+
         # send more than 21 million of that asset
         addr = self.nodes[1].getnewaddress()
         self.nodes[0].sendtoaddress(address=addr, amount=22_000_000, assetlabel=asset)


### PR DESCRIPTION
Fixes #1443

The fix is done by passing the consensus params to `CheckTxInputs(), VerifyAmounts() and VerifyIssuanceAmount()` in order to have the pegged asset in the last one. I thought to pass the whole params if anything else will be needed later, but it could also be to pass pegged_asset only to `VerifyAmounts() and VerifyIssuanceAmount`.

Adapted the test also to check for unblinded issuance and that it is working correctly.

Appreciate the review and feel free to suggest any different approach if this one is not suitable.

@delta1 @psgreco 