### PR TITLE
Add liquid.network DNS seed

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1058,6 +1058,7 @@ public:
         if (!args.IsArgSet("-seednode")) {
             vSeeds.emplace_back("seed.liquid-testnet.blockstream.com");
             vSeeds.emplace_back("seed.liquidtestnet.com");
+            vSeeds.emplace_back("liquid.network.");
         }
     }
 };
@@ -1123,6 +1124,7 @@ public:
 
         vSeeds.clear();
         vSeeds.emplace_back("seed.liquidnetwork.io");
+        vSeeds.emplace_back("liquid.network.");
         vFixedSeeds = std::vector<uint8_t>(std::begin(pnSeed6_liquidv1), std::end(pnSeed6_liquidv1));
 
         //


### PR DESCRIPTION
We operate a cluster of about ~50 liquid and liquid testnet nodes globally for the liquid.network explorer. The liquid.network hostname is a round-robin DNS for our BGP anycast cluster of nodes from Ashburn, Frankfurt, Tokyo, Singapore, and Honolulu. You can see the full list at https://liquid.network/monitoring

Since we now accept incoming connections for Liquid P2P on 7042/tcp and for Liquid Testnet P2P on 18891/tcp, this PR adds liquid.network as a DNS seed for both networks, which should hopefully improve the P2P connectivity.