### PR TITLE
Cherry-pick bitcoin/bitcoin#26777

### DIFF
--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -473,7 +473,6 @@ static const std::vector<RPCResult> TransactionDescriptionString()
            }},
            {RPCResult::Type::STR_HEX, "replaced_by_txid", /*optional=*/true, "The txid if this tx was replaced."},
            {RPCResult::Type::STR_HEX, "replaces_txid", /*optional=*/true, "The txid if the tx replaces one."},
-           {RPCResult::Type::STR, "comment", /*optional=*/true, ""},
            {RPCResult::Type::STR, "to", /*optional=*/true, "If a comment to is associated with the transaction."},
            {RPCResult::Type::NUM_TIME, "time", "The transaction time expressed in " + UNIX_EPOCH_TIME + "."},
            {RPCResult::Type::NUM_TIME, "timereceived", "The time received expressed in " + UNIX_EPOCH_TIME + "."},


### PR DESCRIPTION
Merge https://github.com/bitcoin/bitcoin/pull/26777: rpc: Remove duplicate field in RPCHelpMan for gettransactions

https://github.com/ElementsProject/elements/commit/090ad51c80fe02a73f8988c1d5b867d2e90ab2f3 rpc: Remove duplicate field in RPCHelpMan for gettransactions (Joshua Kelly)

Pull request description:

The field 'comment' appears twice in TransactionDescriptionString, incorrectly - this commit removes the instance of the comment field without a description, preserving the one with a description.

On master, the duplicate fields can be be viewed here: https://github.com/bitcoin/bitcoin/blob/master/src/wallet/rpc/transactions.cpp#L419-L423

TransactionDescriptionString is included in RPC calls such as listtransactions which have functional tests.