### PR TITLE
Use --break-system-packages for macos CI

### DIFF
--- a/ci/test/00_setup_env_mac_native_arm64.sh
+++ b/ci/test/00_setup_env_mac_native_arm64.sh
@@ -7,7 +7,9 @@
 export LC_ALL=C.UTF-8
 
 export HOST=arm64-apple-darwin
-export PIP_PACKAGES="zmq"
+# Homebrew's python@3.12 is marked as externally managed (PEP 668).
+# Therefore, `--break-system-packages` is needed.
+export PIP_PACKAGES="--break-system-packages zmq"
 export GOAL="install"
 # ELEMENTS: add -fno-stack-check to work around clang bug on macos
 export BITCOIN_CONFIG="--with-gui --with-miniupnpc --with-natpmp --enable-reduce-exports CXXFLAGS=-fno-stack-check"

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -11,7 +11,7 @@ if [[ $QEMU_USER_CMD == qemu-s390* ]]; then
 fi
 
 if [ "$CI_OS_NAME" == "macos" ]; then
-  sudo -H pip3 install --upgrade --ignore-installed pip
+  sudo -H pip3 install --upgrade --break-system-packages --ignore-installed pip
   # shellcheck disable=SC2086
   IN_GETOPT_BIN="$(brew --prefix gnu-getopt)/bin/getopt" ${CI_RETRY_EXE} pip3 install --user $PIP_PACKAGES
 fi


### PR DESCRIPTION
Add --break-system-packages to PIP_PACKAGES in macos CI, to allow for macos-runner images to update homebrew packages. 