### PR TITLE
Test: fix intermittent failures for wallet_elements_regression_1259.py and feature_dynafed.py

### DIFF
--- a/test/functional/feature_dynafed.py
+++ b/test/functional/feature_dynafed.py
@@ -305,6 +305,7 @@ class DynaFedTest(BitcoinTestFramework):
         assert comb_result["complete"]
         self.nodes[0].submitblock(comb_result["hex"])
         assert_equal(self.nodes[0].getblockcount(), cur_height+11)
+        self.sync_blocks()
 
     def test_transition_mempool_eject(self):
         self.log.info("Testing mempool (r)ejection policy on transitions...")

--- a/test/functional/wallet_elements_regression_1259.py
+++ b/test/functional/wallet_elements_regression_1259.py
@@ -56,6 +56,7 @@ class WalletTest(BitcoinTestFramework):
         for i in range(num_utxos):
             self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), value, "", "", False, False, None, None, None, asset, False, fee_rate, True)
             self.generate(self.nodes[0], 1)
+        self.sync_all()
 
         # create a raw tx on node 1 consolidating the asset utxos
         self.log.info(f"Create the raw consolidation transaction")


### PR DESCRIPTION
Add sync steps to prevent intermittent failures of `wallet_elements_regression_1259.py` and `feature_dynafed.py`

Fixes: https://github.com/ElementsProject/elements/issues/1404