### PR TITLE
Fix interface_zmq.py functional tests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,7 +114,7 @@ target_link_libraries(elementssimplicity
 )
 
 # macOS Apple Clang is stricter than Linux GCC on this vendored code
-if(APPLE)
+if(CMAKE_C_COMPILER_ID MATCHES "Clang")
   target_compile_options(elementssimplicity PRIVATE
     -Wno-error=conditional-uninitialized
     -Wno-error=implicit-fallthrough

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -986,8 +986,14 @@ class CTransaction:
     def is_valid(self):
         self.calc_sha256()
         for tout in self.vout:
-            if tout.nValue < 0 or tout.nValue > 21000000 * COIN:
-                return False
+            value = tout.nValue
+            # ELEMENTS: nValue is a CTxOutValue. Only explicit (unblinded)
+            # amounts can be range-checked here; confidential outputs are
+            # validated via rangeproofs elsewhere, not by this sanity check.
+            if value.vchCommitment[0] == 1:
+                amount = value.getAmount()
+                if amount < 0 or amount > 21000000 * COIN:
+                    return False
         return True
 
     # Calculate the transaction weight using witness and non-witness


### PR DESCRIPTION
For the test-each-commit CI job:

Broaden the CMake guard from if(APPLE) to also match Clang on any platform, e.g. if(CMAKE_C_COMPILER_ID MATCHES "Clang") (this covers both Clang and AppleClang) for the elementssimplicity compilation. 

Fix is_valid() in test framework for elements amounts, enabling interface_zmq.py to pass. 