### PR TITLE
fix: unblinded re/issuance for non-policy asset greater than 21 million

### DIFF
--- a/src/confidential_validation.cpp
+++ b/src/confidential_validation.cpp
@@ -1,4 +1,5 @@
 
+#include <chainparams.h>
 #include <confidential_validation.h>
 #include <issuance.h>
 #include <pegins.h>
@@ -102,7 +103,7 @@ static bool VerifyIssuanceAmount(secp256k1_pedersen_commitment& value_commit, se
 
     // Build value commitment
     if (value.IsExplicit()) {
-        if (!MoneyRange(value.GetAmount()) || value.GetAmount() == 0) {
+        if ((asset == Params().GetConsensus().pegged_asset && !MoneyRange(value.GetAmount())) || value.GetAmount() <= 0) {
             return false;
         }
         if (!rangeproof.empty()) {

--- a/test/functional/wallet_elements_21million.py
+++ b/test/functional/wallet_elements_21million.py
@@ -42,6 +42,17 @@ class WalletTest(BitcoinTestFramework):
         self.generate(self.nodes[0], 1)
         assert_equal(self.nodes[0].getbalance()[asset], 200_000_000)
 
+        self.log.info("Issue more than 21 million of a unblinded non-policy asset")
+        issuance = self.nodes[0].issueasset(300_000_000, 100, False)
+        unblinded_asset = issuance['asset']
+        self.generate(self.nodes[0], 1)
+        assert_equal(self.nodes[0].getbalance()[unblinded_asset], 300_000_000)
+
+        self.log.info("Reissue more than 21 million of a unblinded non-policy asset")
+        self.nodes[0].reissueasset(unblinded_asset, 200_000_000)
+        self.generate(self.nodes[0], 1)
+        assert_equal(self.nodes[0].getbalance()[unblinded_asset], 500_000_000)
+
         # send more than 21 million of that asset
         addr = self.nodes[1].getnewaddress()
         self.nodes[0].sendtoaddress(address=addr, amount=22_000_000, assetlabel=asset)


### PR DESCRIPTION
- test: add test for unblinded re/issuance greater than 21 million
- fix: unblinded re/issuance for greater than 21 million

<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
