### PR TITLE
syscall: whitelist network access for msghand thread

### DIFF
--- a/src/util/syscall_sandbox.cpp
+++ b/src/util/syscall_sandbox.cpp
@@ -867,6 +867,8 @@ void SetSyscallSandboxPolicy(SyscallSandboxPolicy syscall_policy)
         break;
     case SyscallSandboxPolicy::MESSAGE_HANDLER: // Thread: msghand
         seccomp_policy_builder.AllowFileSystem();
+        // ELEMENTS: Need network to call CallMainChainRPC
+        seccomp_policy_builder.AllowNetwork();
         break;
     case SyscallSandboxPolicy::NET: // Thread: net
         seccomp_policy_builder.AllowFileSystem();


### PR DESCRIPTION
Unlike in Bitcoin, our message handling thread needs to open sockets in order to call out to the mainchain RPC interface. We recently brought in a seccomp syscall whitelist from upstream, which is enabled on my local CI box (though apparently not on Github CI) and it is failing on this.