### PR TITLE
rpc: expose effective fee asset

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -32,6 +32,7 @@
 #include <node/transaction.h>
 #include <node/utxo_snapshot.h>
 #include <node/warnings.h>
+#include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <rpc/server.h>
 #include <rpc/server_util.h>
@@ -3682,6 +3683,7 @@ static RPCHelpMan getsidechaininfo()
                         {RPCResult::Type::ARR, "current_fedpegscripts", "The currently-enforced fedpegscripts in hex. Peg-ins for any entries on this list are honored by consensus and policy. Newest first. Two total entries are possible",
                             {{RPCResult::Type::STR_HEX, "", "active fedpegscript"}}},
                         {RPCResult::Type::STR_HEX, "pegged_asset", "Pegged asset type"},
+                        {RPCResult::Type::STR_HEX, "fee_asset", "The asset used for transaction fees and relay policy"},
                         {RPCResult::Type::STR, "min_peg_diff", "The minimum difficulty parent chain header target. Peg-in headers that have less work will be rejected as an anti-Dos measure"},
                         {RPCResult::Type::STR_HEX, "parent_blockhash", "The parent genesis blockhash as source of pegged-in funds"},
                         {RPCResult::Type::BOOL, "parent_chain_has_pow", "Whether parent chain has pow or signed blocks"},
@@ -3723,6 +3725,7 @@ static RPCHelpMan getsidechaininfo()
     obj.pushKV("current_fedpeg_programs", fedpeg_prog_entries);
     obj.pushKV("current_fedpegscripts", fedpeg_entries);
     obj.pushKV("pegged_asset", consensus.pegged_asset.GetHex());
+    obj.pushKV("fee_asset", policyAsset.GetHex());
     obj.pushKV("min_peg_diff", consensus.parentChainPowLimit.GetHex());
     obj.pushKV("parent_blockhash", parent_blockhash.GetHex());
     obj.pushKV("parent_chain_has_pow", consensus.ParentChainHasPow());

--- a/test/functional/rpc_sidechaininfo.py
+++ b/test/functional/rpc_sidechaininfo.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Elements developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the getsidechaininfo fee-asset contract."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import BITCOIN_ASSET, assert_equal, assert_is_hash_string
+
+
+OVERRIDE_FEE_ASSET = "11" * 32
+
+
+class SidechainInfoTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+        self.extra_args = [[], [f"-feeasset={OVERRIDE_FEE_ASSET}"]]
+
+    def setup_network(self):
+        self.setup_nodes()
+
+    def run_test(self):
+        default_info = self.nodes[0].getsidechaininfo()
+        override_info = self.nodes[1].getsidechaininfo()
+
+        for info in [default_info, override_info]:
+            assert_is_hash_string(info["pegged_asset"])
+            assert_is_hash_string(info["fee_asset"])
+            assert_equal(info["pegged_asset"], BITCOIN_ASSET)
+
+        assert_equal(default_info["fee_asset"], default_info["pegged_asset"])
+        assert_equal(override_info["fee_asset"], OVERRIDE_FEE_ASSET)
+        assert_equal(override_info["pegged_asset"], default_info["pegged_asset"])
+
+
+if __name__ == "__main__":
+    SidechainInfoTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -108,6 +108,7 @@ BASE_SCRIPTS = [
     'feature_blocksign.py --legacy-wallet',
     'rpc_calcfastmerkleroot.py',
     'feature_txwitness.py',
+    'rpc_sidechaininfo.py',
     'rpc_tweakfedpeg.py --legacy-wallet',
     'feature_issuance.py --legacy-wallet',
     'feature_confidential_transactions.py --legacy-wallet',


### PR DESCRIPTION
## Motivation

Elements accepts `-feeasset=<asset-id>` and uses the resulting `policyAsset` for transaction-fee and relay policy, while `getsidechaininfo` currently exposes only the consensus `pegged_asset`. An RPC client connected to an already-running node therefore cannot determine whether the operator selected a different effective fee asset.

## Change

- add an always-present `fee_asset` field to `getsidechaininfo`
- define it as the effective `policyAsset` after startup argument processing
- keep the existing `pegged_asset` field unchanged
- add a wallet-independent functional test covering both the default and an explicit override

The change is additive and read-only. `policyAsset` is fixed before RPC service starts, so it does not introduce new mutable state or locking.

## Local verification

- `rpc_sidechaininfo.py` passed directly and through the functional test runner
- `rpc_tweakfedpeg.py --legacy-wallet` passed
- `feature_dynafed.py --legacy-wallet` passed
- touched-file, include, Python UTF-8, functional-test-list, mypy, and dead-code checks passed

