### PR TITLE
Fix `mempool_unbroadcast.py` test

### DIFF
--- a/test/functional/mempool_unbroadcast.py
+++ b/test/functional/mempool_unbroadcast.py
@@ -41,6 +41,10 @@ class MempoolUnbroadcastTest(BitcoinTestFramework):
         # generate a wallet txn
         addr = node.getnewaddress()
         wallet_tx_hsh = node.sendtoaddress(addr, 0.0001)
+        wallet_tx = node.gettransaction(wallet_tx_hsh,True,True)
+
+        # remove UTXO spent
+        utxos = [utxo for utxo in utxos if utxo['txid'] != wallet_tx['decoded']['vin'][0]['txid']]
 
         # generate a txn using sendrawtransaction
         us0 = utxos.pop()


### PR DESCRIPTION
The `mempool_unbrodcast.py` test was generating a list of 57 confirmed UTXOs and then performing a spend from the same wallet, using a random UTXO. The unmodified list was then used to create a raw transaction, causing a mempool conflict and test failure with a chance of 1/57. 

This fix updates the UTXO list with the spend. 

Fixes https://github.com/ElementsProject/elements/issues/1457