### PR TITLE
ci: fix macos native task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -313,7 +313,7 @@ task:
   name: 'macOS 13 native arm64 [gui, sqlite only] [no depends]'
   macos_instance:
     # Use latest image, but hardcode version to avoid silent upgrades (and breaks)
-    image: ghcr.io/cirruslabs/macos-ventura-xcode:14.1  # https://cirrus-ci.org/guide/macOS
+    image: ghcr.io/cirruslabs/macos-runner:sequoia  # https://cirrus-ci.org/guide/macOS
   << : *MACOS_NATIVE_TASK_TEMPLATE
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV

--- a/ci/test/00_setup_env_mac_native_arm64.sh
+++ b/ci/test/00_setup_env_mac_native_arm64.sh
@@ -7,9 +7,7 @@
 export LC_ALL=C.UTF-8
 
 export HOST=arm64-apple-darwin
-# Homebrew's python@3.12 is marked as externally managed (PEP 668).
-# Therefore, `--break-system-packages` is needed.
-export PIP_PACKAGES="--break-system-packages zmq"
+export PIP_PACKAGES="zmq"
 export GOAL="install"
 # ELEMENTS: add -fno-stack-check to work around clang bug on macos
 export BITCOIN_CONFIG="--with-gui --with-miniupnpc --with-natpmp --enable-reduce-exports CXXFLAGS=-fno-stack-check"

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -11,7 +11,7 @@ if [[ $QEMU_USER_CMD == qemu-s390* ]]; then
 fi
 
 if [ "$CI_OS_NAME" == "macos" ]; then
-  sudo -H pip3 install --upgrade --break-system-packages --ignore-installed pip
+  sudo -H pip3 install --upgrade --ignore-installed pip
   # shellcheck disable=SC2086
   IN_GETOPT_BIN="$(brew --prefix gnu-getopt)/bin/getopt" ${CI_RETRY_EXE} pip3 install --user $PIP_PACKAGES
 fi


### PR DESCRIPTION
Cirrus has started upgrading native MacOS task to sequoia, which then has a pip failure: `no such option: --break-system-packages` - [example](https://cirrus-ci.com/task/5612463619571712?logs=ci#L11) 

This PR gets it passing again. I haven't updated the name/metadata of the task since it is soon removed by upstream, as they move the macos job to github actions. 