### PR TITLE
disable migratewallet rpc for v29

### DIFF
--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -781,6 +781,7 @@ RPCHelpMan simulaterawtransaction()
 static RPCHelpMan migratewallet()
 {
     return RPCHelpMan{"migratewallet",
+        "\nDISABLED\n"
         "\nMigrate the wallet to a descriptor wallet.\n"
         "A new wallet backup will need to be made.\n"
         "\nThe migration process will create a backup of the wallet before migrating. This backup\n"
@@ -819,6 +820,10 @@ static RPCHelpMan migratewallet()
                 wallet_name = request.params[0].get_str();
             }
 
+            throw JSONRPCError(RPC_WALLET_ERROR,
+                "migratewallet is disabled in this version.");
+
+            /* ELEMENTS v29: disable migratewallet
             SecureString wallet_pass;
             wallet_pass.reserve(100);
             if (!request.params[1].isNull()) {
@@ -842,6 +847,7 @@ static RPCHelpMan migratewallet()
             r.pushKV("backup_path", res->backup_path.utf8string());
 
             return r;
+            */
         },
     };
 }


### PR DESCRIPTION
Disable the `migratewallet` RPC for v29. 