### PR TITLE
Cherry-pick bitcoin/bitcoin#26777

### DIFF
--- a/ci/test/00_setup_env_mac_native_arm64.sh
+++ b/ci/test/00_setup_env_mac_native_arm64.sh
@@ -7,7 +7,9 @@
 export LC_ALL=C.UTF-8
 
 export HOST=arm64-apple-darwin
-export PIP_PACKAGES="zmq"
+# Homebrew's python@3.12 is marked as externally managed (PEP 668).
+# Therefore, `--break-system-packages` is needed.
+export PIP_PACKAGES="--break-system-packages zmq"
 export GOAL="install"
 # ELEMENTS: add -fno-stack-check to work around clang bug on macos
 export BITCOIN_CONFIG="--with-gui --with-miniupnpc --with-natpmp --enable-reduce-exports CXXFLAGS=-fno-stack-check"

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -11,7 +11,7 @@ if [[ $QEMU_USER_CMD == qemu-s390* ]]; then
 fi
 
 if [ "$CI_OS_NAME" == "macos" ]; then
-  sudo -H pip3 install --upgrade --ignore-installed pip
+  sudo -H pip3 install --upgrade --break-system-packages --ignore-installed pip
   # shellcheck disable=SC2086
   IN_GETOPT_BIN="$(brew --prefix gnu-getopt)/bin/getopt" ${CI_RETRY_EXE} pip3 install --user $PIP_PACKAGES
 fi

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -473,7 +473,6 @@ static const std::vector<RPCResult> TransactionDescriptionString()
            }},
            {RPCResult::Type::STR_HEX, "replaced_by_txid", /*optional=*/true, "The txid if this tx was replaced."},
            {RPCResult::Type::STR_HEX, "replaces_txid", /*optional=*/true, "The txid if the tx replaces one."},
-           {RPCResult::Type::STR, "comment", /*optional=*/true, ""},
            {RPCResult::Type::STR, "to", /*optional=*/true, "If a comment to is associated with the transaction."},
            {RPCResult::Type::NUM_TIME, "time", "The transaction time expressed in " + UNIX_EPOCH_TIME + "."},
            {RPCResult::Type::NUM_TIME, "timereceived", "The time received expressed in " + UNIX_EPOCH_TIME + "."},

--- a/test/functional/feature_discount_ct.py
+++ b/test/functional/feature_discount_ct.py
@@ -89,26 +89,6 @@ class CTTest(BitcoinTestFramework):
         assert_approx(tx['discountweight'], 1301.5, 0.5)
         assert_equal(tx['discountvsize'], 326)
 
-        self.log.info("Send confidential tx to node 0")
-        addr = node0.getnewaddress()
-        info = node0.getaddressinfo(addr)
-        txid = node0.sendtoaddress(info['confidential'], 1.0, "", "", False, None, None, None, None, None, None, feerate)
-        tx = node0.gettransaction(txid, True, True)
-        decoded = tx['decoded']
-        vin = decoded['vin']
-        vout = decoded['vout']
-        assert_equal(len(vin), 2)
-        assert_equal(len(vout), 3)
-        assert_equal(tx['fee']['bitcoin'], Decimal('-0.00002575'))
-        assert_equal(decoded['vsize'], 2575)
-        # tx weight can be 10299 or 10300, accept both
-        assert_approx(decoded['weight'], 10299.5, 0.5)
-        self.generate(node0, 1)
-        tx = node1.getrawtransaction(txid, True)
-        # tx discountweight can be 1301 or 1302, accept both
-        assert_approx(tx['discountweight'], 1301.5, 0.5)
-        assert_equal(tx['discountvsize'], 326) # node1 has discountvsize
-
         self.log.info("Send explicit tx to node 1")
         addr = node1.getnewaddress()
         info = node1.getaddressinfo(addr)
@@ -128,6 +108,26 @@ class CTTest(BitcoinTestFramework):
         # tx weight can be 1301 or 1302, accept both
         assert_approx(tx['discountweight'], 1301.5, 0.5)
         assert_equal(tx['discountvsize'], 326)
+
+        self.log.info("Send confidential tx to node 0")
+        addr = node0.getnewaddress()
+        info = node0.getaddressinfo(addr)
+        txid = node0.sendtoaddress(info['confidential'], 1.0, "", "", False, None, None, None, None, None, None, feerate)
+        tx = node0.gettransaction(txid, True, True)
+        decoded = tx['decoded']
+        vin = decoded['vin']
+        vout = decoded['vout']
+        assert_equal(len(vin), 2)
+        assert_equal(len(vout), 3)
+        assert_equal(tx['fee']['bitcoin'], Decimal('-0.00002575'))
+        assert_equal(decoded['vsize'], 2575)
+        # tx weight can be 10299 or 10300, accept both
+        assert_approx(decoded['weight'], 10299.5, 0.5)
+        self.generate(node0, 1)
+        tx = node1.getrawtransaction(txid, True)
+        # tx discountweight can be 1301 or 1302, accept both
+        assert_approx(tx['discountweight'], 1301.5, 0.5)
+        assert_equal(tx['discountvsize'], 326) # node1 has discountvsize
 
         self.log.info("Send confidential (undiscounted) tx to node 1")
         addr = node1.getnewaddress()


### PR DESCRIPTION
Merge bitcoin/bitcoin#26777: rpc: Remove duplicate field in RPCHelpMan for gettransactions

090ad51c80fe02a73f8988c1d5b867d2e90ab2f3 rpc: Remove duplicate field in RPCHelpMan for gettransactions (Joshua Kelly)

Pull request description:

  The field 'comment' appears twice in `TransactionDescriptionString`, incorrectly - this commit removes the instance of the comment field without a description, preserving the one with a description.

  On master, the duplicate fields can be be viewed here: https://github.com/bitcoin/bitcoin/blob/master/src/wallet/rpc/transactions.cpp#L419-L423

  `TransactionDescriptionString` is included in RPC calls such as `listtransactions` which have functional tests.