### PR TITLE
Fix p2p_invalid_messages functional test

### DIFF
--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -130,7 +130,7 @@ class InvalidMessagesTest(BitcoinTestFramework):
     def test_size(self):
         self.log.info("Test message with oversized payload disconnects peer")
         conn = self.nodes[0].add_p2p_connection(P2PDataStore())
-        with self.nodes[0].assert_debug_log(['Header error: Size too large (badmsg, 4000001 bytes)']):
+        with self.nodes[0].assert_debug_log(['Header error: Size too large (badmsg, 16000001 bytes)']):
             msg = msg_unrecognized(str_data="d" * (VALID_DATA_LIMIT + 1))
             msg = conn.build_message(msg)
             conn.send_raw_message(msg)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -244,8 +244,7 @@ BASE_SCRIPTS = [
     'p2p_invalid_block.py',
     'feature_elements_taproot_activation.py',
     'feature_elements_simplicity_activation.py',
-    # ELEMENTS: needs to be fixed
-    #'p2p_invalid_messages.py',
+    'p2p_invalid_messages.py',
     'p2p_invalid_tx.py',
     'feature_assumevalid.py',
     'example_test.py',


### PR DESCRIPTION
Fix expected log message for `MAX_PROTOCOL_MESSAGE_LENGTH` for Elements (16MB). 