### PR TITLE
script: add and default to SIGHASH_ALL_WITH_RANGEPROOF for pre-taproot signing 

### DIFF
--- a/doc/release-notes-20861.md
+++ b/doc/release-notes-20861.md
@@ -1,3 +1,25 @@
+Wallet and signing
+------------------
+
+- ELEMENTS: The default sighash used when signing pre-Taproot (legacy and
+  segwit v0) inputs now commits to the output rangeproofs on chains where
+  `SIGHASH_RANGEPROOF` is active (i.e. dynafed is active). Concretely, when no
+  sighash type is specified, the wallet, the `signrawtransactionwithkey` /
+  `signrawtransactionwithwallet` / `walletprocesspsbt` / `descriptorprocesspsbt`
+  RPCs, and `elements-tx` now default to `SIGHASH_ALL|RANGEPROOF` instead of
+  `SIGHASH_ALL`. This removes the previous default's third-party rangeproof
+  (witness) malleability and matches the rangeproof coverage that Taproot inputs
+  already have.
+
+  The new default is gated on activation: node-backed signing checks live
+  dynafed activation at the current tip, while the offline `elements-tx` tool
+  gates on the selected chain's parameters (only chains where dynafed is always
+  active). On chains where `SIGHASH_RANGEPROOF` is not active, the historical
+  `SIGHASH_ALL` default is used so that signatures remain standard and valid.
+  Taproot signing is unaffected: the `SIGHASH_RANGEPROOF` bit is ignored for
+  Taproot (which always commits to rangeproofs). Users can still request any
+  specific sighash type explicitly to override the default.
+
 Updated RPCs
 ------------
 

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -5,6 +5,7 @@
 #include <bitcoin-build-config.h> // IWYU pragma: keep
 
 #include <asset.h>
+#include <chainparams.h>
 #include <chainparamsbase.h>
 #include <clientversion.h>
 #include <coins.h>
@@ -21,6 +22,7 @@
 #include <script/sign.h>
 #include <script/signingprovider.h>
 #include <univalue.h>
+#include <util/chaintype.h>
 #include <util/exception.h>
 #include <util/fs.h>
 #include <util/moneystr.h>
@@ -615,7 +617,16 @@ static std::vector<unsigned char> ParseHexUV(const UniValue& v, const std::strin
 
 static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
 {
-    int nHashType = SIGHASH_ALL;
+    // ELEMENTS: bitcoin-tx has no chainstate, so we cannot check live dynafed
+    // activation. Gate the default on chain parameters instead: commit to
+    // rangeproofs by default on chains where dynafed (which enables
+    // SCRIPT_SIGHASH_RANGEPROOF) is known to be active. Otherwise use the
+    // historical SIGHASH_ALL default so offline-built txs stay standard and valid.
+    // See CChainParams::SighashRangeproofActiveByParams() for the liquidv1 nuance.
+    int nHashType = DefaultSighashType(Params().SighashRangeproofActiveByParams());
+    // DefaultSighashType may return SIGHASH_DEFAULT (0); for the legacy tool path
+    // treat that as SIGHASH_ALL.
+    if (nHashType == SIGHASH_DEFAULT) nHashType = SIGHASH_ALL;
 
     if (flagStr.size() > 0)
         if (!findSighashFlags(nHashType, flagStr))

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -208,6 +208,13 @@ public:
     //! Check if transaction is RBF opt in.
     virtual RBFTransactionState isRBFOptIn(const CTransaction& tx) = 0;
 
+    //! ELEMENTS: Check whether SIGHASH_RANGEPROOF is active for signing at the
+    //! current chain tip (i.e. dynafed, which enables SCRIPT_SIGHASH_RANGEPROOF,
+    //! is active). Used to decide the default pre-Taproot sighash so that we only
+    //! commit to output rangeproofs when doing so yields standard, valid
+    //! signatures.
+    virtual bool isSighashRangeproofActive() = 0;
+
     //! Check if transaction is in mempool.
     virtual bool isInMempool(const uint256& txid) = 0;
 

--- a/src/kernel/chainparams.h
+++ b/src/kernel/chainparams.h
@@ -144,6 +144,21 @@ public:
     std::string GetChainTypeString() const { return m_chain_type.chain_name; }
     /** Return the chain type */
     ChainTypeMeta GetChainTypeMeta() const { return m_chain_type; }
+    /**
+     * ELEMENTS: Whether SIGHASH_RANGEPROOF can be assumed active for this chain
+     * from the chain parameters alone (i.e. without inspecting the current tip).
+     * Used by offline tooling such as elements-tx that has no chainstate to
+     * decide the default sighash. This is true when dynafed (which enables
+     * SCRIPT_SIGHASH_RANGEPROOF) is configured ALWAYS_ACTIVE (e.g. elementsregtest
+     * with dynafed enabled, or liquidv1test), or on liquidv1 where dynafed is
+     * height-activated (nStartTime is a block height, not the ALWAYS_ACTIVE
+     * sentinel) but is long since active on the live chain.
+     */
+    bool SighashRangeproofActiveByParams() const
+    {
+        return consensus.vDeployments[Consensus::DEPLOYMENT_DYNA_FED].nStartTime == Consensus::BIP9Deployment::ALWAYS_ACTIVE
+            || m_chain_type.chain_type == ChainType::LIQUID1;
+    }
     /** Return the list of hostnames to look up for DNS seeds */
     const std::vector<std::string>& DNSSeeds() const { return vSeeds; }
     const std::vector<unsigned char>& Base58Prefix(Base58Type type) const { return base58Prefixes[type]; }

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -668,6 +668,14 @@ public:
         LOCK(m_node.mempool->cs);
         return IsRBFOptIn(tx, *m_node.mempool);
     }
+    bool isSighashRangeproofActive() override
+    {
+        // Mirror the mempool standardness check in MemPoolAccept: dynafed being
+        // active after the current tip enables SCRIPT_SIGHASH_RANGEPROOF, which
+        // is what makes SIGHASH_RANGEPROOF signatures standard and valid.
+        LOCK(::cs_main);
+        return DeploymentActiveAfter(chainman().ActiveChain().Tip(), chainman(), Consensus::DEPLOYMENT_DYNA_FED);
+    }
     bool isInMempool(const uint256& txid) override
     {
         if (!m_node.mempool) return false;

--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -693,10 +693,15 @@ bool PSBTInputSignedAndVerified(const PartiallySignedTransaction psbt, unsigned 
     }
 
     CMutableTransaction tx = psbt.GetUnsignedTx();
+    // ELEMENTS: enable SCRIPT_SIGHASH_RANGEPROOF when verifying, mirroring
+    // ProduceSignature()/DataFromTransaction(). Otherwise signatures using the
+    // SIGHASH_RANGEPROOF (0x40) bit -- which the wallet now produces by default
+    // once dynafed is active -- are rejected as "not understood" and the input
+    // never verifies, breaking finalization.
     if (txdata) {
-        return VerifyScript(input.final_script_sig, utxo.scriptPubKey, &input.final_script_witness, STANDARD_SCRIPT_VERIFY_FLAGS, MutableTransactionSignatureChecker{&tx, input_index, utxo.nValue, *txdata, MissingDataBehavior::FAIL});
+        return VerifyScript(input.final_script_sig, utxo.scriptPubKey, &input.final_script_witness, STANDARD_SCRIPT_VERIFY_FLAGS | SCRIPT_SIGHASH_RANGEPROOF, MutableTransactionSignatureChecker{&tx, input_index, utxo.nValue, *txdata, MissingDataBehavior::FAIL});
     } else {
-        return VerifyScript(input.final_script_sig, utxo.scriptPubKey, &input.final_script_witness, STANDARD_SCRIPT_VERIFY_FLAGS, MutableTransactionSignatureChecker{&tx, input_index, utxo.nValue, MissingDataBehavior::FAIL});
+        return VerifyScript(input.final_script_sig, utxo.scriptPubKey, &input.final_script_witness, STANDARD_SCRIPT_VERIFY_FLAGS | SCRIPT_SIGHASH_RANGEPROOF, MutableTransactionSignatureChecker{&tx, input_index, utxo.nValue, MissingDataBehavior::FAIL});
     }
 }
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -11,6 +11,7 @@
 #include <consensus/amount.h>
 #include <consensus/validation.h>
 #include <core_io.h>
+#include <deploymentstatus.h>
 #include <index/txindex.h>
 #include <key_io.h>
 #include <logging.h>
@@ -891,8 +892,10 @@ static RPCHelpMan signrawtransactionwithkey()
     ParsePrevouts(request.params[2], &keystore, coins);
 
     UniValue result(UniValue::VOBJ);
-    auto tip = WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip());
-    SignTransaction(mtx, &keystore, coins, request.params[3], result, tip);
+    const auto [tip, sighash_rangeproof_active] = WITH_LOCK(::cs_main, return std::make_pair(
+        chainman.ActiveChain().Tip(),
+        DeploymentActiveAfter(chainman.ActiveChain().Tip(), chainman, Consensus::DEPLOYMENT_DYNA_FED)));
+    SignTransaction(mtx, &keystore, coins, request.params[3], result, tip, sighash_rangeproof_active);
     return result;
 },
     };
@@ -3300,7 +3303,16 @@ RPCHelpMan descriptorprocesspsbt()
         EvalDescriptorStringOrObject(descs[i], provider, /*expand_priv=*/true);
     }
 
-    int sighash_type = ParseSighashString(request.params[2]);
+    // ELEMENTS: when no sighash is specified, default to committing to
+    // rangeproofs if SIGHASH_RANGEPROOF is active at the current tip.
+    int sighash_type;
+    if (request.params[2].isNull()) {
+        ChainstateManager& chainman = EnsureAnyChainman(request.context);
+        const bool sighash_rangeproof_active = WITH_LOCK(::cs_main, return DeploymentActiveAfter(chainman.ActiveChain().Tip(), chainman, Consensus::DEPLOYMENT_DYNA_FED));
+        sighash_type = DefaultSighashType(sighash_rangeproof_active);
+    } else {
+        sighash_type = ParseSighashString(request.params[2]);
+    }
     bool bip32derivs = request.params[3].isNull() ? true : request.params[3].get_bool();
     bool finalize = request.params[4].isNull() ? true : request.params[4].get_bool();
 

--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -608,9 +608,11 @@ bool ValidateTransactionPeginInputs(const CMutableTransaction& mtx, const CBlock
     return immature_pegin;
 }
 
-void SignTransaction(CMutableTransaction& mtx, const SigningProvider* keystore, const std::map<COutPoint, Coin>& coins, const UniValue& hashType, UniValue& result, const CBlockIndex* active_chain_tip)
+void SignTransaction(CMutableTransaction& mtx, const SigningProvider* keystore, const std::map<COutPoint, Coin>& coins, const UniValue& hashType, UniValue& result, const CBlockIndex* active_chain_tip, bool sighash_rangeproof_active)
 {
-    int nHashType = ParseSighashString(hashType);
+    // ELEMENTS: when no sighash is specified, default to committing to
+    // rangeproofs if SIGHASH_RANGEPROOF is active at the current tip.
+    int nHashType = hashType.isNull() ? DefaultSighashType(sighash_rangeproof_active) : ParseSighashString(hashType);
 
     // Script verification errors
     std::map<int, bilingual_str> input_errors;

--- a/src/rpc/rawtransaction_util.h
+++ b/src/rpc/rawtransaction_util.h
@@ -37,7 +37,7 @@ class SigningProvider;
  * @param  hashType      The signature hash type
  * @param result         JSON object where signed transaction results accumulate
  */
-void SignTransaction(CMutableTransaction& mtx, const SigningProvider* keystore, const std::map<COutPoint, Coin>& coins, const UniValue& hashType, UniValue& result, const CBlockIndex* active_chain_tip);
+void SignTransaction(CMutableTransaction& mtx, const SigningProvider* keystore, const std::map<COutPoint, Coin>& coins, const UniValue& hashType, UniValue& result, const CBlockIndex* active_chain_tip, bool sighash_rangeproof_active);
 void SignTransactionResultToJSON(CMutableTransaction& mtx, bool complete, const std::map<COutPoint, Coin>& coins, const std::map<int, bilingual_str>& input_errors, bool immature_pegin, UniValue& result);
 
 /**

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -39,6 +39,15 @@ enum
     // ELEMENTS:
     // A flag that means the rangeproofs should be included in the sighash.
     SIGHASH_RANGEPROOF = 0x40,
+
+    // ELEMENTS:
+    // The default sighash used by wallets/tools when signing pre-Taproot
+    // (BASE/WITNESS_V0) inputs on chains where SIGHASH_RANGEPROOF is active.
+    // This commits to the output rangeproofs, closing the pre-Taproot
+    // rangeproof (witness) malleability gap. Note this must only be used once
+    // dynafed (which enables SCRIPT_SIGHASH_RANGEPROOF) is active for the target
+    // chain; otherwise the resulting signatures are non-standard and invalid.
+    SIGHASH_ALL_WITH_RANGEPROOF = SIGHASH_ALL | SIGHASH_RANGEPROOF,
 };
 
 /** Script verification flags.

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -38,6 +38,15 @@ MutableTransactionSignatureCreator::MutableTransactionSignatureCreator(const CMu
 {
 }
 
+int DefaultSighashType(bool sighash_rangeproof_active)
+{
+    // When SIGHASH_RANGEPROOF is active for the chain, default to committing to
+    // rangeproofs for pre-Taproot inputs. The 0x40 bit is stripped for Taproot
+    // signing (see CreateSchnorrSig), so this is a safe universal default.
+    // Otherwise fall back to SIGHASH_DEFAULT (== SIGHASH_ALL for pre-Taproot).
+    return sighash_rangeproof_active ? SIGHASH_ALL_WITH_RANGEPROOF : SIGHASH_DEFAULT;
+}
+
 bool MutableTransactionSignatureCreator::CreateSig(const SigningProvider& provider, std::vector<unsigned char>& vchSig, const CKeyID& address, const CScript& scriptCode, SigVersion sigversion, unsigned int flags) const
 {
     assert(sigversion == SigVersion::BASE || sigversion == SigVersion::WITNESS_V0);
@@ -85,12 +94,17 @@ bool MutableTransactionSignatureCreator::CreateSchnorrSig(const SigningProvider&
         execdata.m_tapleaf_hash_init = true;
         execdata.m_tapleaf_hash = *leaf_hash;
     }
+    // ELEMENTS: SIGHASH_RANGEPROOF is a pre-Taproot-only flag; the BIP341-style
+    // sighash always commits to rangeproofs and rejects the 0x40 bit. Strip it so
+    // that a universal default of SIGHASH_ALL_WITH_RANGEPROOF still produces valid
+    // Taproot signatures.
+    const int taproot_hashtype = nHashType & ~SIGHASH_RANGEPROOF;
     uint256 hash;
-    if (!SignatureHashSchnorr(hash, execdata, m_txto, nIn, nHashType, sigversion, *m_txdata, MissingDataBehavior::FAIL)) return false;
+    if (!SignatureHashSchnorr(hash, execdata, m_txto, nIn, taproot_hashtype, sigversion, *m_txdata, MissingDataBehavior::FAIL)) return false;
     sig.resize(64);
     // Use uint256{} as aux_rnd for now.
     if (!key.SignSchnorr(hash, sig, merkle_root, {})) return false;
-    if (nHashType) sig.push_back(nHashType);
+    if (taproot_hashtype) sig.push_back(taproot_hashtype);
     return true;
 }
 

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -107,4 +107,18 @@ bool IsSegWitOutput(const SigningProvider& provider, const CScript& script);
 /** Sign the CMutableTransaction */
 bool SignTransaction(CMutableTransaction& mtx, const SigningProvider* provider, const std::map<COutPoint, Coin>& coins, int sighash, const uint256& hash_genesis_block, std::map<int, bilingual_str>& input_errors);
 
+/**
+ * ELEMENTS: Return the default sighash type to use when the caller did not
+ * specify one. When SIGHASH_RANGEPROOF is active for the target chain, the
+ * default commits to output rangeproofs (SIGHASH_ALL_WITH_RANGEPROOF for
+ * pre-Taproot inputs); otherwise the historical default (SIGHASH_DEFAULT, which
+ * is equivalent to SIGHASH_ALL for pre-Taproot) is used so that signatures stay
+ * standard and valid on chains where dynafed is not active.
+ *
+ * Note: for Taproot inputs the sighash byte's rangeproof bit is ignored (the
+ * BIP341-style sighash always commits to rangeproofs), so this default is only
+ * meaningful for BASE/WITNESS_V0 signing.
+ */
+int DefaultSighashType(bool sighash_rangeproof_active);
+
 #endif // BITCOIN_SCRIPT_SIGN_H

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -8,6 +8,7 @@
 #include <hash.h>
 #include <script/interpreter.h>
 #include <script/script.h>
+#include <script/sign.h>
 #include <serialize.h>
 #include <streams.h>
 #include <test/data/sighash.json.h>
@@ -207,5 +208,22 @@ BOOST_AUTO_TEST_CASE(sighash_from_data)
         sh = SignatureHash(scriptCode, *tx, nIn, nHashType, 0, SigVersion::BASE, 0);
         BOOST_CHECK_MESSAGE(sh.GetHex() == sigHashHex, strTest);
     }
+}
+
+// ELEMENTS: verify the default sighash selection helper.
+BOOST_AUTO_TEST_CASE(sighash_default_type)
+{
+    // The named constant sets both the ALL and RANGEPROOF bits.
+    BOOST_CHECK_EQUAL(SIGHASH_ALL_WITH_RANGEPROOF, SIGHASH_ALL | SIGHASH_RANGEPROOF);
+    BOOST_CHECK(SIGHASH_ALL_WITH_RANGEPROOF & SIGHASH_RANGEPROOF);
+
+    // When rangeproof signing is not active, fall back to SIGHASH_DEFAULT
+    // (== SIGHASH_ALL for pre-Taproot); do not set the rangeproof bit.
+    BOOST_CHECK_EQUAL(DefaultSighashType(/*sighash_rangeproof_active=*/false), SIGHASH_DEFAULT);
+    BOOST_CHECK((DefaultSighashType(false) & SIGHASH_RANGEPROOF) == 0);
+
+    // When active, default to committing to rangeproofs.
+    BOOST_CHECK_EQUAL(DefaultSighashType(/*sighash_rangeproof_active=*/true), SIGHASH_ALL_WITH_RANGEPROOF);
+    BOOST_CHECK((DefaultSighashType(true) & SIGHASH_RANGEPROOF) == SIGHASH_RANGEPROOF);
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <bitcoin-build-config.h> // IWYU pragma: keep
 #include <chainparams.h>
 #include <consensus/amount.h>
 #include <consensus/merkle.h>
@@ -362,6 +363,30 @@ BOOST_AUTO_TEST_CASE(block_malleation)
         }
         BOOST_CHECK(is_mutated(block, /*check_witness_root=*/true));
     }
+}
+
+// ELEMENTS: the offline (chainstate-less) SIGHASH_RANGEPROOF gating used by
+// elements-tx must treat liquidv1 as known-active even though dynafed there is
+// height-activated rather than ALWAYS_ACTIVE.
+BOOST_AUTO_TEST_CASE(sighash_rangeproof_by_params_test)
+{
+    // liquidv1: dynafed is height-activated (nStartTime = 1000000), NOT the
+    // ALWAYS_ACTIVE sentinel, but must be treated as active by params.
+    const auto liquidv1 = CreateChainParams(*m_node.args, ChainType::LIQUID1);
+    BOOST_CHECK(liquidv1->GetConsensus().vDeployments[Consensus::DEPLOYMENT_DYNA_FED].nStartTime
+                != Consensus::BIP9Deployment::ALWAYS_ACTIVE);
+    BOOST_CHECK(liquidv1->SighashRangeproofActiveByParams());
+
+    // liquidv1test: overrides dynafed to ALWAYS_ACTIVE, so it is active by params
+    // via the ALWAYS_ACTIVE branch (independent of the liquidv1 chain-type check).
+    const auto liquidv1test = CreateChainParams(*m_node.args, ChainType::LIQUID1TEST);
+    BOOST_CHECK_EQUAL(liquidv1test->GetConsensus().vDeployments[Consensus::DEPLOYMENT_DYNA_FED].nStartTime,
+                      Consensus::BIP9Deployment::ALWAYS_ACTIVE);
+    BOOST_CHECK(liquidv1test->SighashRangeproofActiveByParams());
+
+    // regtest: dynafed never active by default; must be inactive by params.
+    const auto regtest = CreateChainParams(*m_node.args, ChainType::REGTEST);
+    BOOST_CHECK(!regtest->SighashRangeproofActiveByParams());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -1050,7 +1050,11 @@ RPCHelpMan signrawtransactionwithwallet()
     LOCK(pwallet->cs_wallet);
     EnsureWalletIsUnlocked(*pwallet);
 
-    int nHashType = ParseSighashString(request.params[2]);
+    // ELEMENTS: when no sighash is specified, default to committing to
+    // rangeproofs if SIGHASH_RANGEPROOF is active at the current tip.
+    int nHashType = request.params[2].isNull()
+        ? DefaultSighashType(pwallet->chain().isSighashRangeproofActive())
+        : ParseSighashString(request.params[2]);
 
     CMutableTransaction mtx;
     if (!DecodeHexTx(mtx, request.params[0].get_str())) {
@@ -1755,7 +1759,11 @@ RPCHelpMan walletprocesspsbt()
     }
 
     // Get the sighash type
-    int nHashType = ParseSighashString(request.params[2]);
+    // ELEMENTS: when no sighash is specified, default to committing to
+    // rangeproofs if SIGHASH_RANGEPROOF is active at the current tip.
+    int nHashType = request.params[2].isNull()
+        ? DefaultSighashType(pwallet->chain().isSighashRangeproofActive())
+        : ParseSighashString(request.params[2]);
 
     // Don't sign, just fill data.
     bool bip32derivs = request.params[3].isNull() ? true : request.params[3].get_bool();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2306,7 +2306,7 @@ bool CWallet::SignTransaction(CMutableTransaction& tx) const
         coins[input.prevout] = Coin(wtx.tx->vout[input.prevout.n], prev_height, wtx.IsCoinBase());
     }
     std::map<int, bilingual_str> input_errors;
-    return SignTransaction(tx, coins, SIGHASH_DEFAULT, input_errors);
+    return SignTransaction(tx, coins, DefaultSighashType(chain().isSighashRangeproofActive()), input_errors); // ELEMENTS
 }
 
 bool CWallet::SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, bilingual_str>& input_errors) const

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -702,6 +702,7 @@ public:
     OutputType TransactionChangeType(const std::optional<OutputType>& change_type, const std::vector<CRecipient>& vecSend) const;
 
     /** Fetch the inputs and sign with SIGHASH_ALL. */
+    // ELEMENTS: sign with SIGHASH_ALL_WITH_RANGEPROOF for DynaFed chains
     bool SignTransaction(CMutableTransaction& tx) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     /** Sign the tx given the input coins and sighash. */
     bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, bilingual_str>& input_errors) const;

--- a/test/functional/feature_sighash_rangeproof.py
+++ b/test/functional/feature_sighash_rangeproof.py
@@ -8,36 +8,35 @@ Test the post-dynafed elements-only SIGHASH_RANGEPROOF sighash flag.
 """
 
 import struct
-from test_framework.test_framework import BitcoinTestFramework
+
+from test_framework import util
 from test_framework.address import base58_to_byte
+from test_framework.blocktools import add_witness_commitment
+from test_framework.key import ECKey
+from test_framework.messages import (
+    CBlock,
+    from_hex,
+    tx_from_hex,
+)
 from test_framework.script import (
-    hash160,
-    LegacySignatureHash,
-    SegwitV0SignatureHash,
-    SIGHASH_ALL,
-    SIGHASH_RANGEPROOF,
-    CScript,
-    CScriptOp,
     OP_CHECKSIG,
     OP_DUP,
     OP_EQUALVERIFY,
     OP_HASH160,
+    SIGHASH_ALL,
+    SIGHASH_RANGEPROOF,
+    CScript,
+    CScriptOp,
+    LegacySignatureHash,
+    SegwitV0SignatureHash,
+    hash160,
 )
-from test_framework.key import ECKey
-
-from test_framework.messages import (
-    CBlock,
-    tx_from_hex,
-    from_hex,
-)
-
-from test_framework import util
+from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
 )
 
-from test_framework.blocktools import add_witness_commitment
 
 def get_p2pkh_script(pubkeyhash):
     """Get the script associated with a P2PKH."""
@@ -112,7 +111,7 @@ class SighashRangeproofTest(BitcoinTestFramework):
 
         # Prepare the keypair we need to re-sign the tx.
         wif = self.nodes[1].dumpprivkey(addr)
-        (b, v) = base58_to_byte(wif)
+        (b, _v) = base58_to_byte(wif)
         privkey = ECKey()
         privkey.set(b[0:32], len(b) == 33)
         pubkey = privkey.get_pubkey()
@@ -235,12 +234,12 @@ class SighashRangeproofTest(BitcoinTestFramework):
         # - the tx is not accepted in the mempool and
         # - the tx is accepted if manually mined in a block
         for address_type in ADDRESS_TYPES:
-            self.log.info("Pre-activation for {} address".format(address_type))
+            self.log.info(f"Pre-activation for {address_type} address")
             tx = self.prepare_tx_signed_with_sighash(address_type, False, False)
             self.assert_tx_standard(tx, False)
             self.assert_tx_valid(tx, True)
 
-            self.log.info("Pre-activation for {} address (with issuance)".format(address_type))
+            self.log.info(f"Pre-activation for {address_type} address (with issuance)")
             tx = self.prepare_tx_signed_with_sighash(address_type, False, True)
             self.assert_tx_standard(tx, False)
             self.assert_tx_valid(tx, True)
@@ -257,25 +256,29 @@ class SighashRangeproofTest(BitcoinTestFramework):
         # Test that the use of SIGHASH_RANGEPROOF is legal and standard
         # after activation.
         for address_type in ADDRESS_TYPES:
-            self.log.info("Post-activation for {} address".format(address_type))
+            self.log.info(f"Post-activation for {address_type} address")
             tx = self.prepare_tx_signed_with_sighash(address_type, True, False)
             self.assert_tx_standard(tx, True)
             self.assert_tx_valid(tx, True)
 
-            self.log.info("Post-activation for {} address (with issuance)".format(address_type))
+            self.log.info(f"Post-activation for {address_type} address (with issuance)")
             tx = self.prepare_tx_signed_with_sighash(address_type, True, True)
             self.assert_tx_standard(tx, True)
             self.assert_tx_valid(tx, True)
 
+            # Post-activation, the wallet default must set SIGHASH_RANGEPROOF.
+            self.log.info(f"Post-activation default sighash for {address_type} address")
+            self.assert_default_sign_commits_rangeproof(address_type, expect_rangeproof=True)
+
         # Ensure that if we then use the old sighash algorithm that doesn't hash
         # the rangeproofs, the signature is no longer valid.
         for address_type in ADDRESS_TYPES:
-            self.log.info("Post-activation invalid sighash for {} address".format(address_type))
+            self.log.info(f"Post-activation invalid sighash for {address_type} address")
             tx = self.prepare_tx_signed_with_sighash(address_type, False, False)
             self.assert_tx_standard(tx, False)
             self.assert_tx_valid(tx, False)
 
-            self.log.info("Post-activation invalid sighash for {} address (with issuance)".format(address_type))
+            self.log.info(f"Post-activation invalid sighash for {address_type} address (with issuance)")
             tx = self.prepare_tx_signed_with_sighash(address_type, False, True)
             self.assert_tx_standard(tx, False)
             self.assert_tx_valid(tx, False)

--- a/test/functional/feature_sighash_rangeproof.py
+++ b/test/functional/feature_sighash_rangeproof.py
@@ -178,6 +178,46 @@ class SighashRangeproofTest(BitcoinTestFramework):
 
         return signed_tx
 
+    def assert_default_sign_commits_rangeproof(self, address_type, expect_rangeproof):
+        # Sign a blinded tx using the wallet default sighash (no explicit sighash
+        # argument) and assert whether the resulting pre-Taproot signatures
+        # commit to the SIGHASH_RANGEPROOF (0x40) bit.
+        addr = self.nodes[1].getnewaddress("", address_type)
+        assert len(self.nodes[1].getaddressinfo(addr)["confidential_key"]) > 0
+        self.nodes[0].sendtoaddress(addr, 1.0)
+        self.generate(self.nodes[0], 1)
+        self.sync_all()
+        utxo = self.nodes[1].listunspent(1, 1, [addr])[0]
+
+        sink_addr = self.nodes[2].getnewaddress()
+        unsigned_hex = self.nodes[1].createrawtransaction(
+            [{"txid": utxo["txid"], "vout": utxo["vout"]}],
+            [{sink_addr: 0.9}, {"fee": 0.1}]
+        )
+        blinded_hex = self.nodes[1].blindrawtransaction(unsigned_hex)
+        # Deliberately omit the sighash argument to exercise the wallet default.
+        signed = self.nodes[1].signrawtransactionwithwallet(blinded_hex)
+        assert signed["complete"], f"default-signed tx incomplete: {signed}"
+        signed_tx = tx_from_hex(signed["hex"])
+
+        # The tx must be accepted (standard + valid) with the default sighash.
+        test_accept = self.nodes[0].testmempoolaccept([signed["hex"]])[0]
+        assert test_accept["allowed"], "default-signed tx not accepted: {}".format(test_accept["reject-reason"])
+
+        # Extract the sighash byte from the signature and check the 0x40 bit.
+        if address_type == "legacy":
+            # scriptSig: <sig> <pubkey>; the signature is the first push.
+            script_sig = signed_tx.vin[0].scriptSig
+            # The first byte is the push length of the signature.
+            sig_len = script_sig[0]
+            sig = script_sig[1:1 + sig_len]
+        else:
+            # segwit v0 (native or p2sh-wrapped): signature is first witness item.
+            sig = signed_tx.wit.vtxinwit[0].scriptWitness.stack[0]
+        sighash_byte = sig[-1]
+        has_rangeproof = bool(sighash_byte & SIGHASH_RANGEPROOF)
+        assert_equal(has_rangeproof, expect_rangeproof)
+
     def assert_tx_standard(self, tx, assert_standard=True):
         # Test the standardness of the tx by submitting it to the mempool.
 
@@ -243,6 +283,11 @@ class SighashRangeproofTest(BitcoinTestFramework):
             tx = self.prepare_tx_signed_with_sighash(address_type, False, True)
             self.assert_tx_standard(tx, False)
             self.assert_tx_valid(tx, True)
+
+            # Pre-activation, the wallet default must NOT set SIGHASH_RANGEPROOF,
+            # otherwise it would produce non-standard/invalid signatures.
+            self.log.info(f"Pre-activation default sighash for {address_type} address")
+            self.assert_default_sign_commits_rangeproof(address_type, expect_rangeproof=False)
 
         # Activate dynafed (nb of blocks taken from dynafed activation test)
         # Generate across several calls to `generatetoaddress` to ensure no individual call times out


### PR DESCRIPTION
Pre-Taproot signatures using the historical SIGHASH_ALL default do not commit to output rangeproofs, leaving a witness malleability gap: an attacker can alter a transaction's rangeproofs without invalidating its signatures. This branch closes that gap by making signing default to SIGHASH_ALL | SIGHASH_RANGEPROOF on chains where dynafed is active, while leaving explicit user-supplied sighash types untouched and preserving the legacy default.

Scope:

- script: adds SIGHASH_ALL_WITH_RANGEPROOF and a DefaultSighashType() helper; strips the 0x40 bit for Taproot/Schnorr signing so the constant is a valid universal default.
- node: exposes Chain::isSighashRangeproofActive() for a live tip-based dynafed check.
- chainparams: adds SighashRangeproofActiveByParams() for chainstate-less gating (used by bitcoin-tx).
- wallet + raw RPCs (signrawtransactionwithkey, signrawtransactionwithwallet, walletprocesspsbt, descriptorprocesspsbt) + - bitcoin-tx: default to the rangeproof-committing sighash when dynafed is active.
- Adds unit and functional test coverage plus a release note.